### PR TITLE
Remove debug print in halfspace contact manifold

### DIFF
--- a/src/query/contact_manifolds/contact_manifolds_halfspace_pfm.rs
+++ b/src/query/contact_manifolds/contact_manifolds_halfspace_pfm.rs
@@ -86,8 +86,6 @@ pub fn contact_manifold_halfspace_pfm<'a, ManifoldData, ContactData, S2>(
         manifold.local_n2 = -*normal1_2;
     }
 
-    println!("Found contacts: {}", manifold.points.len());
-
     // Transfer impulses.
     manifold.match_contacts(&old_manifold_points);
 }


### PR DESCRIPTION
Hello, I just got started with rapier3d (and by extension, parry) in my project! During every step in my project, my output is flooded by what looks like a debug `println!` left in the latest parry release:

```
Found contacts: 0
Found contacts: 0
Found contacts: 0
Found contacts: 0
Found contacts: 0
Found contacts: 0
Found contacts: 0
...
```

I tracked down the print to here. Should it be removed?