### PR TITLE
Fix QBVH crash when nodes are empty

### DIFF
--- a/src/partitioning/qbvh.rs
+++ b/src/partitioning/qbvh.rs
@@ -415,6 +415,10 @@ impl<T: IndexedData> QBVH<T> {
         stack.clear();
         stack.push(0);
 
+        if self.nodes.is_empty() {
+            return;
+        }
+
         while let Some(entry) = stack.pop() {
             let node = self.nodes[entry as usize];
             let leaf_data = if node.leaf {

--- a/src/partitioning/qbvh.rs
+++ b/src/partitioning/qbvh.rs
@@ -413,12 +413,10 @@ impl<T: IndexedData> QBVH<T> {
         stack: &mut Vec<u32>,
     ) {
         stack.clear();
-        stack.push(0);
 
-        if self.nodes.is_empty() {
-            return;
+        if !self.nodes.is_empty() {
+            stack.push(0);
         }
-
         while let Some(entry) = stack.pop() {
             let node = self.nodes[entry as usize];
             let leaf_data = if node.leaf {


### PR DESCRIPTION
QBVH traversal panics when `nodes` is empty. I add a check to prevent a panic.