### PR TITLE
Comment out print statements

### DIFF
--- a/src/query/closest_points/closest_points_cuboid_cuboid.rs
+++ b/src/query/closest_points/closest_points_cuboid_cuboid.rs
@@ -36,7 +36,8 @@ pub fn closest_points_cuboid_cuboid(
 
     // The best separating axis is face-vertex.
     if sep1.0 >= sep2.0 && sep1.0 >= sep3.0 {
-        println!("AA: {:?}", sep1);
+        // println!("AA: {:?}", sep1);
+
         // To compute the closest points, we need to project the support point
         // from cuboid2 on the support-face of cuboid1. For simplicity, we just
         // project the support point from cuboid2 on cuboid1 itself (not just the face).
@@ -51,7 +52,7 @@ pub fn closest_points_cuboid_cuboid(
 
     // The best separating axis is vertex-face.
     if sep2.0 >= sep1.0 && sep2.0 >= sep3.0 {
-        println!("BB: {:?}", sep2);
+        // println!("BB: {:?}", sep2);
 
         // To compute the actual closest points, we need to project the support point
         // from cuboid1 on the support-face of cuboid2. For simplicity, we just
@@ -69,7 +70,7 @@ pub fn closest_points_cuboid_cuboid(
     // The best separating axis is edge-edge.
     #[cfg(feature = "dim3")]
     if sep3.0 >= sep2.0 && sep3.0 >= sep1.0 {
-        println!("AA: {:?}, BB: {:?}, CC: {:?}", sep1, sep2, sep3);
+        // println!("AA: {:?}, BB: {:?}, CC: {:?}", sep1, sep2, sep3);
 
         // To compute the actual distance, we need to compute the closest
         // points between the two edges that generated the separating axis.

--- a/src/query/contact_manifolds/contact_manifolds_halfspace_pfm.rs
+++ b/src/query/contact_manifolds/contact_manifolds_halfspace_pfm.rs
@@ -86,7 +86,7 @@ pub fn contact_manifold_halfspace_pfm<'a, ManifoldData, ContactData, S2>(
         manifold.local_n2 = -*normal1_2;
     }
 
-    println!("Found contacts: {}", manifold.points.len());
+    // println!("Found contacts: {}", manifold.points.len());
 
     // Transfer impulses.
     manifold.match_contacts(&old_manifold_points);

--- a/src/query/epa/epa3.rs
+++ b/src/query/epa/epa3.rs
@@ -478,7 +478,7 @@ impl EPA {
                 continue;
             }
 
-            println!("checking {}-th face.", i);
+            // println!("checking {}-th face.", i);
             let adj1 = &self.faces[face.adj[0]];
             let adj2 = &self.faces[face.adj[1]];
             let adj3 = &self.faces[face.adj[2]];


### PR DESCRIPTION
Those seems to be for debugging purposes.
Consider using `tracing` crate for filterable logs which user can enable and disable as needed.