### PR TITLE
Make ShapeType hashable

### DIFF
--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -20,7 +20,7 @@ use na::{RealField, Unit};
 use num::Zero;
 use num_derive::FromPrimitive;
 
-#[derive(Copy, Clone, Debug, FromPrimitive)]
+#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, Eq, Hash)]
 /// Enum representing the type of a shape.
 pub enum ShapeType {
     /// A ball shape.

--- a/src/transformation/to_polyline/cuboid_to_polyline.rs
+++ b/src/transformation/to_polyline/cuboid_to_polyline.rs
@@ -13,9 +13,9 @@ impl Cuboid {
 /// The contour of a unit cuboid lying on the x-y plane.
 fn unit_rectangle() -> Vec<Point2<Real>> {
     vec![
-        Point2::new(-0.5, 0.5),
-        Point2::new(0.5, 0.5),
         Point2::new(-0.5, -0.5),
         Point2::new(0.5, -0.5),
+        Point2::new(0.5, 0.5),
+        Point2::new(-0.5, 0.5),
     ]
 }


### PR DESCRIPTION
This makes the `ShapeType` enum usable as a `HashMap` key.
This also includes an unrelated small changes: the order of vertices output by `Cuboid::to_polyline` has been modified as it was invalid before (it did not represent the boundary of the cuboid as it included its diagonal).