### PR TITLE
Remove unneeded comparison for 2D intersections test

### DIFF
--- a/src/query/intersection_test/intersection_test_cuboid_cuboid.rs
+++ b/src/query/intersection_test/intersection_test_cuboid_cuboid.rs
@@ -22,8 +22,10 @@ pub fn intersection_test_cuboid_cuboid(
     }
 
     #[cfg(feature = "dim2")]
-    let sep3 = -Real::MAX; // This case does not exist in 2D.
+    return true; // This case does not exist in 2D.
     #[cfg(feature = "dim3")]
-    let sep3 = sat::cuboid_cuboid_find_local_separating_edge_twoway(cuboid1, cuboid2, &pos12).0;
-    sep3 <= 0.0
+    {
+        let sep3 = sat::cuboid_cuboid_find_local_separating_edge_twoway(cuboid1, cuboid2, &pos12).0;
+        sep3 <= 0.0
+    }
 }

--- a/src/query/intersection_test/intersection_test_cuboid_segment.rs
+++ b/src/query/intersection_test/intersection_test_cuboid_segment.rs
@@ -48,8 +48,10 @@ pub fn intersection_test_cuboid_segment(
     }
 
     #[cfg(feature = "dim2")]
-    let sep3 = -Real::MAX; // This case does not exist in 2D.
+    return true; // This case does not exist in 2D.
     #[cfg(feature = "dim3")]
-    let sep3 = sat::cuboid_segment_find_local_separating_edge_twoway(cube1, segment2, &pos12).0;
-    sep3 <= 0.0
+    {
+        let sep3 = sat::cuboid_segment_find_local_separating_edge_twoway(cube1, segment2, &pos12).0;
+        sep3 <= 0.0
+    }
 }

--- a/src/query/intersection_test/intersection_test_cuboid_triangle.rs
+++ b/src/query/intersection_test/intersection_test_cuboid_triangle.rs
@@ -40,8 +40,11 @@ pub fn intersection_test_cuboid_triangle(
     }
 
     #[cfg(feature = "dim2")]
-    let sep3 = -Real::MAX; // This case does not exist in 2D.
+    return true; // This case does not exist in 2D.
     #[cfg(feature = "dim3")]
-    let sep3 = sat::cuboid_triangle_find_local_separating_edge_twoway(cube1, triangle2, &pos12).0;
-    sep3 <= 0.0
+    {
+        let sep3 =
+            sat::cuboid_triangle_find_local_separating_edge_twoway(cube1, triangle2, &pos12).0;
+        sep3 <= 0.0
+    }
 }


### PR DESCRIPTION
At this point I think it's nitpicking but I still think it could be useful.