### PR TITLE
Introduce ScaledTriMesh shape

### DIFF
--- a/src/bounding_volume/bounding_sphere_trimesh.rs
+++ b/src/bounding_volume/bounding_sphere_trimesh.rs
@@ -1,8 +1,22 @@
 use crate::bounding_volume::BoundingSphere;
 use crate::math::{Isometry, Real};
-use crate::shape::TriMesh;
+use crate::shape::{ScaledTriMesh, TriMesh};
 
 impl TriMesh {
+    /// Computes the world-space bounding sphere of this triangle mesh, transformed by `pos`.
+    #[inline]
+    pub fn bounding_sphere(&self, pos: &Isometry<Real>) -> BoundingSphere {
+        self.local_aabb().bounding_sphere().transform_by(pos)
+    }
+
+    /// Computes the local-space bounding sphere of this triangle mesh.
+    #[inline]
+    pub fn local_bounding_sphere(&self) -> BoundingSphere {
+        self.local_aabb().bounding_sphere()
+    }
+}
+
+impl ScaledTriMesh {
     /// Computes the world-space bounding sphere of this triangle mesh, transformed by `pos`.
     #[inline]
     pub fn bounding_sphere(&self, pos: &Isometry<Real>) -> BoundingSphere {

--- a/src/query/point/point_composite_shape.rs
+++ b/src/query/point/point_composite_shape.rs
@@ -7,8 +7,8 @@ use crate::query::{
     visitors::CompositePointContainmentTest, PointProjection, PointQuery, PointQueryWithLocation,
 };
 use crate::shape::{
-    Compound, FeatureId, Polyline, SegmentPointLocation, TriMesh, TrianglePointLocation,
-    TypedSimdCompositeShape,
+    Compound, FeatureId, Polyline, ScaledTriMesh, SegmentPointLocation, TriMesh,
+    TrianglePointLocation, TypedSimdCompositeShape,
 };
 use na;
 use simba::simd::{SimdBool as _, SimdPartialOrd, SimdValue};
@@ -43,6 +43,34 @@ impl PointQuery for Polyline {
 }
 
 impl PointQuery for TriMesh {
+    #[inline]
+    fn project_local_point(&self, point: &Point<Real>, solid: bool) -> PointProjection {
+        self.project_local_point_and_get_location(point, solid).0
+    }
+
+    #[inline]
+    fn project_local_point_and_get_feature(
+        &self,
+        point: &Point<Real>,
+    ) -> (PointProjection, FeatureId) {
+        let mut visitor =
+            PointCompositeShapeProjWithFeatureBestFirstVisitor::new(self, point, false);
+        let (proj, (id, _feature)) = self.quadtree().traverse_best_first(&mut visitor).unwrap().1;
+        let feature_id = FeatureId::Face(id);
+        (proj, feature_id)
+    }
+
+    // FIXME: implement distance_to_point too?
+
+    #[inline]
+    fn contains_local_point(&self, point: &Point<Real>) -> bool {
+        let mut visitor = CompositePointContainmentTest::new(self, point);
+        self.quadtree().traverse_depth_first(&mut visitor);
+        visitor.found
+    }
+}
+
+impl PointQuery for ScaledTriMesh {
     #[inline]
     fn project_local_point(&self, point: &Point<Real>, solid: bool) -> PointProjection {
         self.project_local_point_and_get_location(point, solid).0
@@ -113,6 +141,21 @@ impl PointQueryWithLocation for Polyline {
 }
 
 impl PointQueryWithLocation for TriMesh {
+    type Location = (u32, TrianglePointLocation);
+
+    #[inline]
+    fn project_local_point_and_get_location(
+        &self,
+        point: &Point<Real>,
+        solid: bool,
+    ) -> (PointProjection, Self::Location) {
+        let mut visitor =
+            PointCompositeShapeProjWithLocationBestFirstVisitor::new(self, point, solid);
+        self.quadtree().traverse_best_first(&mut visitor).unwrap().1
+    }
+}
+
+impl PointQueryWithLocation for ScaledTriMesh {
     type Location = (u32, TrianglePointLocation);
 
     #[inline]

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -38,6 +38,7 @@ pub use self::cylinder::Cylinder;
 pub use self::heightfield3::{HeightField, HeightFieldCellStatus};
 #[cfg(feature = "dim3")]
 pub use self::polygonal_feature3d::PolygonalFeature;
+pub use self::scaled_trimesh::ScaledTriMesh;
 #[cfg(feature = "dim3")]
 pub use self::tetrahedron::{Tetrahedron, TetrahedronPointLocation};
 pub use self::trimesh::TriMesh;
@@ -91,6 +92,7 @@ mod heightfield3;
 #[cfg(feature = "dim3")]
 mod polygonal_feature3d;
 mod polygonal_feature_map;
+mod scaled_trimesh;
 #[cfg(feature = "dim3")]
 mod tetrahedron;
 mod trimesh;

--- a/src/shape/scaled_trimesh.rs
+++ b/src/shape/scaled_trimesh.rs
@@ -1,0 +1,133 @@
+use std::sync::Arc;
+
+use crate::bounding_volume::AABB;
+use crate::math::{Isometry, Point, Real, Vector};
+use crate::partitioning::QBVH;
+use crate::shape::composite_shape::SimdCompositeShape;
+use crate::shape::TriMesh;
+use crate::shape::{Shape, Triangle, TypedSimdCompositeShape};
+
+#[derive(Clone)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+/// A scaled [`TriMesh`]
+pub struct ScaledTriMesh {
+    /// The underlying triangle mesh
+    trimesh: Arc<TriMesh>,
+    /// Scaling factors for each dimension
+    // This could easily be expanded into an arbitrary transform, if a use case arises.
+    scaling_factors: Vector<Real>,
+    quadtree: QBVH<u32>,
+}
+
+impl ScaledTriMesh {
+    /// Creates a triangle mesh by scaling `trimesh` along each axis
+    pub fn new(trimesh: Arc<TriMesh>, scaling_factors: Vector<Real>) -> Self {
+        // Future work: Would it be more efficient to scale trimesh.quadtree rather than building a
+        // new one from scratch?
+        let data = trimesh.triangles().enumerate().map(|(i, tri)| {
+            let aabb = scale_tri(&tri, &scaling_factors).local_aabb();
+            (i as u32, aabb)
+        });
+        let mut quadtree = QBVH::new();
+        quadtree.clear_and_rebuild(data, 0.0);
+        Self {
+            trimesh,
+            scaling_factors,
+            quadtree,
+        }
+    }
+
+    /// The underlying unscaled trimesh
+    pub fn trimesh(&self) -> &Arc<TriMesh> {
+        &self.trimesh
+    }
+
+    /// Scaling factors used to derive this shape from the underlying trimesh
+    pub fn scaling_factors(&self) -> Vector<Real> {
+        self.scaling_factors
+    }
+
+    /// Compute the axis-aligned bounding box of this triangle mesh.
+    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+        self.quadtree.root_aabb().transform_by(pos)
+    }
+
+    /// Gets the local axis-aligned bounding box of this triangle mesh.
+    pub fn local_aabb(&self) -> &AABB {
+        self.quadtree.root_aabb()
+    }
+
+    /// The acceleration structure used by this triangle-mesh.
+    pub fn quadtree(&self) -> &QBVH<u32> {
+        &self.quadtree
+    }
+
+    /// An iterator through all the scaled triangles of this mesh.
+    pub fn triangles(&self) -> impl ExactSizeIterator<Item = Triangle> + '_ {
+        self.trimesh
+            .triangles()
+            .map(move |tri| scale_tri(&tri, &self.scaling_factors))
+    }
+
+    /// Get the `i`-th scaled triangle of this mesh.
+    pub fn triangle(&self, i: u32) -> Triangle {
+        scale_tri(&self.trimesh.triangle(i), &self.scaling_factors)
+    }
+
+    /// The vertex buffer of this mesh.
+    pub fn vertices(&self) -> impl ExactSizeIterator<Item = Point<Real>> + '_ {
+        self.trimesh
+            .vertices()
+            .iter()
+            .map(move |v| v.coords.component_mul(&self.scaling_factors).into())
+    }
+
+    /// The index buffer of this mesh.
+    pub fn indices(&self) -> &[[u32; 3]] {
+        self.trimesh.indices()
+    }
+}
+
+fn scale_tri(tri: &Triangle, factors: &Vector<Real>) -> Triangle {
+    Triangle {
+        a: tri.a.coords.component_mul(factors).into(),
+        b: tri.b.coords.component_mul(factors).into(),
+        c: tri.c.coords.component_mul(factors).into(),
+    }
+}
+
+impl SimdCompositeShape for ScaledTriMesh {
+    fn map_part_at(&self, i: u32, f: &mut dyn FnMut(Option<&Isometry<Real>>, &dyn Shape)) {
+        let tri = self.triangle(i);
+        f(None, &tri)
+    }
+
+    fn quadtree(&self) -> &QBVH<u32> {
+        &self.quadtree
+    }
+}
+
+impl TypedSimdCompositeShape for ScaledTriMesh {
+    type PartShape = Triangle;
+    type PartId = u32;
+
+    #[inline(always)]
+    fn map_typed_part_at(
+        &self,
+        i: u32,
+        mut f: impl FnMut(Option<&Isometry<Real>>, &Self::PartShape),
+    ) {
+        let tri = self.triangle(i);
+        f(None, &tri)
+    }
+
+    #[inline(always)]
+    fn map_untyped_part_at(&self, i: u32, mut f: impl FnMut(Option<&Isometry<Real>>, &dyn Shape)) {
+        let tri = self.triangle(i);
+        f(None, &tri)
+    }
+
+    fn typed_quadtree(&self) -> &QBVH<u32> {
+        &self.quadtree
+    }
+}

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -75,7 +75,7 @@ impl TriMesh {
     }
 
     /// An iterator through all the triangles of this mesh.
-    pub fn triangles(&self) -> impl Iterator<Item = Triangle> + '_ {
+    pub fn triangles(&self) -> impl ExactSizeIterator<Item = Triangle> + '_ {
         self.indices.iter().map(move |ids| {
             Triangle::new(
                 self.vertices[ids[0] as usize],


### PR DESCRIPTION
Allows reuse of collision geometry between scaled objects, e.g. encoded in a GLTF file.

I think this change is more or less complete, albeit untested, but I'd like to discuss some questions before moving forwards:

- Should the transformation be more general? Translation/rotation can be expressed elsewhere, but maybe someone wants to skew? GLTF at least doesn't support anything beyond translation + rotation + nonuniform scaling, but there's not much downside to an arbitrary transform matrix here.
- Should the transformation be *less* general? Uniform scaling could in theory allow sharing of the quadtree, as well as the actual geometry, although this would require additional refactoring to realize, likely involving changes to `QBVH` and perhaps its existing users. Losing support for some cases of GLTF is a shame, but maybe nobody uses nonuniform scaling much in practice?
- Is any of this worth the extra code? Downstream code can always just make another `TriMesh` with whatever vertices it likes. Collision geometry usually isn't that big, especially for repeated objects. The composite shape abstraction makes the implementation pretty concise, but even so...