### PR TITLE
Add bevy-components feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ parry2d = { path = "build/parry2d" }
 parry3d = { path = "build/parry3d" }
 parry2d-f64 = { path = "build/parry2d-f64" }
 parry3d-f64 = { path = "build/parry3d-f64" }
+bevy = {path = "../bevy"}

--- a/build/parry2d-f64/Cargo.toml
+++ b/build/parry2d-f64/Cargo.toml
@@ -27,6 +27,7 @@ enhanced-determinism = [ "simba/libm_force", "indexmap" ]
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
 simd-is-enabled = [ ]
+bevy-components = ["bevy"]
 
 [lib]
 name = "parry2d_f64"
@@ -48,6 +49,7 @@ serde           = { version = "1.0", optional = true, features = ["derive"]}
 num-derive      = "0.3"
 indexmap = { version = "1", features = [ "serde-1" ], optional = true }
 rustc-hash = "1"
+bevy            = { version = "0.5", default-features = false, optional = true }
 
 [dev-dependencies]
 simba = { version = "0.6", features = [ "partial_fixed_point_support" ] }

--- a/build/parry2d/Cargo.toml
+++ b/build/parry2d/Cargo.toml
@@ -27,6 +27,7 @@ enhanced-determinism = [ "simba/libm_force", "indexmap" ]
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
 simd-is-enabled = [ ]
+bevy-components = ["bevy"]
 
 [lib]
 name = "parry2d"
@@ -48,6 +49,7 @@ serde           = { version = "1.0", optional = true, features = ["derive"]}
 num-derive      = "0.3"
 indexmap        = { version = "1", features = [ "serde-1" ], optional = true }
 rustc-hash      = "1"
+bevy            = { version = "0.5", default-features = false, optional = true }
 
 [dev-dependencies]
 simba = { version = "0.6", features = [ "partial_fixed_point_support" ] }

--- a/build/parry3d-f64/Cargo.toml
+++ b/build/parry3d-f64/Cargo.toml
@@ -27,6 +27,7 @@ enhanced-determinism = [ "simba/libm_force", "indexmap" ]
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
 simd-is-enabled = [ ]
+bevy-components = ["bevy"]
 
 [lib]
 name = "parry3d_f64"
@@ -47,7 +48,7 @@ serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}
 num-derive   = "0.3"
 indexmap = { version = "1", features = [ "serde-1" ], optional = true }
 rustc-hash = "1"
-
+bevy            = { version = "0.5", default-features = false, optional = true }
 
 [dev-dependencies]
 oorandom = "11"

--- a/build/parry3d/Cargo.toml
+++ b/build/parry3d/Cargo.toml
@@ -27,6 +27,7 @@ enhanced-determinism = [ "simba/libm_force", "indexmap" ]
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
 simd-is-enabled = [ ]
+bevy-components = ["bevy"]
 
 [lib]
 name = "parry3d"
@@ -47,7 +48,7 @@ serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}
 num-derive   = "0.3"
 indexmap = { version = "1", features = [ "serde-1" ], optional = true }
 rustc-hash = "1"
-
+bevy            = { version = "0.5", default-features = false, optional = true }
 
 [dev-dependencies]
 oorandom = "11"

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 /// The shape of a collider.
 #[derive(Clone)]
+#[cfg_attr(feature = "bevy-components", derive(bevy::prelude::Component))]
 pub struct SharedShape(pub Arc<dyn Shape>);
 
 impl Deref for SharedShape {


### PR DESCRIPTION
After https://github.com/bevyengine/bevy/pull/2254 there is a requirement that anything used as a component must derive `Component` explicitly.

From what I can tell, most of the data structures that are used as components in `bevy_rapier` are defined in `rapier`, but `SharedShape` is re-exported from `parry`, so the annotation has to go here.

I attempted to minimize the effect on `parry` by:
- putting it behind a feature flag
- minimizing the number of lines of code referring to bevy in parry
- turning off default features in bevy to reduce the effect on compile time

One thing I'm unsure of is specifying the version of bevy. I've included it as `0.5` here, because that's what's on crates.io right now, but this code won't actually work with that version, only with a particular branch of bevy in this PR (which will hopefully land soon):

https://github.com/bevyengine/bevy/pull/2305