### PR TITLE
Add various utilities

### DIFF
--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -2,8 +2,8 @@
 
 use crate::bounding_volume::{BoundingSphere, BoundingVolume};
 use crate::math::{Isometry, Point, Real, UnitVector, Vector, DIM};
-use crate::shape::{Cuboid, Segment, SupportMap};
-use crate::utils::{IntervalFunction, IsometryOps};
+use crate::shape::{Cuboid, SupportMap};
+use crate::utils::IsometryOps;
 use na;
 use num::Bounded;
 
@@ -273,7 +273,6 @@ impl AABB {
 
         struct SpiralPlaneDistance {
             center: Point<Real>,
-            axis: Vector<Real>,
             tangents: [Vector<Real>; 2],
             linvel: Vector<Real>,
             angvel: Real,
@@ -335,7 +334,6 @@ impl AABB {
         let dpos = point - center;
         let mut distance_fn = SpiralPlaneDistance {
             center: *center,
-            axis: axis.into_inner(),
             tangents,
             linvel: *linvel,
             angvel,

--- a/src/partitioning/mod.rs
+++ b/src/partitioning/mod.rs
@@ -8,7 +8,7 @@ pub use self::visitor::{
 
 /// A quaternary bounding-volume-hierarchy.
 #[deprecated(note = "Renamed to QBVH")]
-pub type SimdQuadTree<T> = QBVH<T>;
+pub type SimdQbvh<T> = QBVH<T>;
 
 mod qbvh;
 mod visitor;

--- a/src/partitioning/qbvh.rs
+++ b/src/partitioning/qbvh.rs
@@ -76,7 +76,7 @@ impl NodeIndex {
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 struct QBVHNode {
-    /// The AABBs of the quadtree nodes represented by this node.
+    /// The AABBs of the qbvh nodes represented by this node.
     pub simd_aabb: SimdAABB,
     /// Index of the nodes of the 4 nodes represented by `self`.
     /// If this is a leaf, it contains the proxy ids instead.
@@ -570,7 +570,7 @@ struct QBVHIncrementalBuilderStep {
 
 #[allow(dead_code)]
 struct QBVHIncrementalBuilder<T> {
-    quadtree: QBVH<T>,
+    qbvh: QBVH<T>,
     to_insert: Vec<QBVHIncrementalBuilderStep>,
     aabbs: Vec<AABB>,
     indices: Vec<usize>,
@@ -580,7 +580,7 @@ struct QBVHIncrementalBuilder<T> {
 impl<T: IndexedData> QBVHIncrementalBuilder<T> {
     pub fn new() -> Self {
         Self {
-            quadtree: QBVH::new(),
+            qbvh: QBVH::new(),
             to_insert: Vec::new(),
             aabbs: Vec::new(),
             indices: Vec::new(),
@@ -593,7 +593,7 @@ impl<T: IndexedData> QBVHIncrementalBuilder<T> {
 
             // Leaf case.
             if indices.len() <= 4 {
-                let id = self.quadtree.nodes.len();
+                let id = self.qbvh.nodes.len();
                 let mut aabb = AABB::new_invalid();
                 let mut leaf_aabbs = [AABB::new_invalid(); 4];
                 let mut proxy_ids = [u32::MAX; 4];
@@ -612,12 +612,12 @@ impl<T: IndexedData> QBVHIncrementalBuilder<T> {
                     dirty: false,
                 };
 
-                self.quadtree.nodes[to_insert.parent.index as usize].children
+                self.qbvh.nodes[to_insert.parent.index as usize].children
                     [to_insert.parent.lane as usize] = id as u32;
-                self.quadtree.nodes[to_insert.parent.index as usize]
+                self.qbvh.nodes[to_insert.parent.index as usize]
                     .simd_aabb
                     .replace(to_insert.parent.lane as usize, aabb);
-                self.quadtree.nodes.push(node);
+                self.qbvh.nodes.push(node);
                 return;
             }
 
@@ -678,8 +678,8 @@ impl<T: IndexedData> QBVHIncrementalBuilder<T> {
                 dirty: false,
             };
 
-            let id = self.quadtree.nodes.len() as u32;
-            self.quadtree.nodes.push(node);
+            let id = self.qbvh.nodes.len() as u32;
+            self.qbvh.nodes.push(node);
 
             // Recurse!
             let a = left_bottom.len();
@@ -703,9 +703,9 @@ impl<T: IndexedData> QBVHIncrementalBuilder<T> {
                 parent: NodeIndex::new(id, 3),
             });
 
-            self.quadtree.nodes[to_insert.parent.index as usize].children
+            self.qbvh.nodes[to_insert.parent.index as usize].children
                 [to_insert.parent.lane as usize] = id as u32;
-            self.quadtree.nodes[to_insert.parent.index as usize]
+            self.qbvh.nodes[to_insert.parent.index as usize]
                 .simd_aabb
                 .replace(to_insert.parent.lane as usize, aabb);
         }

--- a/src/partitioning/qbvh.rs
+++ b/src/partitioning/qbvh.rs
@@ -127,6 +127,16 @@ impl<T: IndexedData> QBVH<T> {
         }
     }
 
+    /// Iterates mutable through all the leaf data in this QBVH.
+    pub fn iter_data_mut(&mut self) -> impl Iterator<Item = (NodeIndex, &mut T)> {
+        self.proxies.iter_mut().map(|p| (p.node, &mut p.data))
+    }
+
+    /// Iterate through all the leaf data in this QBVH.
+    pub fn iter_data(&self) -> impl Iterator<Item = (NodeIndex, &T)> {
+        self.proxies.iter().map(|p| (p.node, &p.data))
+    }
+
     /// The AABB of the root of this tree.
     pub fn root_aabb(&self) -> &AABB {
         &self.root_aabb

--- a/src/query/closest_points/closest_points_composite_shape_shape.rs
+++ b/src/query/closest_points/closest_points_composite_shape_shape.rs
@@ -22,7 +22,7 @@ where
     let mut visitor =
         CompositeShapeAgainstShapeClosestPointsVisitor::new(dispatcher, pos12, g1, g2, margin);
 
-    g1.typed_quadtree()
+    g1.typed_qbvh()
         .traverse_best_first(&mut visitor)
         .expect("The composite shape must not be empty.")
         .1

--- a/src/query/contact/contact_composite_shape_shape.rs
+++ b/src/query/contact/contact_composite_shape_shape.rs
@@ -41,7 +41,7 @@ where
     };
 
     let mut visitor = BoundingVolumeIntersectionsVisitor::new(&ls_aabb2, &mut leaf_callback);
-    g1.quadtree().traverse_depth_first(&mut visitor);
+    g1.qbvh().traverse_depth_first(&mut visitor);
     res
 }
 

--- a/src/query/contact_manifolds/contact_manifolds_composite_shape_composite_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_composite_shape_composite_shape.rs
@@ -73,25 +73,25 @@ pub fn contact_manifolds_composite_shape_composite_shape<'a, ManifoldData, Conta
      * Compute interferences.
      */
 
-    let mut quadtree1 = composite1.quadtree();
-    let mut quadtree2 = composite2.quadtree();
+    let mut qbvh1 = composite1.qbvh();
+    let mut qbvh2 = composite2.qbvh();
 
     let mut pos12 = *pos12;
     let mut pos21 = pos12.inverse();
     let mut stack2 = Vec::new();
 
-    let mut ls_aabb1 = quadtree1.root_aabb();
-    let mut ls_aabb2 = quadtree2.root_aabb();
+    let mut ls_aabb1 = qbvh1.root_aabb();
+    let mut ls_aabb2 = qbvh2.root_aabb();
     let flipped = ls_aabb1.half_extents().norm_squared() < ls_aabb2.half_extents().norm_squared();
 
     if flipped {
         std::mem::swap(&mut composite1, &mut composite2);
-        std::mem::swap(&mut quadtree1, &mut quadtree2);
+        std::mem::swap(&mut qbvh1, &mut qbvh2);
         std::mem::swap(&mut pos12, &mut pos21);
         std::mem::swap(&mut ls_aabb1, &mut ls_aabb2);
     }
 
-    // Traverse quadtree1 first.
+    // Traverse qbvh1 first.
     let ls_aabb2_1 = ls_aabb2.transform_by(&pos12).loosened(prediction);
     let mut old_manifolds = std::mem::replace(manifolds, Vec::new());
 
@@ -169,14 +169,14 @@ pub fn contact_manifolds_composite_shape_composite_shape<'a, ManifoldData, Conta
             let mut visitor2 =
                 BoundingVolumeIntersectionsVisitor::new(&ls_part_aabb1_2, &mut leaf_fn2);
 
-            quadtree2.traverse_depth_first_with_stack(&mut visitor2, &mut stack2);
+            qbvh2.traverse_depth_first_with_stack(&mut visitor2, &mut stack2);
         });
 
         true
     };
 
     let mut visitor1 = BoundingVolumeIntersectionsVisitor::new(&ls_aabb2_1, &mut leaf_fn1);
-    quadtree1.traverse_depth_first(&mut visitor1);
+    qbvh1.traverse_depth_first(&mut visitor1);
 
     workspace
         .sub_detectors

--- a/src/query/contact_manifolds/contact_manifolds_composite_shape_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_composite_shape_shape.rs
@@ -77,7 +77,7 @@ pub fn contact_manifolds_composite_shape_shape<ManifoldData, ContactData>(
     let pos12 = *pos12;
     let pos21 = pos12.inverse();
 
-    // Traverse quadtree1 first.
+    // Traverse qbvh1 first.
     let ls_aabb2_1 = shape2.compute_aabb(&pos12).loosened(prediction);
     let mut old_manifolds = std::mem::replace(manifolds, Vec::new());
 
@@ -140,7 +140,7 @@ pub fn contact_manifolds_composite_shape_shape<ManifoldData, ContactData>(
     };
 
     let mut visitor1 = BoundingVolumeIntersectionsVisitor::new(&ls_aabb2_1, &mut leaf1_fn);
-    composite1.quadtree().traverse_depth_first(&mut visitor1);
+    composite1.qbvh().traverse_depth_first(&mut visitor1);
 
     workspace
         .sub_detectors

--- a/src/query/contact_manifolds/contact_manifolds_heightfield_composite_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_heightfield_composite_shape.rs
@@ -76,12 +76,9 @@ pub fn contact_manifolds_heightfield_composite_shape<ManifoldData, ContactData>(
     /*
      * Compute interferences.
      */
-    let quadtree2 = composite2.quadtree();
+    let qbvh2 = composite2.qbvh();
     let mut stack2 = Vec::new();
-    let ls_aabb2_1 = quadtree2
-        .root_aabb()
-        .transform_by(pos12)
-        .loosened(prediction);
+    let ls_aabb2_1 = qbvh2.root_aabb().transform_by(pos12).loosened(prediction);
     let mut old_manifolds = std::mem::replace(manifolds, Vec::new());
 
     heightfield1.map_elements_in_local_aabb(&ls_aabb2_1, &mut |leaf1, part1| {
@@ -150,7 +147,7 @@ pub fn contact_manifolds_heightfield_composite_shape<ManifoldData, ContactData>(
         };
 
         let mut visitor2 = BoundingVolumeIntersectionsVisitor::new(&ls_aabb1_2, &mut leaf_fn2);
-        quadtree2.traverse_depth_first_with_stack(&mut visitor2, &mut stack2);
+        qbvh2.traverse_depth_first_with_stack(&mut visitor2, &mut stack2);
     });
 
     workspace

--- a/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
@@ -124,7 +124,7 @@ pub fn contact_manifolds_trimesh_shape<ManifoldData, ContactData>(
 
         workspace.interferences.clear();
         trimesh1
-            .quadtree()
+            .qbvh()
             .intersect_aabb(&local_aabb2, &mut workspace.interferences);
         workspace.local_aabb2 = local_aabb2;
     }

--- a/src/query/distance/distance_composite_shape_shape.rs
+++ b/src/query/distance/distance_composite_shape_shape.rs
@@ -18,7 +18,7 @@ where
     G1: TypedSimdCompositeShape,
 {
     let mut visitor = CompositeShapeAgainstAnyDistanceVisitor::new(dispatcher, pos12, g1, g2);
-    g1.typed_quadtree()
+    g1.typed_qbvh()
         .traverse_best_first(&mut visitor)
         .expect("The composite shape must not be empty.")
         .1

--- a/src/query/intersection_test/intersection_test_composite_shape_shape.rs
+++ b/src/query/intersection_test/intersection_test_composite_shape_shape.rs
@@ -20,7 +20,7 @@ where
     let mut visitor =
         IntersectionCompositeShapeShapeBestFirstVisitor::new(dispatcher, pos12, g1, g2);
 
-    g1.typed_quadtree()
+    g1.typed_qbvh()
         .traverse_best_first(&mut visitor)
         .map(|e| e.1 .1)
         .unwrap_or(false)

--- a/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_composite_shape_shape.rs
+++ b/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_composite_shape_shape.rs
@@ -31,7 +31,7 @@ where
         stop_at_penetration,
     );
 
-    g1.typed_quadtree()
+    g1.typed_qbvh()
         .traverse_best_first(&mut visitor)
         .map(|res| res.1 .1)
 }

--- a/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_support_map_support_map.rs
+++ b/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_support_map_support_map.rs
@@ -68,11 +68,6 @@ where
     SM1: ?Sized + SupportMap,
     SM2: ?Sized + SupportMap,
 {
-    // println!(
-    //     ">>>>>>>> cube-cube: {}",
-    //     g1.as_cuboid().is_some() && g2.as_cuboid().is_some()
-    // );
-    // dbg!(mode);
     let sphere1 = g1.compute_local_bounding_sphere();
     let sphere2 = g2.compute_local_bounding_sphere();
 
@@ -127,7 +122,7 @@ where
         let pos2 = motion2.position_at_time(result.toi);
         let pos12 = pos1.inv_mul(&pos2);
 
-        // FIXME: use the _with_params version of the closest points query.
+        // TODO: use the _with_params version of the closest points query.
         match dispatcher
             .closest_points(&pos12, g1, g2, Real::max_value())
             .ok()?

--- a/src/query/point/point_composite_shape.rs
+++ b/src/query/point/point_composite_shape.rs
@@ -26,7 +26,7 @@ impl PointQuery for Polyline {
     ) -> (PointProjection, FeatureId) {
         let mut visitor =
             PointCompositeShapeProjWithFeatureBestFirstVisitor::new(self, point, false);
-        let (proj, (id, feature)) = self.quadtree().traverse_best_first(&mut visitor).unwrap().1;
+        let (proj, (id, feature)) = self.qbvh().traverse_best_first(&mut visitor).unwrap().1;
         let polyline_feature = self.segment_feature_to_polyline_feature(id, feature);
 
         (proj, polyline_feature)
@@ -37,7 +37,7 @@ impl PointQuery for Polyline {
     #[inline]
     fn contains_local_point(&self, point: &Point<Real>) -> bool {
         let mut visitor = CompositePointContainmentTest::new(self, point);
-        self.quadtree().traverse_depth_first(&mut visitor);
+        self.qbvh().traverse_depth_first(&mut visitor);
         visitor.found
     }
 }
@@ -55,7 +55,7 @@ impl PointQuery for TriMesh {
     ) -> (PointProjection, FeatureId) {
         let mut visitor =
             PointCompositeShapeProjWithFeatureBestFirstVisitor::new(self, point, false);
-        let (proj, (id, _feature)) = self.quadtree().traverse_best_first(&mut visitor).unwrap().1;
+        let (proj, (id, _feature)) = self.qbvh().traverse_best_first(&mut visitor).unwrap().1;
         let feature_id = FeatureId::Face(id);
         (proj, feature_id)
     }
@@ -65,7 +65,7 @@ impl PointQuery for TriMesh {
     #[inline]
     fn contains_local_point(&self, point: &Point<Real>) -> bool {
         let mut visitor = CompositePointContainmentTest::new(self, point);
-        self.quadtree().traverse_depth_first(&mut visitor);
+        self.qbvh().traverse_depth_first(&mut visitor);
         visitor.found
     }
 }
@@ -74,11 +74,7 @@ impl PointQuery for Compound {
     #[inline]
     fn project_local_point(&self, point: &Point<Real>, solid: bool) -> PointProjection {
         let mut visitor = PointCompositeShapeProjBestFirstVisitor::new(self, point, solid);
-        self.quadtree()
-            .traverse_best_first(&mut visitor)
-            .unwrap()
-            .1
-             .0
+        self.qbvh().traverse_best_first(&mut visitor).unwrap().1 .0
     }
 
     #[inline]
@@ -92,7 +88,7 @@ impl PointQuery for Compound {
     #[inline]
     fn contains_local_point(&self, point: &Point<Real>) -> bool {
         let mut visitor = CompositePointContainmentTest::new(self, point);
-        self.quadtree().traverse_depth_first(&mut visitor);
+        self.qbvh().traverse_depth_first(&mut visitor);
         visitor.found
     }
 }
@@ -108,7 +104,7 @@ impl PointQueryWithLocation for Polyline {
     ) -> (PointProjection, Self::Location) {
         let mut visitor =
             PointCompositeShapeProjWithLocationBestFirstVisitor::new(self, point, solid);
-        self.quadtree().traverse_best_first(&mut visitor).unwrap().1
+        self.qbvh().traverse_best_first(&mut visitor).unwrap().1
     }
 }
 
@@ -123,7 +119,7 @@ impl PointQueryWithLocation for TriMesh {
     ) -> (PointProjection, Self::Location) {
         let mut visitor =
             PointCompositeShapeProjWithLocationBestFirstVisitor::new(self, point, solid);
-        self.quadtree().traverse_best_first(&mut visitor).unwrap().1
+        self.qbvh().traverse_best_first(&mut visitor).unwrap().1
     }
 }
 

--- a/src/query/ray/ray_composite_shape.rs
+++ b/src/query/ray/ray_composite_shape.rs
@@ -10,7 +10,7 @@ impl RayCast for TriMesh {
     fn cast_local_ray(&self, ray: &Ray, max_toi: Real, solid: bool) -> Option<Real> {
         let mut visitor = RayCompositeShapeToiBestFirstVisitor::new(self, ray, max_toi, solid);
 
-        self.quadtree()
+        self.qbvh()
             .traverse_best_first(&mut visitor)
             .map(|res| res.1 .1)
     }
@@ -25,7 +25,7 @@ impl RayCast for TriMesh {
         let mut visitor =
             RayCompositeShapeToiAndNormalBestFirstVisitor::new(self, ray, max_toi, solid);
 
-        self.quadtree()
+        self.qbvh()
             .traverse_best_first(&mut visitor)
             .map(|(_, (best, mut res))| {
                 // We hit a backface.
@@ -45,7 +45,7 @@ impl RayCast for Polyline {
     fn cast_local_ray(&self, ray: &Ray, max_toi: Real, solid: bool) -> Option<Real> {
         let mut visitor = RayCompositeShapeToiBestFirstVisitor::new(self, ray, max_toi, solid);
 
-        self.quadtree()
+        self.qbvh()
             .traverse_best_first(&mut visitor)
             .map(|res| res.1 .1)
     }
@@ -60,7 +60,7 @@ impl RayCast for Polyline {
         let mut visitor =
             RayCompositeShapeToiAndNormalBestFirstVisitor::new(self, ray, max_toi, solid);
 
-        self.quadtree()
+        self.qbvh()
             .traverse_best_first(&mut visitor)
             .map(|(_, (_, res))| res)
     }
@@ -71,7 +71,7 @@ impl RayCast for Compound {
     fn cast_local_ray(&self, ray: &Ray, max_toi: Real, solid: bool) -> Option<Real> {
         let mut visitor = RayCompositeShapeToiBestFirstVisitor::new(self, ray, max_toi, solid);
 
-        self.quadtree()
+        self.qbvh()
             .traverse_best_first(&mut visitor)
             .map(|res| res.1 .1)
     }
@@ -86,7 +86,7 @@ impl RayCast for Compound {
         let mut visitor =
             RayCompositeShapeToiAndNormalBestFirstVisitor::new(self, ray, max_toi, solid);
 
-        self.quadtree()
+        self.qbvh()
             .traverse_best_first(&mut visitor)
             .map(|(_, (_, res))| res)
     }

--- a/src/query/ray/ray_support_map.rs
+++ b/src/query/ray/ray_support_map.rs
@@ -182,12 +182,11 @@ impl RayCast for Segment {
 
                     match (dist1 >= 0.0, dist2 >= 0.0) {
                         (true, true) => {
-                            if dist1 <= dist2 {
-                                Some(RayIntersection::new(
-                                    dist1 / ray.dir.norm_squared(),
-                                    normal,
-                                    FeatureId::Vertex(0),
-                                ))
+                            let toi = dist1.min(dist2) / ray.dir.norm_squared();
+                            if toi > max_toi {
+                                None
+                            } else if dist1 <= dist2 {
+                                Some(RayIntersection::new(toi, normal, FeatureId::Vertex(0)))
                             } else {
                                 Some(RayIntersection::new(
                                     dist2 / ray.dir.norm_squared(),
@@ -209,7 +208,7 @@ impl RayCast for Segment {
                     // The rays never intersect.
                     None
                 }
-            } else if s >= 0.0 && t >= 0.0 && t <= 1.0 {
+            } else if s >= 0.0 && s <= max_toi && t >= 0.0 && t <= 1.0 {
                 let normal = self.scaled_normal();
 
                 if normal.dot(&ray.dir) > 0.0 {

--- a/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
+++ b/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
@@ -20,7 +20,7 @@ where
 {
     let mut visitor =
         TOICompositeShapeShapeBestFirstVisitor::new(dispatcher, pos12, vel12, g1, g2, max_toi);
-    g1.typed_quadtree()
+    g1.typed_qbvh()
         .traverse_best_first(&mut visitor)
         .map(|res| res.1 .1)
 }

--- a/src/shape/composite_shape.rs
+++ b/src/shape/composite_shape.rs
@@ -11,7 +11,7 @@ pub trait SimdCompositeShape {
     fn map_part_at(&self, shape_id: u32, f: &mut dyn FnMut(Option<&Isometry<Real>>, &dyn Shape));
 
     /// Gets the acceleration structure of the composite shape.
-    fn quadtree(&self) -> &QBVH<u32>;
+    fn qbvh(&self) -> &QBVH<u32>;
 }
 
 pub trait TypedSimdCompositeShape {
@@ -33,7 +33,7 @@ pub trait TypedSimdCompositeShape {
         f: impl FnMut(Option<&Isometry<Real>>, &dyn Shape),
     );
 
-    fn typed_quadtree(&self) -> &QBVH<Self::PartId>;
+    fn typed_qbvh(&self) -> &QBVH<Self::PartId>;
 }
 
 impl<'a> TypedSimdCompositeShape for dyn SimdCompositeShape + 'a {
@@ -56,7 +56,7 @@ impl<'a> TypedSimdCompositeShape for dyn SimdCompositeShape + 'a {
         self.map_part_at(shape_id, &mut f)
     }
 
-    fn typed_quadtree(&self) -> &QBVH<Self::PartId> {
-        self.quadtree()
+    fn typed_qbvh(&self) -> &QBVH<Self::PartId> {
+        self.qbvh()
     }
 }

--- a/src/shape/compound.rs
+++ b/src/shape/compound.rs
@@ -16,7 +16,7 @@ use crate::shape::{Shape, SharedShape, SimdCompositeShape, TypedSimdCompositeSha
 #[derive(Clone)]
 pub struct Compound {
     shapes: Vec<(Isometry<Real>, SharedShape)>,
-    quadtree: QBVH<u32>,
+    qbvh: QBVH<u32>,
     aabbs: Vec<AABB>,
     aabb: AABB,
 }
@@ -47,14 +47,14 @@ impl Compound {
             }
         }
 
-        let mut quadtree = QBVH::new();
+        let mut qbvh = QBVH::new();
         // NOTE: we apply no dilation factor because we won't
         // update this tree dynamically.
-        quadtree.clear_and_rebuild(leaves.into_iter(), 0.0);
+        qbvh.clear_and_rebuild(leaves.into_iter(), 0.0);
 
         Compound {
             shapes,
-            quadtree,
+            qbvh,
             aabbs,
             aabb,
         }
@@ -88,8 +88,8 @@ impl Compound {
 
     /// The acceleration structure used by this compound shape.
     #[inline]
-    pub fn quadtree(&self) -> &QBVH<u32> {
-        &self.quadtree
+    pub fn qbvh(&self) -> &QBVH<u32> {
+        &self.qbvh
     }
 }
 
@@ -102,8 +102,8 @@ impl SimdCompositeShape for Compound {
     }
 
     #[inline]
-    fn quadtree(&self) -> &QBVH<u32> {
-        &self.quadtree
+    fn qbvh(&self) -> &QBVH<u32> {
+        &self.qbvh
     }
 }
 
@@ -134,7 +134,7 @@ impl TypedSimdCompositeShape for Compound {
     }
 
     #[inline]
-    fn typed_quadtree(&self) -> &QBVH<u32> {
-        &self.quadtree
+    fn typed_qbvh(&self) -> &QBVH<u32> {
+        &self.qbvh
     }
 }

--- a/src/shape/polyline.rs
+++ b/src/shape/polyline.rs
@@ -8,7 +8,7 @@ use crate::shape::{FeatureId, Segment, Shape, TypedSimdCompositeShape};
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// A polyline.
 pub struct Polyline {
-    quadtree: QBVH<u32>,
+    qbvh: QBVH<u32>,
     vertices: Vec<Point<Real>>,
     indices: Vec<[u32; 2]>,
 }
@@ -24,13 +24,13 @@ impl Polyline {
             (i as u32, aabb)
         });
 
-        let mut quadtree = QBVH::new();
+        let mut qbvh = QBVH::new();
         // NOTE: we apply no dilation factor because we won't
         // update this tree dynamically.
-        quadtree.clear_and_rebuild(data, 0.0);
+        qbvh.clear_and_rebuild(data, 0.0);
 
         Self {
-            quadtree,
+            qbvh,
             vertices,
             indices,
         }
@@ -38,16 +38,16 @@ impl Polyline {
 
     /// Compute the axis-aligned bounding box of this polyline.
     pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
-        self.quadtree.root_aabb().transform_by(pos)
+        self.qbvh.root_aabb().transform_by(pos)
     }
 
     /// Gets the local axis-aligned bounding box of this polyline.
     pub fn local_aabb(&self) -> &AABB {
-        &self.quadtree.root_aabb()
+        &self.qbvh.root_aabb()
     }
 
-    pub(crate) fn quadtree(&self) -> &QBVH<u32> {
-        &self.quadtree
+    pub(crate) fn qbvh(&self) -> &QBVH<u32> {
+        &self.qbvh
     }
 
     /// The number of segments forming this polyline.
@@ -117,7 +117,7 @@ impl Polyline {
 
         // Because we reversed the indices, we need to
         // adjust the segment indices stored in the QBVH.
-        for (_, seg_id) in self.quadtree.iter_data_mut() {
+        for (_, seg_id) in self.qbvh.iter_data_mut() {
             *seg_id = self.indices.len() as u32 - *seg_id - 1;
         }
     }
@@ -129,8 +129,8 @@ impl SimdCompositeShape for Polyline {
         f(None, &tri)
     }
 
-    fn quadtree(&self) -> &QBVH<u32> {
-        &self.quadtree
+    fn qbvh(&self) -> &QBVH<u32> {
+        &self.qbvh
     }
 }
 
@@ -154,7 +154,7 @@ impl TypedSimdCompositeShape for Polyline {
         f(None, &seg)
     }
 
-    fn typed_quadtree(&self) -> &QBVH<u32> {
-        &self.quadtree
+    fn typed_qbvh(&self) -> &QBVH<u32> {
+        &self.qbvh
     }
 }

--- a/src/shape/polyline.rs
+++ b/src/shape/polyline.rs
@@ -105,6 +105,22 @@ impl Polyline {
             std::slice::from_raw_parts(data, len)
         }
     }
+
+    /// Reverse the orientation of this polyline by swapping the indices of all
+    /// its segments and reverting its index buffer.
+    pub fn reverse(&mut self) {
+        for idx in &mut self.indices {
+            idx.swap(0, 1);
+        }
+
+        self.indices.reverse();
+
+        // Because we reversed the indices, we need to
+        // adjust the segment indices stored in the QBVH.
+        for (_, seg_id) in self.quadtree.iter_data_mut() {
+            *seg_id = self.indices.len() as u32 - *seg_id - 1;
+        }
+    }
 }
 
 impl SimdCompositeShape for Polyline {

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -12,7 +12,7 @@ use crate::utils::HashablePartialEq;
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// A triangle mesh.
 pub struct TriMesh {
-    quadtree: QBVH<u32>,
+    qbvh: QBVH<u32>,
     vertices: Vec<Point<Real>>,
     indices: Vec<[u32; 3]>,
 }
@@ -35,13 +35,13 @@ impl TriMesh {
             (i as u32, aabb)
         });
 
-        let mut quadtree = QBVH::new();
+        let mut qbvh = QBVH::new();
         // NOTE: we apply no dilation factor because we won't
         // update this tree dynamically.
-        quadtree.clear_and_rebuild(data, 0.0);
+        qbvh.clear_and_rebuild(data, 0.0);
 
         Self {
-            quadtree,
+            qbvh,
             vertices,
             indices,
         }
@@ -49,17 +49,17 @@ impl TriMesh {
 
     /// Compute the axis-aligned bounding box of this triangle mesh.
     pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
-        self.quadtree.root_aabb().transform_by(pos)
+        self.qbvh.root_aabb().transform_by(pos)
     }
 
     /// Gets the local axis-aligned bounding box of this triangle mesh.
     pub fn local_aabb(&self) -> &AABB {
-        self.quadtree.root_aabb()
+        self.qbvh.root_aabb()
     }
 
     /// The acceleration structure used by this triangle-mesh.
-    pub fn quadtree(&self) -> &QBVH<u32> {
-        &self.quadtree
+    pub fn qbvh(&self) -> &QBVH<u32> {
+        &self.qbvh
     }
 
     /// The number of triangles forming this mesh.
@@ -179,7 +179,7 @@ impl RayCast for TriMesh {
     ) -> Option<RayIntersection> {
         // FIXME: do a best-first search.
         let mut intersections = Vec::new();
-        self.quadtree.cast_ray(&ray, max_toi, &mut intersections);
+        self.qbvh.cast_ray(&ray, max_toi, &mut intersections);
         let mut best: Option<RayIntersection> = None;
 
         for inter in intersections {
@@ -201,7 +201,7 @@ impl RayCast for TriMesh {
     fn intersects_local_ray(&self, ray: &Ray, max_toi: Real) -> bool {
         // FIXME: do a best-first search.
         let mut intersections = Vec::new();
-        self.quadtree.cast_ray(&ray, max_toi, &mut intersections);
+        self.qbvh.cast_ray(&ray, max_toi, &mut intersections);
 
         for inter in intersections {
             let tri = self.triangle(inter);
@@ -237,8 +237,8 @@ impl SimdCompositeShape for TriMesh {
         f(None, &tri)
     }
 
-    fn quadtree(&self) -> &QBVH<u32> {
-        &self.quadtree
+    fn qbvh(&self) -> &QBVH<u32> {
+        &self.qbvh
     }
 }
 
@@ -262,7 +262,7 @@ impl TypedSimdCompositeShape for TriMesh {
         f(None, &tri)
     }
 
-    fn typed_quadtree(&self) -> &QBVH<u32> {
-        &self.quadtree
+    fn typed_qbvh(&self) -> &QBVH<u32> {
+        &self.qbvh
     }
 }

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -116,6 +116,11 @@ impl TriMesh {
         }
     }
 
+    /// Remove all duplicate vertices and adjust the index buffer accordingly.
+    ///
+    /// This is typically used to recover a vertex buffer from which we can deduce
+    /// adjacency information. between triangles by observing how the vertices are
+    /// shared by triangles based on the index buffer.
     pub fn recover_topology(&mut self) {
         let mut vtx_to_id = HashMap::default();
         let mut new_vertices = Vec::with_capacity(self.vertices.len());

--- a/src/utils/hashable_partial_eq.rs
+++ b/src/utils/hashable_partial_eq.rs
@@ -9,10 +9,10 @@ pub struct HashablePartialEq<T> {
 }
 
 impl<T> HashablePartialEq<T> {
-    /// Creates a new `HashablePartialEq`. This is unsafe because you must be sure that you really
+    /// Creates a new `HashablePartialEq`. Please make sure that you really
     /// want to transform the wrapped object's partial equality to an equivalence relation.
-    pub unsafe fn new(value: T) -> HashablePartialEq<T> {
-        HashablePartialEq { value: value }
+    pub fn new(value: T) -> HashablePartialEq<T> {
+        HashablePartialEq { value }
     }
 
     /// Gets the wrapped value.

--- a/src/utils/interval.rs
+++ b/src/utils/interval.rs
@@ -1,0 +1,533 @@
+// "Complete Interval Arithmetic and its Implementation on the Computer"
+// Ulrich W. Kulisch
+use na::{RealField, SimdPartialOrd};
+use num::{One, Zero};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
+
+pub trait IntervalFunction<T> {
+    fn eval(&self, t: T) -> T;
+    fn eval_interval(&self, t: Interval<T>) -> Interval<T>;
+    fn eval_interval_gradient(&self, t: Interval<T>) -> Interval<T>;
+}
+
+pub fn find_root_intervals_to<T: RealField>(
+    function: &impl IntervalFunction<T>,
+    init: Interval<T>,
+    min_interval_width: T,
+    min_image_width: T,
+    max_recursions: usize,
+    results: &mut Vec<Interval<T>>,
+    candidates: &mut Vec<(Interval<T>, usize)>,
+) {
+    candidates.clear();
+
+    let push_candidate = |candidate,
+                          recursion,
+                          results: &mut Vec<Interval<T>>,
+                          candidates: &mut Vec<(Interval<T>, usize)>| {
+        let candidate_image = function.eval_interval(candidate);
+        let is_small_range =
+            candidate.width() < min_interval_width || candidate_image.width() < min_image_width;
+
+        if candidate_image.contains(T::zero()) {
+            if recursion == max_recursions || is_small_range {
+                results.push(candidate);
+            } else {
+                candidates.push((candidate, recursion + 1));
+            }
+        } else if is_small_range
+            && function.eval(candidate.midpoint()).abs() < T::default_epsilon().sqrt()
+        {
+            // If we have a small range, and we are close to zero,
+            // consider that we reached zero.
+            results.push(candidate);
+        }
+    };
+
+    push_candidate(init, 0, results, candidates);
+
+    while let Some((candidate, recursion)) = candidates.pop() {
+        // println!(
+        //     "Candidate: {:?}, recursion: {}, image: {:?}",
+        //     candidate,
+        //     recursion,
+        //     function.eval_interval(candidate)
+        // );
+
+        // NOTE: we don't check the max_recursions at the beginning of the
+        //       loop here because that would make us loose the candidate
+        //       we just popped.
+        let mid = candidate.midpoint();
+        let f_mid = function.eval(mid);
+        let gradient = function.eval_interval_gradient(candidate);
+        let (shift1, shift2) = Interval(f_mid, f_mid) / gradient;
+
+        let new_candidates = [
+            (Interval(mid, mid) - shift1).intersect(candidate),
+            shift2.and_then(|shift2| (Interval(mid, mid) - shift2).intersect(candidate)),
+        ];
+
+        let prev_width = candidate.width();
+
+        for new_candidate in new_candidates.iter() {
+            if let Some(new_candidate) = new_candidate {
+                if new_candidate.width() > prev_width * na::convert(0.75) {
+                    // If the new candidate range is still quite big compared to
+                    // new candidate, split it to accelerate the search.
+                    let [a, b] = new_candidate.split();
+                    push_candidate(a, recursion, results, candidates);
+                    push_candidate(b, recursion, results, candidates);
+                } else {
+                    push_candidate(*new_candidate, recursion, results, candidates);
+                }
+            }
+        }
+    }
+}
+
+pub fn find_root_intervals<T: RealField>(
+    function: &impl IntervalFunction<T>,
+    init: Interval<T>,
+    min_interval_width: T,
+    min_image_width: T,
+    mut max_recursions: usize,
+) -> Vec<Interval<T>> {
+    let mut results = vec![];
+    let mut candidates = vec![];
+    find_root_intervals_to(
+        function,
+        init,
+        min_interval_width,
+        min_image_width,
+        max_recursions,
+        &mut results,
+        &mut candidates,
+    );
+    results
+}
+
+/// An interval implementing interval arithmetic.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Interval<T>(pub T, pub T);
+
+impl<T> Interval<T> {
+    #[must_use]
+    pub fn sort(a: T, b: T) -> Self
+    where
+        T: PartialOrd,
+    {
+        if a < b {
+            Self(a, b)
+        } else {
+            Self(b, a)
+        }
+    }
+
+    #[must_use]
+    pub fn splat(e: T) -> Self
+    where
+        T: Clone,
+    {
+        Self(e.clone(), e)
+    }
+
+    /// Does this interval contain the given value?
+    #[must_use]
+    pub fn contains(&self, t: T) -> bool
+    where
+        T: PartialOrd<T>,
+    {
+        self.0 <= t && self.1 >= t
+    }
+
+    #[must_use]
+    pub fn width(self) -> T::Output
+    where
+        T: Sub<T>,
+    {
+        self.1 - self.0
+    }
+
+    #[must_use]
+    pub fn midpoint(self) -> T
+    where
+        T: RealField,
+    {
+        let two: T = na::convert(2.0);
+        (self.0 + self.1) / two
+    }
+
+    #[must_use]
+    pub fn split(self) -> [Self; 2]
+    where
+        T: RealField,
+    {
+        let mid = self.midpoint();
+        [Interval(self.0, mid), Interval(mid, self.1)]
+    }
+
+    #[must_use]
+    pub fn enclose(self, t: T) -> Self
+    where
+        T: PartialOrd,
+    {
+        if t < self.0 {
+            Interval(t, self.1)
+        } else if t > self.1 {
+            Interval(self.0, t)
+        } else {
+            self
+        }
+    }
+
+    #[must_use]
+    pub fn intersect(self, rhs: Self) -> Option<Self>
+    where
+        T: PartialOrd + SimdPartialOrd, // TODO: it is weird to have both.
+    {
+        let result = Interval(self.0.simd_max(rhs.0), self.1.simd_min(rhs.1));
+
+        if result.0 > result.1 {
+            // The range is invalid if there is no intersection.
+            None
+        } else {
+            Some(result)
+        }
+    }
+
+    #[must_use]
+    pub fn sin_cos(self) -> (Self, Self)
+    where
+        T: RealField,
+    {
+        (self.sin(), self.cos())
+    }
+
+    /// Bounds the image of the sinus function on this interval.
+    #[must_use]
+    pub fn sin(self) -> Self
+    where
+        T: RealField,
+    {
+        if self.width() >= T::two_pi() {
+            Interval(-T::one(), T::one())
+        } else {
+            let sin0 = self.0.sin();
+            let sin1 = self.1.sin();
+            let mut result = Interval::sort(sin0, sin1);
+
+            let orig = (self.0 / T::two_pi()).floor() * T::two_pi();
+            let crit = [orig + T::frac_pi_2(), orig + T::pi() + T::frac_pi_2()];
+            let crit_vals = [T::one(), -T::one()];
+
+            for i in 0..2 {
+                if self.contains(crit[i]) || self.contains(crit[i] + T::two_pi()) {
+                    result = result.enclose(crit_vals[i])
+                }
+            }
+
+            result
+        }
+    }
+
+    /// Bounds the image of the cosinus function on this interval.
+    #[must_use]
+    pub fn cos(self) -> Self
+    where
+        T: RealField,
+    {
+        if self.width() >= T::two_pi() {
+            Interval(-T::one(), T::one())
+        } else {
+            let cos0 = self.0.cos();
+            let cos1 = self.1.cos();
+            let mut result = Interval::sort(cos0, cos1);
+
+            let orig = (self.0 / T::two_pi()).floor() * T::two_pi();
+            let crit = [orig, orig + T::pi()];
+            let crit_vals = [T::one(), -T::one()];
+
+            for i in 0..2 {
+                if self.contains(crit[i]) || self.contains(crit[i] + T::two_pi()) {
+                    result = result.enclose(crit_vals[i])
+                }
+            }
+
+            result
+        }
+    }
+}
+
+impl<T: Add<T> + Copy> Add<T> for Interval<T> {
+    type Output = Interval<<T as Add<T>>::Output>;
+
+    fn add(self, rhs: T) -> Self::Output {
+        Interval(self.0 + rhs, self.1 + rhs)
+    }
+}
+
+impl<T: Add<T>> Add<Interval<T>> for Interval<T> {
+    type Output = Interval<<T as Add<T>>::Output>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Interval(self.0 + rhs.0, self.1 + rhs.1)
+    }
+}
+
+impl<T: Sub<T> + Copy> Sub<T> for Interval<T> {
+    type Output = Interval<<T as Sub<T>>::Output>;
+
+    fn sub(self, rhs: T) -> Self::Output {
+        Interval(self.0 - rhs, self.1 - rhs)
+    }
+}
+
+impl<T: Sub<T> + Copy> Sub<Interval<T>> for Interval<T> {
+    type Output = Interval<<T as Sub<T>>::Output>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Interval(self.0 - rhs.1, self.1 - rhs.0)
+    }
+}
+
+impl<T: Neg> Neg for Interval<T> {
+    type Output = Interval<T::Output>;
+
+    fn neg(self) -> Self::Output {
+        Interval(-self.1, -self.0)
+    }
+}
+
+impl<T: Mul<T>> Mul<T> for Interval<T>
+where
+    T: Copy + PartialOrd + Zero,
+{
+    type Output = Interval<<T as Mul<T>>::Output>;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        if rhs < T::zero() {
+            Interval(self.1 * rhs, self.0 * rhs)
+        } else {
+            Interval(self.0 * rhs, self.1 * rhs)
+        }
+    }
+}
+
+impl<T: Mul<T>> Mul<Interval<T>> for Interval<T>
+where
+    T: Copy + PartialOrd + Zero,
+    <T as Mul<T>>::Output: SimdPartialOrd,
+{
+    type Output = Interval<<T as Mul<T>>::Output>;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let Interval(a1, a2) = self;
+        let Interval(b1, b2) = rhs;
+
+        if a2 <= T::zero() {
+            if b2 <= T::zero() {
+                Interval(a2 * b2, a1 * b1)
+            } else if b1 < T::zero() {
+                Interval(a1 * b2, a1 * b1)
+            } else {
+                Interval(a1 * b2, a2 * b1)
+            }
+        } else if a1 < T::zero() {
+            if b2 <= T::zero() {
+                Interval(a2 * b1, a1 * b1)
+            } else if b1 < T::zero() {
+                Interval((a1 * b2).simd_min(b2 * b1), (a1 * b1).simd_max(a2 * b2))
+            } else {
+                Interval(a1 * b2, a2 * b2)
+            }
+        } else {
+            if b2 <= T::zero() {
+                Interval(a2 * b1, a1 * b2)
+            } else if b1 < T::zero() {
+                Interval(a2 * b1, a2 * b2)
+            } else {
+                Interval(a1 * b1, a2 * b2)
+            }
+        }
+    }
+}
+
+impl<T: Div<T>> Div<Interval<T>> for Interval<T>
+where
+    T: RealField,
+    <T as Div<T>>::Output: SimdPartialOrd,
+{
+    type Output = (
+        Interval<<T as Div<T>>::Output>,
+        Option<Interval<<T as Div<T>>::Output>>,
+    );
+
+    fn div(self, rhs: Self) -> Self::Output {
+        let infinity = T::one() / T::zero();
+
+        let Interval(a1, a2) = self;
+        let Interval(b1, b2) = rhs;
+
+        if b1 <= T::zero() && b2 >= T::zero() {
+            // rhs contains T::zero() so we my have to return
+            // two intervals.
+            if a2 < T::zero() {
+                if b2 == T::zero() {
+                    (Interval(a2 / b1, infinity), None)
+                } else if b1 != T::zero() {
+                    (
+                        Interval(-infinity, a2 / b2),
+                        Some(Interval(a2 / b1, infinity)),
+                    )
+                } else {
+                    (Interval(-infinity, a2 / b2), None)
+                }
+            } else if a1 <= T::zero() {
+                (Interval(-infinity, infinity), None)
+            } else {
+                if b2 == T::zero() {
+                    (Interval(-infinity, a1 / b1), None)
+                } else if b1 != T::zero() {
+                    (
+                        Interval(-infinity, a1 / b1),
+                        Some(Interval(a1 / b2, infinity)),
+                    )
+                } else {
+                    (Interval(a1 / b2, infinity), None)
+                }
+            }
+        } else {
+            if a2 <= T::zero() {
+                if b2 < T::zero() {
+                    (Interval(a2 / b1, a1 / b2), None)
+                } else {
+                    (Interval(a1 / b1, a2 / b2), None)
+                }
+            } else if a1 < T::zero() {
+                if b2 < T::zero() {
+                    (Interval(a2 / b2, a1 / b2), None)
+                } else {
+                    (Interval(a1 / b1, a2 / b1), None)
+                }
+            } else {
+                if b2 < T::zero() {
+                    (Interval(a2 / b2, a1 / b1), None)
+                } else {
+                    (Interval(a1 / b2, a2 / b1), None)
+                }
+            }
+        }
+    }
+}
+
+impl<T: Copy + Add<T, Output = T>> AddAssign<Interval<T>> for Interval<T> {
+    fn add_assign(&mut self, rhs: Interval<T>) {
+        *self = *self + rhs;
+    }
+}
+
+impl<T: Copy + Sub<T, Output = T>> SubAssign<Interval<T>> for Interval<T> {
+    fn sub_assign(&mut self, rhs: Interval<T>) {
+        *self = *self - rhs;
+    }
+}
+
+impl<T: Mul<T, Output = T>> MulAssign<Interval<T>> for Interval<T>
+where
+    T: Copy + PartialOrd + Zero,
+    <T as Mul<T>>::Output: SimdPartialOrd,
+{
+    fn mul_assign(&mut self, rhs: Interval<T>) {
+        *self = *self * rhs;
+    }
+}
+
+impl<T: Zero + Add<T>> Zero for Interval<T> {
+    fn zero() -> Self {
+        Self(T::zero(), T::zero())
+    }
+
+    fn is_zero(&self) -> bool {
+        self.0.is_zero() && self.1.is_zero()
+    }
+}
+
+impl<T: One + Mul<T>> One for Interval<T>
+where
+    Interval<T>: Mul<Interval<T>, Output = Interval<T>>,
+{
+    fn one() -> Self {
+        Self(T::one(), T::one())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Interval, IntervalFunction};
+    use na::RealField;
+
+    #[test]
+    fn roots_sin() {
+        struct Sin;
+
+        impl IntervalFunction<f32> for Sin {
+            fn eval(&self, t: f32) -> f32 {
+                t.sin()
+            }
+
+            fn eval_interval(&self, t: Interval<f32>) -> Interval<f32> {
+                t.sin()
+            }
+
+            fn eval_interval_gradient(&self, t: Interval<f32>) -> Interval<f32> {
+                t.cos()
+            }
+        }
+
+        let function = Sin;
+        let roots = super::find_root_intervals(
+            &function,
+            Interval(0.0, f32::two_pi()),
+            1.0e-5,
+            1.0e-5,
+            100,
+        );
+        assert_eq!(roots.len(), 3);
+    }
+
+    #[test]
+    fn interval_sin_cos() {
+        let a = f32::pi() / 6.0;
+        let b = f32::pi() / 2.0 + f32::pi() / 6.0;
+        let c = f32::pi() + f32::pi() / 6.0;
+        let d = f32::pi() + f32::pi() / 2.0 + f32::pi() / 6.0;
+        let shifts = [0.0, f32::two_pi() * 100.0, -f32::two_pi() * 100.0];
+
+        for shift in shifts.iter() {
+            // Test sinus.
+            assert_eq!(
+                Interval(a + *shift, b + *shift).sin(),
+                Interval((a + *shift).sin(), 1.0)
+            );
+            assert_eq!(
+                Interval(a + *shift, c + *shift).sin(),
+                Interval((c + *shift).sin(), 1.0)
+            );
+            assert_eq!(Interval(a + *shift, d + *shift).sin(), Interval(-1.0, 1.0));
+
+            // Test cosinus.
+            assert_eq!(
+                Interval(a + *shift, b + *shift).cos(),
+                Interval((b + *shift).cos(), (a + *shift).cos())
+            );
+            assert_eq!(
+                Interval(a + *shift, c + *shift).cos(),
+                Interval(-1.0, (a + *shift).cos())
+            );
+            assert_eq!(
+                Interval(a + *shift, d + *shift).cos(),
+                Interval(-1.0, (a + *shift).cos())
+            );
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -19,6 +19,7 @@ pub use self::as_bytes::AsBytes;
 pub(crate) use self::consts::*;
 pub use self::cov::cov;
 pub use self::hashable_partial_eq::HashablePartialEq;
+pub use self::interval::{find_root_intervals, find_root_intervals_to, Interval, IntervalFunction};
 #[cfg(feature = "dim3")]
 pub(crate) use self::sort::sort2;
 pub(crate) use self::sort::sort3;
@@ -36,6 +37,7 @@ mod cov;
 mod deterministic_state;
 mod hashable_partial_eq;
 pub mod hashmap;
+mod interval;
 mod inv;
 mod isometry_ops;
 mod median;


### PR DESCRIPTION
This adds various utilities I found useful for some geometric operations:
- Add a method to reverse the order of a polyline.
- Add a method to remove duplicate vertices form a `TriMesh` (and adjusting the index buffer accordingly).
- Add a method to iterate through all the lean data stored by a QBVH.
- Implement the Interval Newton Method for computing all the roots of a non-linear scalar function.
- Implement the intersection test between a spiral and an AABB.
- Rename all occurrences of `quadtree` to `qbvh`. Using the term `quadtree` was not representative of the actual acceleration structure being used (which is a BVH).