### PR TITLE
Fix edge case for the contact between various convex shapes vs. ball

### DIFF
--- a/src/query/contact/contact_ball_convex_polyhedron.rs
+++ b/src/query/contact/contact_ball_convex_polyhedron.rs
@@ -1,6 +1,6 @@
-use crate::math::{Isometry, Point, Real};
+use crate::math::{Isometry, Point, Real, Vector};
 use crate::query::Contact;
-use crate::shape::{Ball, FeatureId, Shape};
+use crate::shape::{Ball, Shape};
 
 use na::{self, Unit};
 
@@ -45,13 +45,11 @@ pub fn contact_convex_polyhedron_ball(
             normal1 = -dir1;
         }
     } else {
-        if f1 == FeatureId::Unknown {
-            // We cant do anything more at this point.
-            return None;
-        }
-
         dist = -ball2.radius;
-        normal1 = shape1.feature_normal_at_point(f1, &proj.point)?;
+        normal1 = shape1
+            .feature_normal_at_point(f1, &proj.point)
+            .or_else(|| Unit::try_new(proj.point.coords, crate::math::DEFAULT_EPSILON))
+            .unwrap_or_else(|| Vector::y_axis());
     }
 
     if dist <= prediction {

--- a/src/shape/convex_polygon.rs
+++ b/src/shape/convex_polygon.rs
@@ -98,6 +98,24 @@ impl ConvexPolygon {
             utils::point_cloud_support_point_id(local_dir.as_ref(), &self.points) as u32,
         )
     }
+
+    /// The normal of the given feature.
+    pub fn feature_normal(&self, feature: FeatureId) -> Option<Unit<Vector<Real>>> {
+        match feature {
+            FeatureId::Face(id) => Some(self.normals[id as usize]),
+            FeatureId::Vertex(id2) => {
+                let id1 = if id2 == 0 {
+                    self.normals.len() - 1
+                } else {
+                    id2 as usize - 1
+                };
+                Some(Unit::new_normalize(
+                    *self.normals[id1] + *self.normals[id2 as usize],
+                ))
+            }
+            _ => None,
+        }
+    }
 }
 
 impl SupportMap for ConvexPolygon {
@@ -152,20 +170,7 @@ impl ConvexPolyhedron for ConvexPolygon {
         out.set_feature_id(FeatureId::Face(ia as u32));
     }
 
-    fn feature_normal(&self, feature: FeatureId) -> Unit<Vector<Real>> {
-        match feature {
-            FeatureId::Face(id) => self.normals[id as usize],
-            FeatureId::Vertex(id2) => {
-                let id1 = if id2 == 0 {
-                    self.normals.len() - 1
-                } else {
-                    id2 as usize - 1
-                };
-                Unit::new_normalize(*self.normals[id1] + *self.normals[id2 as usize])
-            }
-            _ => panic!("Invalid feature ID: {:?}", feature),
-        }
-    }
+
 
     fn support_face_toward(
         &self,

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -575,6 +575,16 @@ impl Shape for Ball {
     fn as_support_map(&self) -> Option<&dyn SupportMap> {
         Some(self as &dyn SupportMap)
     }
+
+    /// The shape's normal at the given point located on a specific feature.
+    #[inline]
+    fn feature_normal_at_point(
+        &self,
+        _: FeatureId,
+        point: &Point<Real>,
+    ) -> Option<Unit<Vector<Real>>> {
+        Unit::try_new(point.coords, crate::math::DEFAULT_EPSILON)
+    }
 }
 
 impl Shape for Cuboid {
@@ -624,6 +634,14 @@ impl Shape for Cuboid {
 
     fn as_polygonal_feature_map(&self) -> Option<(&dyn PolygonalFeatureMap, Real)> {
         Some((self as &dyn PolygonalFeatureMap, 0.0))
+    }
+
+    fn feature_normal_at_point(
+        &self,
+        feature: FeatureId,
+        _point: &Point<Real>,
+    ) -> Option<Unit<Vector<Real>>> {
+        self.feature_normal(feature)
     }
 }
 
@@ -729,6 +747,14 @@ impl Shape for Triangle {
     fn as_polygonal_feature_map(&self) -> Option<(&dyn PolygonalFeatureMap, Real)> {
         Some((self as &dyn PolygonalFeatureMap, 0.0))
     }
+
+    fn feature_normal_at_point(
+        &self,
+        feature: FeatureId,
+        _point: &Point<Real>,
+    ) -> Option<Unit<Vector<Real>>> {
+        self.feature_normal(feature)
+    }
 }
 
 impl Shape for Segment {
@@ -778,6 +804,14 @@ impl Shape for Segment {
 
     fn as_polygonal_feature_map(&self) -> Option<(&dyn PolygonalFeatureMap, Real)> {
         Some((self as &dyn PolygonalFeatureMap, 0.0))
+    }
+
+    fn feature_normal_at_point(
+        &self,
+        feature: FeatureId,
+        _point: &Point<Real>,
+    ) -> Option<Unit<Vector<Real>>> {
+        self.feature_normal(feature)
     }
 }
 
@@ -1011,6 +1045,14 @@ impl Shape for ConvexPolygon {
     fn as_polygonal_feature_map(&self) -> Option<(&dyn PolygonalFeatureMap, Real)> {
         Some((self as &dyn PolygonalFeatureMap, 0.0))
     }
+
+    fn feature_normal_at_point(
+        &self,
+        feature: FeatureId,
+        _point: &Point<Real>,
+    ) -> Option<Unit<Vector<Real>>> {
+        self.feature_normal(feature)
+    }
 }
 
 #[cfg(feature = "dim3")]
@@ -1065,6 +1107,14 @@ impl Shape for ConvexPolyhedron {
 
     fn as_polygonal_feature_map(&self) -> Option<(&dyn PolygonalFeatureMap, Real)> {
         Some((self as &dyn PolygonalFeatureMap, 0.0))
+    }
+
+    fn feature_normal_at_point(
+        &self,
+        feature: FeatureId,
+        _point: &Point<Real>,
+    ) -> Option<Unit<Vector<Real>>> {
+        self.feature_normal(feature)
     }
 }
 

--- a/src/shape/triangle.rs
+++ b/src/shape/triangle.rs
@@ -1,7 +1,7 @@
 //! Definition of the triangle shape.
 
 use crate::math::{Isometry, Point, Real, Vector};
-use crate::shape::SupportMap;
+use crate::shape::{FeatureId, SupportMap};
 use crate::shape::{PolygonalFeature, Segment};
 use crate::utils;
 
@@ -425,6 +425,11 @@ impl Triangle {
             && d13 >= 0.0
             && d13 <= p3p1.norm_squared()
     }
+
+    /// The normal of the given feature of this shape.
+    pub fn feature_normal(&self, _: FeatureId) -> Option<Unit<Vector<Real>>> {
+        self.normal()
+    }
 }
 
 impl SupportMap for Triangle {
@@ -502,15 +507,6 @@ impl ConvexPolyhedron for Triangle {
         } else {
             face.push(self.a, FeatureId::Vertex(0));
             face.set_feature_id(FeatureId::Vertex(0));
-        }
-    }
-
-    fn feature_normal(&self, _: FeatureId) -> Unit<Vector<Real>> {
-        if let Some(normal) = self.normal() {
-            // FIXME: We should be able to do much better here.
-            normal
-        } else {
-            Vector::y_axis()
         }
     }
 


### PR DESCRIPTION
`query::contact` could return `None` in cases where the center of the ball lies on the boundary of the shape.
Fix #34