### PR TITLE
Aabb utilities

### DIFF
--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -105,6 +105,96 @@ impl AABB {
 
         true
     }
+
+    /// Computes the vertices of this AABB.
+    #[inline]
+    #[cfg(feature = "dim2")]
+    pub fn vertices(&self) -> [Point<Real>; 4] {
+        [
+            Point::new(self.mins.x, self.mins.y),
+            Point::new(self.mins.x, self.maxs.y),
+            Point::new(self.maxs.x, self.mins.y),
+            Point::new(self.maxs.x, self.maxs.y),
+        ]
+    }
+
+    /// Computes the vertices of this AABB.
+    #[inline]
+    #[cfg(feature = "dim3")]
+    pub fn vertices(&self) -> [Point<Real>; 8] {
+        [
+            Point::new(self.mins.x, self.mins.y, self.mins.z),
+            Point::new(self.mins.x, self.mins.y, self.maxs.z),
+            Point::new(self.mins.x, self.maxs.y, self.mins.z),
+            Point::new(self.mins.x, self.maxs.y, self.maxs.z),
+            Point::new(self.maxs.x, self.mins.y, self.mins.z),
+            Point::new(self.maxs.x, self.mins.y, self.maxs.z),
+            Point::new(self.maxs.x, self.maxs.y, self.mins.z),
+            Point::new(self.maxs.x, self.maxs.y, self.maxs.z),
+        ]
+    }
+
+    /// Splits this AABB at its center, into four parts (as in a quad-tree).
+    #[inline]
+    #[cfg(feature = "dim2")]
+    pub fn split_at_center(&self) -> [AABB; 4] {
+        let center = self.center();
+
+        [
+            AABB::new(self.mins, center),
+            AABB::new(
+                Point::new(center.x, self.mins.y),
+                Point::new(self.maxs.x, center.y),
+            ),
+            AABB::new(center, self.maxs),
+            AABB::new(
+                Point::new(self.mins.x, center.y),
+                Point::new(center.x, self.maxs.y),
+            ),
+        ]
+    }
+
+    /// Splits this AABB at its center, into height parts (as in an octree).
+    #[inline]
+    #[cfg(feature = "dim3")]
+    pub fn split_at_center(&self) -> [AABB; 8] {
+        let center = self.center();
+
+        [
+            AABB::new(
+                Point::new(self.mins.x, self.mins.y, self.mins.z),
+                Point::new(center.x, center.y, center.z),
+            ),
+            AABB::new(
+                Point::new(center.x, self.mins.y, self.mins.z),
+                Point::new(self.maxs.x, center.y, center.z),
+            ),
+            AABB::new(
+                Point::new(center.x, center.y, self.mins.z),
+                Point::new(self.maxs.x, self.maxs.y, center.z),
+            ),
+            AABB::new(
+                Point::new(self.mins.x, center.y, self.mins.z),
+                Point::new(center.x, self.maxs.y, center.z),
+            ),
+            AABB::new(
+                Point::new(self.mins.x, self.mins.y, center.z),
+                Point::new(center.x, center.y, self.maxs.z),
+            ),
+            AABB::new(
+                Point::new(center.x, self.mins.y, center.z),
+                Point::new(self.maxs.x, center.y, self.maxs.z),
+            ),
+            AABB::new(
+                Point::new(center.x, center.y, center.z),
+                Point::new(self.maxs.x, self.maxs.y, self.maxs.z),
+            ),
+            AABB::new(
+                Point::new(self.mins.x, center.y, center.z),
+                Point::new(center.x, self.maxs.y, self.maxs.z),
+            ),
+        ]
+    }
 }
 
 impl BoundingVolume for AABB {

--- a/src/query/point/mod.rs
+++ b/src/query/point/mod.rs
@@ -13,7 +13,11 @@ mod point_ball;
 mod point_bounding_sphere;
 mod point_capsule;
 mod point_composite_shape;
+#[cfg(feature = "dim3")]
+mod point_cone;
 mod point_cuboid;
+#[cfg(feature = "dim3")]
+mod point_cylinder;
 mod point_halfspace;
 mod point_heightfield;
 #[doc(hidden)]

--- a/src/query/point/point_cone.rs
+++ b/src/query/point/point_cone.rs
@@ -1,9 +1,7 @@
-use crate::approx::AbsDiffEq;
 use crate::math::{Point, Real, Vector};
-use crate::query::gjk::GJKResult::Proximity;
 use crate::query::{PointProjection, PointQuery};
 use crate::shape::{Cone, FeatureId, Segment};
-use na::{self, Unit};
+use na;
 
 impl PointQuery for Cone {
     #[inline]

--- a/src/query/point/point_cone.rs
+++ b/src/query/point/point_cone.rs
@@ -1,0 +1,74 @@
+use crate::approx::AbsDiffEq;
+use crate::math::{Point, Real, Vector};
+use crate::query::gjk::GJKResult::Proximity;
+use crate::query::{PointProjection, PointQuery};
+use crate::shape::{Cone, FeatureId, Segment};
+use na::{self, Unit};
+
+impl PointQuery for Cone {
+    #[inline]
+    fn project_local_point(&self, pt: &Point<Real>, solid: bool) -> PointProjection {
+        // Project on the basis.
+        let mut dir_from_basis_center = pt.coords.xz();
+        let planar_dist_from_basis_center = dir_from_basis_center.normalize_mut();
+
+        if planar_dist_from_basis_center <= crate::math::DEFAULT_EPSILON {
+            dir_from_basis_center = na::Vector2::x();
+        }
+
+        let projection_on_basis = Point::new(pt.coords.x, -self.half_height, pt.coords.z);
+
+        if pt.y < -self.half_height && planar_dist_from_basis_center <= self.radius {
+            // The projection is on the basis.
+            return PointProjection::new(false, projection_on_basis);
+        }
+
+        // Project on the basis circle.
+        let proj2d = dir_from_basis_center * self.radius;
+        let projection_on_basis_circle = Point::new(proj2d[0], -self.half_height, proj2d[1]);
+
+        // Project on the conic side.
+        // TODO: we could solve this in 2D using the plane passing through the cone axis and the conic_side_segment to save some computation.
+        let apex_point = Point::new(0.0, self.half_height, 0.0);
+        let conic_side_segment = Segment::new(apex_point, projection_on_basis_circle);
+        let conic_side_segment_dir = conic_side_segment.scaled_direction();
+        let mut proj = conic_side_segment.project_local_point(pt, true);
+
+        let apex_to_basis_center = Vector::new(0.0, -2.0 * self.half_height, 0.0);
+
+        // Now determine if the point is inside of the cone.
+        if pt.y >= -self.half_height
+            && pt.y <= self.half_height
+            && conic_side_segment_dir
+                .cross(&(pt - apex_point))
+                .dot(&conic_side_segment_dir.cross(&apex_to_basis_center))
+                >= 0.0
+        {
+            if solid {
+                PointProjection::new(true, *pt)
+            } else {
+                // We are inside of the cone, so the correct projection is
+                // either on the basis of the cone, or on the conic side.
+                if (proj.point - pt).norm_squared() > (projection_on_basis - pt).norm_squared() {
+                    PointProjection::new(true, projection_on_basis)
+                } else {
+                    proj.is_inside = true;
+                    proj
+                }
+            }
+        } else {
+            // We are outside of the cone, return the computed proj
+            // as-is.
+            proj
+        }
+    }
+
+    #[inline]
+    fn project_local_point_and_get_feature(
+        &self,
+        pt: &Point<Real>,
+    ) -> (PointProjection, FeatureId) {
+        // TODO: get the actual feature.
+        (self.project_local_point(pt, false), FeatureId::Unknown)
+    }
+}

--- a/src/query/point/point_cylinder.rs
+++ b/src/query/point/point_cylinder.rs
@@ -1,0 +1,83 @@
+use crate::approx::AbsDiffEq;
+use crate::math::{Point, Real, Vector};
+use crate::query::gjk::GJKResult::Proximity;
+use crate::query::{PointProjection, PointQuery};
+use crate::shape::{Cylinder, FeatureId, Segment};
+use na::{self, Unit};
+
+impl PointQuery for Cylinder {
+    #[inline]
+    fn project_local_point(&self, pt: &Point<Real>, solid: bool) -> PointProjection {
+        // Project on the basis.
+        let mut dir_from_basis_center = pt.coords.xz();
+        let planar_dist_from_basis_center = dir_from_basis_center.normalize_mut();
+
+        if planar_dist_from_basis_center <= crate::math::DEFAULT_EPSILON {
+            dir_from_basis_center = na::Vector2::x();
+        }
+
+        let proj2d = dir_from_basis_center * self.radius;
+
+        if pt.y >= -self.half_height
+            && pt.y <= self.half_height
+            && planar_dist_from_basis_center <= self.radius
+        {
+            // The point is inside of the cylinder.
+            if solid {
+                PointProjection::new(true, *pt)
+            } else {
+                let dist_to_top = self.half_height - pt.coords.y;
+                let dist_to_bottom = pt.coords.y - (-self.half_height);
+                let dist_to_side = self.radius - planar_dist_from_basis_center;
+
+                if dist_to_top < dist_to_bottom && dist_to_top < dist_to_side {
+                    let projection_on_top = Point::new(pt.coords.x, self.half_height, pt.coords.z);
+                    PointProjection::new(true, projection_on_top)
+                } else if dist_to_bottom < dist_to_top && dist_to_bottom < dist_to_side {
+                    let projection_on_bottom =
+                        Point::new(pt.coords.x, -self.half_height, pt.coords.z);
+                    PointProjection::new(true, projection_on_bottom)
+                } else {
+                    let projection_on_side = Point::new(proj2d[0], pt.y, proj2d[1]);
+                    PointProjection::new(true, projection_on_side)
+                }
+            }
+        } else {
+            // The point is outside of the cylinder.
+            if pt.y > self.half_height {
+                if planar_dist_from_basis_center <= self.radius {
+                    let projection_on_top = Point::new(pt.coords.x, self.half_height, pt.coords.z);
+                    return PointProjection::new(false, projection_on_top);
+                } else {
+                    let projection_on_top_circle =
+                        Point::new(proj2d[0], self.half_height, proj2d[1]);
+                    return PointProjection::new(false, projection_on_top_circle);
+                }
+            } else if pt.y < -self.half_height {
+                // Project on the bottom plane or the bottom circle.
+                if planar_dist_from_basis_center <= self.radius {
+                    let projection_on_bottom =
+                        Point::new(pt.coords.x, -self.half_height, pt.coords.z);
+                    return PointProjection::new(false, projection_on_bottom);
+                } else {
+                    let projection_on_bottom_circle =
+                        Point::new(proj2d[0], -self.half_height, proj2d[1]);
+                    return PointProjection::new(false, projection_on_bottom_circle);
+                }
+            } else {
+                // Project on the side.
+                let projection_on_side = Point::new(proj2d[0], pt.y, proj2d[1]);
+                return PointProjection::new(false, projection_on_side);
+            }
+        }
+    }
+
+    #[inline]
+    fn project_local_point_and_get_feature(
+        &self,
+        pt: &Point<Real>,
+    ) -> (PointProjection, FeatureId) {
+        // TODO: get the actual feature.
+        (self.project_local_point(pt, false), FeatureId::Unknown)
+    }
+}

--- a/src/query/point/point_cylinder.rs
+++ b/src/query/point/point_cylinder.rs
@@ -1,9 +1,7 @@
-use crate::approx::AbsDiffEq;
-use crate::math::{Point, Real, Vector};
-use crate::query::gjk::GJKResult::Proximity;
+use crate::math::{Point, Real};
 use crate::query::{PointProjection, PointQuery};
-use crate::shape::{Cylinder, FeatureId, Segment};
-use na::{self, Unit};
+use crate::shape::{Cylinder, FeatureId};
+use na;
 
 impl PointQuery for Cylinder {
     #[inline]

--- a/src/query/point/point_support_map.rs
+++ b/src/query/point/point_support_map.rs
@@ -49,38 +49,6 @@ where
 }
 
 #[cfg(feature = "dim3")]
-impl PointQuery for Cylinder {
-    #[inline]
-    fn project_local_point(&self, point: &Point<Real>, solid: bool) -> PointProjection {
-        local_point_projection_on_support_map(self, &mut VoronoiSimplex::new(), point, solid)
-    }
-
-    #[inline]
-    fn project_local_point_and_get_feature(
-        &self,
-        point: &Point<Real>,
-    ) -> (PointProjection, FeatureId) {
-        (self.project_local_point(point, false), FeatureId::Unknown)
-    }
-}
-
-#[cfg(feature = "dim3")]
-impl PointQuery for Cone {
-    #[inline]
-    fn project_local_point(&self, point: &Point<Real>, solid: bool) -> PointProjection {
-        local_point_projection_on_support_map(self, &mut VoronoiSimplex::new(), point, solid)
-    }
-
-    #[inline]
-    fn project_local_point_and_get_feature(
-        &self,
-        point: &Point<Real>,
-    ) -> (PointProjection, FeatureId) {
-        (self.project_local_point(point, false), FeatureId::Unknown)
-    }
-}
-
-#[cfg(feature = "dim3")]
 impl PointQuery for ConvexPolyhedron {
     #[inline]
     fn project_local_point(&self, point: &Point<Real>, solid: bool) -> PointProjection {

--- a/src/query/point/point_support_map.rs
+++ b/src/query/point/point_support_map.rs
@@ -7,7 +7,7 @@ use crate::query::{PointProjection, PointQuery};
 #[cfg(feature = "dim2")]
 use crate::shape::ConvexPolygon;
 #[cfg(feature = "dim3")]
-use crate::shape::{Cone, ConvexPolyhedron, Cylinder};
+use crate::shape::ConvexPolyhedron;
 use crate::shape::{FeatureId, SupportMap};
 
 /// Projects a point on a shape using the GJK algorithm.

--- a/src/transformation/to_trimesh/cuboid_to_trimesh.rs
+++ b/src/transformation/to_trimesh/cuboid_to_trimesh.rs
@@ -1,7 +1,19 @@
+use crate::bounding_volume::AABB;
 use crate::math::Real;
 use crate::shape::Cuboid;
 use crate::transformation::utils;
 use na::{self, Point3};
+
+impl AABB {
+    /// Discretize the boundary of this AABB as a triangle-mesh.
+    pub fn to_trimesh(&self) -> (Vec<Point3<Real>>, Vec<[u32; 3]>) {
+        let center = self.center();
+        let half_extents = self.half_extents();
+        let mut cube_mesh = Cuboid::new(half_extents).to_trimesh();
+        cube_mesh.0.iter_mut().for_each(|p| *p += center.coords);
+        cube_mesh
+    }
+}
 
 impl Cuboid {
     /// Discretize the boundary of this cuboid as a triangle-mesh.


### PR DESCRIPTION
This adds a few utilities for AABBs:
- `AABB::vertices` to get an array containing its vertices.
- `AABB::split_at_center` to split an AABB into 4 (in 2D) or 8 (in 3D) parts.
- `AABB::to_trimesh` to compute the mesh representation of an AABB.