### PR TITLE
`Compound::decompose_trimesh`: Remove `self` from arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Unreleased
+- Remove `&self` argument from `Compound::decompose_trimesh`.
+
 ## v0.8.0 (2 Jan. 2022)
 ### Modified
 - Until now, the orientation of the polygon computed by 2D convex hull computation `parry2d::transformation::convex_hull` and

--- a/src/shape/compound.rs
+++ b/src/shape/compound.rs
@@ -69,7 +69,7 @@ impl Compound {
     /// polygons using the Hertel-Mehlhorn algorithm.
     ///
     /// Can fail and return `None` if any of the created shapes has close to zero or zero surface area.
-    pub fn decompose_trimesh(&self, trimesh: &TriMesh) -> Option<Self> {
+    pub fn decompose_trimesh(trimesh: &TriMesh) -> Option<Self> {
         let polygons = hertel_mehlhorn(trimesh.vertices(), trimesh.indices());
         let shapes: Option<Vec<_>> = polygons
             .into_iter()

--- a/src/transformation/ear_clipping.rs
+++ b/src/transformation/ear_clipping.rs
@@ -1,3 +1,6 @@
+//! Ear-clipping algorithm for creating a triangle mesh from a simple polygon.
+//! Based on https://github.com/ivanfratric/polypartition, contributed by embotech AG.
+
 use crate::{
     math::{Point, Real},
     utils::point_in_triangle::{corner_direction, is_point_in_triangle, Orientation},

--- a/src/transformation/hertel_mehlhorn.rs
+++ b/src/transformation/hertel_mehlhorn.rs
@@ -1,3 +1,6 @@
+//! Hertel-Mehlhorn algorithm for convex partitioning.
+//! Based on https://github.com/ivanfratric/polypartition, contributed by embotech AG.
+
 use crate::math::{Point, Real};
 use crate::utils::point_in_triangle::{corner_direction, Orientation};
 


### PR DESCRIPTION
Fixes #72 