### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
 # Change Log
-## v0.2.0 (WIP)
-- Remove the `Shape::as_serialize` method.
+## v0.2.0
+### Added
 - Add the `Shape::as_typed_shape` method to convert the shape trait-object
   to an enum.
 - Add the `TypedShape` enum with variants containing references to concrete shapes
   (except for user-defined custom shapes).
+- Add dedicated algorithms for the projection of a point on a cone or a cylinder.
+- Improve the overall shape serialization performance.
+- Add `AABB::vertices` to get an array containing its vertices.
+- Add `AABB::split_at_center` to split an AABB into 4 (in 2D) or 8 (in 3D) parts.
+- Add `AABB::to_trimesh` to compute the mesh representation of an AABB.
+
+### Removed
+- Remove the `Shape::as_serialize` method.
+
+### Fixed
+- Fix a bug causing making some ball/convex shape contact manifold computation
+  fail when they are penetrating deeply.

--- a/build/parry2d-f64/Cargo.toml
+++ b/build/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry2d-f64"
-version = "0.1.2"
+version = "0.2.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."
@@ -41,8 +41,8 @@ num-traits      = { version = "0.2", default-features = false }
 smallvec        = "1"
 slab            = "0.4"
 arrayvec        = "0.5"
-simba           = "0.3"
-nalgebra        = "0.24"
+simba           = "0.4"
+nalgebra        = "0.25"
 approx          = { version = "0.4", default-features = false }
 serde           = { version = "1.0", optional = true, features = ["derive"]}
 num-derive      = "0.3"
@@ -50,5 +50,5 @@ indexmap = { version = "1", features = [ "serde-1" ], optional = true }
 rustc-hash = "1"
 
 [dev-dependencies]
-rand  = { version = "0.7", default-features = false }
-simba = { version = "0.3", features = [ "partial_fixed_point_support" ] }
+rand  = { version = "0.8", default-features = false }
+simba = { version = "0.4", features = [ "partial_fixed_point_support" ] }

--- a/build/parry2d/Cargo.toml
+++ b/build/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry2d"
-version = "0.1.2"
+version = "0.2.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 dimensional collision detection library in Rust."
@@ -41,8 +41,8 @@ num-traits      = { version = "0.2", default-features = false }
 smallvec        = "1"
 slab            = "0.4"
 arrayvec        = "0.5"
-simba           = "0.3"
-nalgebra        = "0.24"
+simba           = "0.4"
+nalgebra        = "0.25"
 approx          = { version = "0.4", default-features = false }
 serde           = { version = "1.0", optional = true, features = ["derive"]}
 num-derive      = "0.3"
@@ -50,5 +50,5 @@ indexmap = { version = "1", features = [ "serde-1" ], optional = true }
 rustc-hash = "1"
 
 [dev-dependencies]
-rand  = { version = "0.7", default-features = false }
-simba = { version = "0.3", features = [ "partial_fixed_point_support" ] }
+rand  = { version = "0.8", default-features = false }
+simba = { version = "0.4", features = [ "partial_fixed_point_support" ] }

--- a/build/parry3d-f64/Cargo.toml
+++ b/build/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry3d-f64"
-version = "0.1.2"
+version = "0.2.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."
@@ -40,8 +40,8 @@ downcast-rs = "1"
 num-traits = { version = "0.2", default-features = false }
 smallvec   = "1"
 slab       = "0.4"
-simba      = "0.3"
-nalgebra   = "0.24"
+simba      = "0.4"
+nalgebra   = "0.25"
 approx     = { version = "0.4", default-features = false }
 serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}
 num-derive   = "0.3"
@@ -50,5 +50,5 @@ rustc-hash = "1"
 
 
 [dev-dependencies]
-rand_isaac = "0.2"
-rand       = { version = "0.7", default-features = false }
+rand_isaac = "0.3"
+rand       = { version = "0.8", default-features = false }

--- a/build/parry3d/Cargo.toml
+++ b/build/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry3d"
-version = "0.1.2"
+version = "0.2.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "3 dimensional collision detection library in Rust."
@@ -40,8 +40,8 @@ downcast-rs = "1"
 num-traits = { version = "0.2", default-features = false }
 smallvec   = "1"
 slab       = "0.4"
-simba      = "0.3"
-nalgebra   = "0.24"
+simba      = "0.4"
+nalgebra   = "0.25"
 approx     = { version = "0.4", default-features = false }
 serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}
 num-derive   = "0.3"
@@ -50,5 +50,5 @@ rustc-hash = "1"
 
 
 [dev-dependencies]
-rand_isaac = "0.2"
-rand       = { version = "0.7", default-features = false }
+rand_isaac = "0.3"
+rand       = { version = "0.8", default-features = false }


### PR DESCRIPTION
## Changelog
### Added
- Add the `Shape::as_typed_shape` method to convert the shape trait-object
  to an enum.
- Add the `TypedShape` enum with variants containing references to concrete shapes
  (except for user-defined custom shapes).
- Add dedicated algorithms for the projection of a point on a cone or a cylinder.
- Improve the overall shape serialization performance.
- Add `AABB::vertices` to get an array containing its vertices.
- Add `AABB::split_at_center` to split an AABB into 4 (in 2D) or 8 (in 3D) parts.
- Add `AABB::to_trimesh` to compute the mesh representation of an AABB.

### Removed
- Remove the `Shape::as_serialize` method.

### Fixed
- Fix a bug causing making some ball/convex shape contact manifold computation
  fail when they are penetrating deeply.