### PR TITLE
Fix linear TOI computation when the first shape is rotated + remove target_dist argument

### DIFF
--- a/build/parry2d/examples/time_of_impact_query2d.rs
+++ b/build/parry2d/examples/time_of_impact_query2d.rs
@@ -28,7 +28,6 @@ fn main() {
         &box_vel1,
         &cuboid,
         Real::MAX,
-        0.0,
     )
     .unwrap();
     let toi_will_touch = query::time_of_impact(
@@ -39,7 +38,6 @@ fn main() {
         &box_vel2,
         &cuboid,
         Real::MAX,
-        0.0,
     )
     .unwrap();
     let toi_wont_touch = query::time_of_impact(
@@ -50,7 +48,6 @@ fn main() {
         &box_vel1,
         &cuboid,
         Real::MAX,
-        0.0,
     )
     .unwrap();
 

--- a/build/parry2d/tests/geometry/ball_ball_toi.rs
+++ b/build/parry2d/tests/geometry/ball_ball_toi.rs
@@ -13,7 +13,7 @@ fn test_ball_ball_toi() {
     let v1 = Vector2::new(0.0, 10.0);
     let v2 = Vector2::zeros();
 
-    let cast = query::time_of_impact(&m1, &v1, &b, &m2, &v2, &b, Real::MAX, 0.0).unwrap();
+    let cast = query::time_of_impact(&m1, &v1, &b, &m2, &v2, &b, Real::MAX).unwrap();
 
     assert_eq!(cast.unwrap().toi, 0.9);
 }

--- a/build/parry3d/examples/time_of_impact_query3d.rs
+++ b/build/parry3d/examples/time_of_impact_query3d.rs
@@ -28,7 +28,6 @@ fn main() {
         &cuboid_vel1,
         &cuboid,
         Real::MAX,
-        0.0,
     )
     .unwrap();
     let toi_will_touch = query::time_of_impact(
@@ -39,7 +38,6 @@ fn main() {
         &cuboid_vel2,
         &cuboid,
         Real::MAX,
-        0.0,
     )
     .unwrap();
     let toi_wont_touch = query::time_of_impact(
@@ -50,7 +48,6 @@ fn main() {
         &cuboid_vel1,
         &cuboid,
         Real::MAX,
-        0.0,
     )
     .unwrap();
 

--- a/build/parry3d/tests/geometry/ball_ball_toi.rs
+++ b/build/parry3d/tests/geometry/ball_ball_toi.rs
@@ -13,7 +13,7 @@ fn test_ball_ball_toi() {
     let vel1 = Vector3::new(0.0, 10.0, 0.0);
     let vel2 = Vector3::zeros();
 
-    let cast = query::time_of_impact(&m1, &vel1, &b, &m2, &vel2, &b, Real::MAX, 0.0).unwrap();
+    let cast = query::time_of_impact(&m1, &vel1, &b, &m2, &vel2, &b, Real::MAX).unwrap();
 
     assert_eq!(cast.unwrap().toi, 0.9);
 }

--- a/build/parry3d/tests/geometry/ball_triangle_toi.rs
+++ b/build/parry3d/tests/geometry/ball_triangle_toi.rs
@@ -18,7 +18,7 @@ fn ball_triangle_toi_infinite_loop_issue() {
     let vel1 = Vector3::new(0.0, 0.000000000000000000000000000000000000000006925, 0.0);
     let vel2 = Vector3::zeros();
 
-    let cast = query::time_of_impact(&m1, &vel1, &b, &m2, &vel2, &t, std::f32::MAX, 0.0).unwrap();
+    let cast = query::time_of_impact(&m1, &vel1, &b, &m2, &vel2, &t, std::f32::MAX).unwrap();
 
     println!("TOI: {:?}", cast);
     assert!(cast.is_none()); // The provided velocity is too small.

--- a/build/parry3d/tests/geometry/still_objects_toi.rs
+++ b/build/parry3d/tests/geometry/still_objects_toi.rs
@@ -25,18 +25,9 @@ fn collide(v_y: f32) -> Option<f32> {
     let vel2 = Vector3::zeros();
     let cuboid = Cuboid::new(Vector3::new(0.5, 0.5, 0.5));
 
-    time_of_impact(
-        &pos1,
-        &vel1,
-        &cuboid,
-        &pos2,
-        &vel2,
-        &cuboid,
-        std::f32::MAX,
-        0.0,
-    )
-    .unwrap()
-    .map(|toi| toi.toi)
+    time_of_impact(&pos1, &vel1, &cuboid, &pos2, &vel2, &cuboid, std::f32::MAX)
+        .unwrap()
+        .map(|toi| toi.toi)
 }
 
 #[test]

--- a/build/parry3d/tests/geometry/time_of_impact3.rs
+++ b/build/parry3d/tests/geometry/time_of_impact3.rs
@@ -27,7 +27,6 @@ fn ball_cuboid_toi() {
         &cuboid_vel1,
         &cuboid,
         Real::MAX,
-        0.0,
     )
     .unwrap()
     .map(|toi| toi.toi);
@@ -39,7 +38,6 @@ fn ball_cuboid_toi() {
         &cuboid_vel2,
         &cuboid,
         Real::MAX,
-        0.0,
     )
     .unwrap()
     .map(|toi| toi.toi);
@@ -51,7 +49,6 @@ fn ball_cuboid_toi() {
         &cuboid_vel1,
         &cuboid,
         Real::MAX,
-        0.0,
     )
     .unwrap()
     .map(|toi| toi.toi);

--- a/build/parry3d/tests/geometry/trimesh_trimesh_toi.rs
+++ b/build/parry3d/tests/geometry/trimesh_trimesh_toi.rs
@@ -41,7 +41,6 @@ fn do_toi_test() -> Option<Real> {
         &vel_two,
         &shape_two,
         Real::MAX,
-        0.0,
     )
     .unwrap()
     .map(|toi| toi.toi)

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -255,71 +255,64 @@ impl QueryDispatcher for DefaultQueryDispatcher {
     fn time_of_impact(
         &self,
         pos12: &Isometry<Real>,
-        vel12: &Vector<Real>,
+        local_vel12: &Vector<Real>,
         shape1: &dyn Shape,
         shape2: &dyn Shape,
         max_toi: Real,
-        target_distance: Real,
     ) -> Result<Option<TOI>, Unsupported> {
         if let (Some(b1), Some(b2)) = (shape1.as_ball(), shape2.as_ball()) {
             Ok(query::details::time_of_impact_ball_ball(
                 pos12,
-                vel12,
+                local_vel12,
                 b1,
                 b2,
                 max_toi,
-                target_distance,
             ))
         } else if let (Some(p1), Some(s2)) =
             (shape1.as_shape::<HalfSpace>(), shape2.as_support_map())
         {
             Ok(query::details::time_of_impact_halfspace_support_map(
                 pos12,
-                vel12,
+                local_vel12,
                 p1,
                 s2,
                 max_toi,
-                target_distance,
             ))
         } else if let (Some(s1), Some(p2)) =
             (shape1.as_support_map(), shape2.as_shape::<HalfSpace>())
         {
             Ok(query::details::time_of_impact_support_map_halfspace(
                 pos12,
-                vel12,
+                local_vel12,
                 s1,
                 p2,
                 max_toi,
-                target_distance,
             ))
         } else if let (Some(s1), Some(s2)) = (shape1.as_support_map(), shape2.as_support_map()) {
             Ok(query::details::time_of_impact_support_map_support_map(
                 pos12,
-                vel12,
+                local_vel12,
                 s1,
                 s2,
                 max_toi,
-                target_distance,
             ))
         } else if let Some(c1) = shape1.as_composite_shape() {
             Ok(query::details::time_of_impact_composite_shape_shape(
                 self,
                 pos12,
-                vel12,
+                local_vel12,
                 c1,
                 shape2,
                 max_toi,
-                target_distance,
             ))
         } else if let Some(c2) = shape2.as_composite_shape() {
             Ok(query::details::time_of_impact_shape_composite_shape(
                 self,
                 pos12,
-                vel12,
+                local_vel12,
                 shape1,
                 c2,
                 max_toi,
-                target_distance,
             ))
         } else {
             Err(Unsupported)

--- a/src/query/gjk/gjk.rs
+++ b/src/query/gjk/gjk.rs
@@ -200,6 +200,8 @@ where
 
 /// Compute the normal and the distance that can travel `g1` along the direction
 /// `dir` so that `g1` and `g2` just touch.
+///
+/// The `dir` vector must be expressed in the local-space of the first shape.
 pub fn directional_distance<G1: ?Sized, G2: ?Sized>(
     pos12: &Isometry<Real>,
     g1: &G1,

--- a/src/query/nonlinear_time_of_impact/nonlinear_rigid_motion.rs
+++ b/src/query/nonlinear_time_of_impact/nonlinear_rigid_motion.rs
@@ -3,9 +3,7 @@ use crate::math::{Isometry, Point, Real, Translation, Vector};
 /// A nonlinear motion from a starting isometry traveling at constant translational and rotational velocity.
 #[derive(Debug, Copy, Clone)]
 pub struct NonlinearRigidMotion {
-    /// The time at which this parametrization begins. Can be negative.
-    pub t0: Real,
-    /// The starting isometry at `t = self.t0`.
+    /// The starting isometry at `t = 0`.
     pub start: Isometry<Real>,
     /// The local-space point at which the rotational part of this motion is applied.
     pub local_center: Point<Real>,
@@ -23,14 +21,12 @@ impl NonlinearRigidMotion {
     /// Initialize a motion from a starting isometry and linear and angular velocities.
     #[cfg(feature = "dim2")]
     pub fn new(
-        t0: Real,
         start: Isometry<Real>,
         local_center: Point<Real>,
         linvel: Vector<Real>,
         angvel: Real,
     ) -> Self {
         NonlinearRigidMotion {
-            t0,
             start,
             local_center,
             linvel,
@@ -41,14 +37,12 @@ impl NonlinearRigidMotion {
     /// Initialize a motion from a starting isometry and linear and angular velocities.
     #[cfg(feature = "dim3")]
     pub fn new(
-        t0: Real,
         start: Isometry<Real>,
         local_center: Point<Real>,
         linvel: Vector<Real>,
         angvel: Vector<Real>,
     ) -> Self {
         NonlinearRigidMotion {
-            t0,
             start,
             local_center,
             linvel,
@@ -64,7 +58,6 @@ impl NonlinearRigidMotion {
     /// Create a `NonlinearRigidMotion` that always return `pos`.
     pub fn constant_position(pos: Isometry<Real>) -> Self {
         Self {
-            t0: 0.0,
             start: pos,
             linvel: na::zero(),
             angvel: na::zero(),
@@ -125,9 +118,8 @@ impl NonlinearRigidMotion {
 
     /// Computes the position at time `t` of a rigid-body following the motion described by `self`.
     pub fn position_at_time(&self, t: Real) -> Isometry<Real> {
-        let dt = t - self.t0;
         let center = self.start * self.local_center;
         let shift = Translation::from(center.coords);
-        (shift * Isometry::new(self.linvel * dt, self.angvel * dt)) * (shift.inverse() * self.start)
+        (shift * Isometry::new(self.linvel * t, self.angvel * t)) * (shift.inverse() * self.start)
     }
 }

--- a/src/query/query_dispatcher.rs
+++ b/src/query/query_dispatcher.rs
@@ -87,14 +87,22 @@ pub trait QueryDispatcher: Send + Sync {
     /// distance smaller or equal to `distance`.
     ///
     /// Returns `0.0` if the objects are touching or penetrating.
+    ///
+    /// # Parameters
+    /// - `pos12`: the position of the second shape relative to the first shape.
+    /// - `local_vel12`: the relative velocity between the two shapes, expressed in the local-space
+    ///                  of the first shape. In other world: `pos1.inverse() * (vel2 - vel1)`.
+    /// - `g1`: the first shape involved in the TOI computation.
+    /// - `g2`: the second shape involved in the TOI computation.
+    /// - `max_toi`: the maximum allowed TOI. This method returns `None` if the time-of-impact
+    ///              detected is theater than this value.
     fn time_of_impact(
         &self,
         pos12: &Isometry<Real>,
-        vel12: &Vector<Real>,
+        local_vel12: &Vector<Real>,
         g1: &dyn Shape,
         g2: &dyn Shape,
         max_toi: Real,
-        target_distance: Real,
     ) -> Result<Option<TOI>, Unsupported>;
 
     /// Construct a `QueryDispatcher` that falls back on `other` for cases not handled by `self`
@@ -164,7 +172,6 @@ where
         g1: &dyn Shape,
         g2: &dyn Shape,
         max_toi: Real,
-        target_distance: Real,
     ) -> Option<TOI>);
 
     chain_method!(nonlinear_time_of_impact(

--- a/src/query/time_of_impact/time_of_impact.rs
+++ b/src/query/time_of_impact/time_of_impact.rs
@@ -63,8 +63,8 @@ impl TOI {
             toi: self.toi,
             witness1: pos * self.witness1,
             witness2: self.witness2,
-            normal1: self.normal1,
-            normal2: pos * self.normal2,
+            normal1: pos * self.normal1,
+            normal2: self.normal2,
             status: self.status,
         }
     }
@@ -85,6 +85,6 @@ pub fn time_of_impact(
     target_distance: Real,
 ) -> Result<Option<TOI>, Unsupported> {
     let pos12 = pos1.inv_mul(pos2);
-    let vel12 = vel2 - vel1;
-    DefaultQueryDispatcher.time_of_impact(&pos12, &vel12, g1, g2, max_toi, target_distance)
+    let vel12 = pos1.inverse_transform_vector(&(vel2 - vel1));
+    DefaultQueryDispatcher.time_of_impact(&pos12, &vel12, g1, g2, max_toi)
 }

--- a/src/query/time_of_impact/time_of_impact.rs
+++ b/src/query/time_of_impact/time_of_impact.rs
@@ -82,7 +82,6 @@ pub fn time_of_impact(
     vel2: &Vector<Real>,
     g2: &dyn Shape,
     max_toi: Real,
-    target_distance: Real,
 ) -> Result<Option<TOI>, Unsupported> {
     let pos12 = pos1.inv_mul(pos2);
     let vel12 = pos1.inverse_transform_vector(&(vel2 - vel1));

--- a/src/query/time_of_impact/time_of_impact_ball_ball.rs
+++ b/src/query/time_of_impact/time_of_impact_ball_ball.rs
@@ -13,10 +13,9 @@ pub fn time_of_impact_ball_ball(
     b1: &Ball,
     b2: &Ball,
     max_toi: Real,
-    target_distance: Real,
 ) -> Option<TOI> {
     let rsum = b1.radius + b2.radius;
-    let radius = rsum + target_distance;
+    let radius = rsum;
     let center = Point::from(-pos12.translation.vector);
     let ray = Ray::new(Point::origin(), *vel12);
 

--- a/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
+++ b/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
@@ -50,7 +50,7 @@ where
     time_of_impact_composite_shape_shape(
         dispatcher,
         &pos12.inverse(),
-        &-vel12,
+        &-pos12.inverse_transform_vector(&vel12),
         g2,
         g1,
         max_toi,
@@ -148,7 +148,7 @@ where
                                 .dispatcher
                                 .time_of_impact(
                                     &part_pos1.inv_mul(&self.pos12),
-                                    self.vel12,
+                                    &part_pos1.inverse_transform_vector(self.vel12),
                                     g1,
                                     self.g2,
                                     self.max_toi,

--- a/src/query/time_of_impact/time_of_impact_halfspace_support_map.rs
+++ b/src/query/time_of_impact/time_of_impact_halfspace_support_map.rs
@@ -9,7 +9,6 @@ pub fn time_of_impact_halfspace_support_map<G: ?Sized>(
     halfspace: &HalfSpace,
     other: &G,
     max_toi: Real,
-    target_distance: Real,
 ) -> Option<TOI>
 where
     G: SupportMap,
@@ -17,7 +16,7 @@ where
     // FIXME: add method to get only the local support point.
     // This would avoid the `inverse_transform_point` later.
     let support_point = other.support_point(pos12, &-halfspace.normal);
-    let closest_point = support_point - *halfspace.normal * target_distance;
+    let closest_point = support_point;
     let ray = Ray::new(closest_point, *vel12);
 
     if let Some(toi) = halfspace.cast_local_ray(&ray, max_toi, true) {
@@ -58,18 +57,16 @@ pub fn time_of_impact_support_map_halfspace<G: ?Sized>(
     other: &G,
     halfspace: &HalfSpace,
     max_toi: Real,
-    target_distance: Real,
 ) -> Option<TOI>
 where
     G: SupportMap,
 {
     time_of_impact_halfspace_support_map(
         &pos12.inverse(),
-        &-vel12,
+        &-pos12.inverse_transform_vector(&vel12),
         halfspace,
         other,
         max_toi,
-        target_distance,
     )
     .map(|toi| toi.swapped())
 }

--- a/src/query/time_of_impact/time_of_impact_support_map_support_map.rs
+++ b/src/query/time_of_impact/time_of_impact_support_map_support_map.rs
@@ -1,8 +1,8 @@
 use na::Unit;
 
 use crate::math::{Isometry, Real, Vector};
-use crate::query::gjk::{self, DilatedShape, GJKResult, VoronoiSimplex};
-use crate::query::{self, TOIStatus, TOI};
+use crate::query::gjk::{self, VoronoiSimplex};
+use crate::query::{TOIStatus, TOI};
 use crate::shape::SupportMap;
 use num::Zero;
 
@@ -13,94 +13,29 @@ pub fn time_of_impact_support_map_support_map<G1: ?Sized, G2: ?Sized>(
     g1: &G1,
     g2: &G2,
     max_toi: Real,
-    target_distance: Real,
 ) -> Option<TOI>
 where
     G1: SupportMap,
     G2: SupportMap,
 {
-    if target_distance.is_zero() {
-        gjk::directional_distance(pos12, g1, g2, &vel12, &mut VoronoiSimplex::new()).and_then(
-            |(toi, normal1, witness1, witness2)| {
-                if toi > max_toi {
-                    None
-                } else {
-                    Some(TOI {
-                        toi,
-                        normal1: Unit::new_unchecked(normal1),
-                        normal2: Unit::new_unchecked(pos12.inverse_transform_vector(&-normal1)),
-                        witness1,
-                        witness2: pos12.inverse_transform_point(&witness2),
-                        status: if toi.is_zero() {
-                            TOIStatus::Penetrating
-                        } else {
-                            TOIStatus::Converged
-                        },
-                    })
-                }
-            },
-        )
-    } else {
-        let dilated1 = DilatedShape {
-            shape: g1,
-            radius: target_distance,
-        };
-
-        gjk::directional_distance(pos12, &dilated1, g2, &vel12, &mut VoronoiSimplex::new())
-            .and_then(|(toi, normal1, witness1, witness2)| {
-                if toi > max_toi {
-                    None
-                } else {
-                    // This is mutable because, if the TOI is zero, we have to determine
-                    // if the status isn't really a TOIStatus::Penetrating.
-                    let mut status = TOIStatus::Converged;
-
-                    if toi.is_zero() {
-                        // The TOI is zero but we don't have valid witness points and normal
-                        // yet because of we based our computations so far on the dilated shape.
-                        // Therefore we need an extra step to retrieve the actual closest points, and
-                        // determine if the actual shapes are penetrating or not.
-                        // FIXME: all those computations are costly. Add a variant that returns only
-                        // the TOI and does not computes the normal and witness points?
-                        match query::details::closest_points_support_map_support_map_with_params(
-                            pos12,
-                            g1,
-                            g2,
-                            target_distance,
-                            &mut VoronoiSimplex::new(),
-                            Some(normal1),
-                        ) {
-                            GJKResult::ClosestPoints(pt1, pt2, _) => {
-                                // Ok, we managed to compute the witness points.
-                                let normal1 = Unit::new_normalize(pt2 - pt1);
-                                return Some(TOI {
-                                    toi,
-                                    normal1,
-                                    normal2: Unit::new_unchecked(
-                                        pos12.inverse_transform_vector(&-normal1),
-                                    ),
-                                    witness1,
-                                    witness2: pos12.inverse_transform_point(&pt2),
-                                    status: TOIStatus::Converged,
-                                });
-                            }
-                            GJKResult::NoIntersection(_) => {
-                                // This should never happen.
-                            }
-                            GJKResult::Intersection => status = TOIStatus::Penetrating,
-                            GJKResult::Proximity(_) => unreachable!(),
-                        }
-                    }
-
-                    Some(TOI {
-                        toi,
-                        normal1: Unit::new_unchecked(normal1),
-                        normal2: Unit::new_unchecked(pos12.inverse_transform_vector(&-normal1)),
-                        witness1: witness1 - normal1 * target_distance,
-                        witness2: pos12.inverse_transform_point(&witness2),
-                        status,
-                    })
-                }
-            })
-    }
+    gjk::directional_distance(pos12, g1, g2, &vel12, &mut VoronoiSimplex::new()).and_then(
+        |(toi, normal1, witness1, witness2)| {
+            if toi > max_toi {
+                None
+            } else {
+                Some(TOI {
+                    toi,
+                    normal1: Unit::new_unchecked(normal1),
+                    normal2: Unit::new_unchecked(pos12.inverse_transform_vector(&-normal1)),
+                    witness1,
+                    witness2: pos12.inverse_transform_point(&witness2),
+                    status: if toi.is_zero() {
+                        TOIStatus::Penetrating
+                    } else {
+                        TOIStatus::Converged
+                    },
+                })
+            }
+        },
+    )
 }


### PR DESCRIPTION
Fix #19 
In addition this removes the `target_dist` argument. That argument results in a significant amount of complexity in the general case, and is prone to return a result that is less accurate. So I think it's best to remove it as it will be set to 0.0 most of the time anyways.