### PR TITLE
Default to existing normal if can't normalize

### DIFF
--- a/src/shape/convex_polyhedron.rs
+++ b/src/shape/convex_polyhedron.rs
@@ -414,11 +414,11 @@ impl ConvexPolyhedron {
             .for_each(|pt| pt.coords.component_mul_assign(scale));
 
         for f in &mut self.faces {
-            f.normal = Unit::try_new(f.normal.component_mul(&scale), 0.0)?;
+            f.normal = Unit::try_new(f.normal.component_mul(&scale), 0.0).unwrap_or(f.normal);
         }
 
         for e in &mut self.edges {
-            e.dir = Unit::try_new(e.dir.component_mul(&scale), 0.0)?;
+            e.dir = Unit::try_new(e.dir.component_mul(&scale), 0.0).unwrap_or(e.dir);
         }
 
         Some(self)


### PR DESCRIPTION
Currently only doing it on `ConvexPolyhedron` colliders, but could essentially copy paste this to the rest of the scaling.