### PR TITLE
Improve linear shape-casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change Log
 
+## Unreleased
+
+### Modified
+- Add to `query::time_of_impact` a boolean argument `stop_at_penetration`. If set to `false`
+  the linear shape-cast won’t immediately stop if the shape is penetrating another shape at its
+  starting point **and** its trajectory is such that it’s existing that penetration configuration.
+
+### Added
+- Add 2D `Heightfield::to_polyline` to get the explicit vertices/indices of a 2D heightfield
+  seen as a polyline.
+- Add the support for linear shape-cast (`query::time_of_impact`) for heightfields.
+- Make the convex polyhedron scaling more forgiving regarding normals to avoid frequent unjustified panics.
+- Fix panic happening when building a convex polyhedron with empty inputs.
+
+
+### Fixed
+- Fix the application of non-uniform scaling to balls.
+
 ## v0.9.0 (30 Apr. 2022)
 
 ### Modified

--- a/crates/parry2d/examples/time_of_impact_query2d.rs
+++ b/crates/parry2d/examples/time_of_impact_query2d.rs
@@ -28,6 +28,7 @@ fn main() {
         &box_vel1,
         &cuboid,
         Real::MAX,
+        true,
     )
     .unwrap();
     let toi_will_touch = query::time_of_impact(
@@ -38,6 +39,7 @@ fn main() {
         &box_vel2,
         &cuboid,
         Real::MAX,
+        true,
     )
     .unwrap();
     let toi_wont_touch = query::time_of_impact(
@@ -48,6 +50,7 @@ fn main() {
         &box_vel1,
         &cuboid,
         Real::MAX,
+        true,
     )
     .unwrap();
 

--- a/crates/parry2d/tests/geometry/ball_ball_toi.rs
+++ b/crates/parry2d/tests/geometry/ball_ball_toi.rs
@@ -13,7 +13,7 @@ fn test_ball_ball_toi() {
     let v1 = Vector2::new(0.0, 10.0);
     let v2 = Vector2::zeros();
 
-    let cast = query::time_of_impact(&m1, &v1, &b, &m2, &v2, &b, Real::MAX).unwrap();
+    let cast = query::time_of_impact(&m1, &v1, &b, &m2, &v2, &b, Real::MAX, true).unwrap();
 
     assert_eq!(cast.unwrap().toi, 0.9);
 }

--- a/crates/parry2d/tests/geometry/time_of_impact2.rs
+++ b/crates/parry2d/tests/geometry/time_of_impact2.rs
@@ -27,6 +27,7 @@ fn ball_cuboid_toi() {
         &cuboid_vel1,
         &cuboid,
         Real::MAX,
+        true,
     )
     .unwrap();
     let toi_will_touch = query::time_of_impact(
@@ -37,6 +38,7 @@ fn ball_cuboid_toi() {
         &cuboid_vel2,
         &cuboid,
         Real::MAX,
+        true,
     )
     .unwrap();
     let toi_wont_touch = query::time_of_impact(
@@ -47,6 +49,7 @@ fn ball_cuboid_toi() {
         &cuboid_vel1,
         &cuboid,
         Real::MAX,
+        true,
     )
     .unwrap();
 
@@ -69,8 +72,17 @@ fn cuboid_cuboid_toi_issue_214() {
     let vel1 = Vector2::new(1.0, 0.0);
     let vel2 = Vector2::new(0.0, 0.0);
 
-    let toi =
-        query::time_of_impact(&pos1, &vel1, &shape1, &pos2, &vel2, &shape2, Real::MAX).unwrap();
+    let toi = query::time_of_impact(
+        &pos1,
+        &vel1,
+        &shape1,
+        &pos2,
+        &vel2,
+        &shape2,
+        Real::MAX,
+        true,
+    )
+    .unwrap();
     assert!(toi.is_some());
 }
 
@@ -100,6 +112,7 @@ fn time_of_impact_should_return_toi_for_ball_and_rotated_polyline() {
         &polyline_velocity,
         &polyline,
         1.0,
+        true,
     )
     .unwrap();
 
@@ -132,6 +145,7 @@ fn time_of_impact_should_return_toi_for_ball_and_rotated_segment() {
         &segment_velocity,
         &segment,
         1.0,
+        true,
     )
     .unwrap();
 
@@ -164,6 +178,7 @@ fn time_of_impact_should_return_toi_for_rotated_segment_and_ball() {
         &ball_velocity,
         &ball,
         1.0,
+        true,
     )
     .unwrap();
 

--- a/crates/parry3d/examples/time_of_impact_query3d.rs
+++ b/crates/parry3d/examples/time_of_impact_query3d.rs
@@ -28,6 +28,7 @@ fn main() {
         &cuboid_vel1,
         &cuboid,
         Real::MAX,
+        true,
     )
     .unwrap();
     let toi_will_touch = query::time_of_impact(
@@ -38,6 +39,7 @@ fn main() {
         &cuboid_vel2,
         &cuboid,
         Real::MAX,
+        true,
     )
     .unwrap();
     let toi_wont_touch = query::time_of_impact(
@@ -48,6 +50,7 @@ fn main() {
         &cuboid_vel1,
         &cuboid,
         Real::MAX,
+        true,
     )
     .unwrap();
 

--- a/crates/parry3d/tests/geometry/ball_ball_toi.rs
+++ b/crates/parry3d/tests/geometry/ball_ball_toi.rs
@@ -13,7 +13,7 @@ fn test_ball_ball_toi() {
     let vel1 = Vector3::new(0.0, 10.0, 0.0);
     let vel2 = Vector3::zeros();
 
-    let cast = query::time_of_impact(&m1, &vel1, &b, &m2, &vel2, &b, Real::MAX).unwrap();
+    let cast = query::time_of_impact(&m1, &vel1, &b, &m2, &vel2, &b, Real::MAX, true).unwrap();
 
     assert_eq!(cast.unwrap().toi, 0.9);
 }

--- a/crates/parry3d/tests/geometry/ball_triangle_toi.rs
+++ b/crates/parry3d/tests/geometry/ball_triangle_toi.rs
@@ -18,7 +18,7 @@ fn ball_triangle_toi_infinite_loop_issue() {
     let vel1 = Vector3::new(0.0, 0.000000000000000000000000000000000000000006925, 0.0);
     let vel2 = Vector3::zeros();
 
-    let cast = query::time_of_impact(&m1, &vel1, &b, &m2, &vel2, &t, std::f32::MAX).unwrap();
+    let cast = query::time_of_impact(&m1, &vel1, &b, &m2, &vel2, &t, std::f32::MAX, true).unwrap();
 
     println!("TOI: {:?}", cast);
     assert!(cast.is_none()); // The provided velocity is too small.

--- a/crates/parry3d/tests/geometry/still_objects_toi.rs
+++ b/crates/parry3d/tests/geometry/still_objects_toi.rs
@@ -25,9 +25,18 @@ fn collide(v_y: f32) -> Option<f32> {
     let vel2 = Vector3::zeros();
     let cuboid = Cuboid::new(Vector3::new(0.5, 0.5, 0.5));
 
-    time_of_impact(&pos1, &vel1, &cuboid, &pos2, &vel2, &cuboid, std::f32::MAX)
-        .unwrap()
-        .map(|toi| toi.toi)
+    time_of_impact(
+        &pos1,
+        &vel1,
+        &cuboid,
+        &pos2,
+        &vel2,
+        &cuboid,
+        std::f32::MAX,
+        true,
+    )
+    .unwrap()
+    .map(|toi| toi.toi)
 }
 
 #[test]

--- a/crates/parry3d/tests/geometry/time_of_impact3.rs
+++ b/crates/parry3d/tests/geometry/time_of_impact3.rs
@@ -27,6 +27,7 @@ fn ball_cuboid_toi() {
         &cuboid_vel1,
         &cuboid,
         Real::MAX,
+        true,
     )
     .unwrap()
     .map(|toi| toi.toi);
@@ -38,6 +39,7 @@ fn ball_cuboid_toi() {
         &cuboid_vel2,
         &cuboid,
         Real::MAX,
+        true,
     )
     .unwrap()
     .map(|toi| toi.toi);
@@ -49,6 +51,7 @@ fn ball_cuboid_toi() {
         &cuboid_vel1,
         &cuboid,
         Real::MAX,
+        true,
     )
     .unwrap()
     .map(|toi| toi.toi);

--- a/crates/parry3d/tests/geometry/trimesh_trimesh_toi.rs
+++ b/crates/parry3d/tests/geometry/trimesh_trimesh_toi.rs
@@ -41,6 +41,7 @@ fn do_toi_test() -> Option<Real> {
         &vel_two,
         &shape_two,
         Real::MAX,
+        true,
     )
     .unwrap()
     .map(|toi| toi.toi)

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -8,7 +8,7 @@ use crate::query::{
     contact_manifolds::ContactManifoldsWorkspace, query_dispatcher::PersistentQueryDispatcher,
     ContactManifold,
 };
-use crate::shape::{HalfSpace, HeightField, Segment, Shape, ShapeType};
+use crate::shape::{HalfSpace, Segment, Shape, ShapeType};
 
 /// A dispatcher that exposes built-in queries
 #[derive(Debug, Clone)]
@@ -306,38 +306,39 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 max_toi,
                 stop_at_penetration,
             ))
-        } else if let Some(heightfield1) = shape1.as_shape::<HeightField>() {
-            query::details::time_of_impact_heightfield_shape(
-                self,
-                pos12,
-                local_vel12,
-                heightfield1,
-                shape2,
-                max_toi,
-                stop_at_penetration,
-            )
-        } else if let Some(heightfield2) = shape1.as_shape::<HeightField>() {
-            query::details::time_of_impact_shape_heightfield(
-                self,
-                pos12,
-                local_vel12,
-                shape1,
-                heightfield2,
-                max_toi,
-                stop_at_penetration,
-            )
-        } else if let (Some(s1), Some(s2)) = (shape1.as_support_map(), shape2.as_support_map()) {
-            Ok(query::details::time_of_impact_support_map_support_map(
-                pos12,
-                local_vel12,
-                s1,
-                s2,
-                max_toi,
-                stop_at_penetration,
-            ))
         } else {
             #[cfg(feature = "std")]
-            if let Some(c1) = shape1.as_composite_shape() {
+            if let Some(heightfield1) = shape1.as_heightfield() {
+                return query::details::time_of_impact_heightfield_shape(
+                    self,
+                    pos12,
+                    local_vel12,
+                    heightfield1,
+                    shape2,
+                    max_toi,
+                    stop_at_penetration,
+                );
+            } else if let Some(heightfield2) = shape1.as_heightfield() {
+                return query::details::time_of_impact_shape_heightfield(
+                    self,
+                    pos12,
+                    local_vel12,
+                    shape1,
+                    heightfield2,
+                    max_toi,
+                    stop_at_penetration,
+                );
+            } else if let (Some(s1), Some(s2)) = (shape1.as_support_map(), shape2.as_support_map())
+            {
+                return Ok(query::details::time_of_impact_support_map_support_map(
+                    pos12,
+                    local_vel12,
+                    s1,
+                    s2,
+                    max_toi,
+                    stop_at_penetration,
+                ));
+            } else if let Some(c1) = shape1.as_composite_shape() {
                 return Ok(query::details::time_of_impact_composite_shape_shape(
                     self,
                     pos12,

--- a/src/query/query_dispatcher.rs
+++ b/src/query/query_dispatcher.rs
@@ -103,6 +103,7 @@ pub trait QueryDispatcher: Send + Sync {
         g1: &dyn Shape,
         g2: &dyn Shape,
         max_toi: Real,
+        stop_at_penetration: bool,
     ) -> Result<Option<TOI>, Unsupported>;
 
     /// Construct a `QueryDispatcher` that falls back on `other` for cases not handled by `self`
@@ -187,6 +188,7 @@ where
         g1: &dyn Shape,
         g2: &dyn Shape,
         max_toi: Real,
+        stop_at_penetration: bool,
     ) -> Option<TOI>);
 
     chain_method!(nonlinear_time_of_impact(

--- a/src/query/time_of_impact/mod.rs
+++ b/src/query/time_of_impact/mod.rs
@@ -10,6 +10,9 @@ pub use self::time_of_impact_composite_shape_shape::{
 pub use self::time_of_impact_halfspace_support_map::{
     time_of_impact_halfspace_support_map, time_of_impact_support_map_halfspace,
 };
+pub use self::time_of_impact_heightfield_shape::{
+    time_of_impact_heightfield_shape, time_of_impact_shape_heightfield,
+};
 pub use self::time_of_impact_support_map_support_map::time_of_impact_support_map_support_map;
 
 mod time_of_impact;
@@ -17,4 +20,5 @@ mod time_of_impact_ball_ball;
 #[cfg(feature = "std")]
 mod time_of_impact_composite_shape_shape;
 mod time_of_impact_halfspace_support_map;
+mod time_of_impact_heightfield_shape;
 mod time_of_impact_support_map_support_map;

--- a/src/query/time_of_impact/mod.rs
+++ b/src/query/time_of_impact/mod.rs
@@ -2,23 +2,27 @@
 
 pub use self::time_of_impact::{time_of_impact, TOIStatus, TOI};
 pub use self::time_of_impact_ball_ball::time_of_impact_ball_ball;
-#[cfg(feature = "std")]
-pub use self::time_of_impact_composite_shape_shape::{
-    time_of_impact_composite_shape_shape, time_of_impact_shape_composite_shape,
-    TOICompositeShapeShapeBestFirstVisitor,
-};
 pub use self::time_of_impact_halfspace_support_map::{
     time_of_impact_halfspace_support_map, time_of_impact_support_map_halfspace,
 };
-pub use self::time_of_impact_heightfield_shape::{
-    time_of_impact_heightfield_shape, time_of_impact_shape_heightfield,
+#[cfg(feature = "std")]
+pub use self::{
+    time_of_impact_composite_shape_shape::{
+        time_of_impact_composite_shape_shape, time_of_impact_shape_composite_shape,
+        TOICompositeShapeShapeBestFirstVisitor,
+    },
+    time_of_impact_heightfield_shape::{
+        time_of_impact_heightfield_shape, time_of_impact_shape_heightfield,
+    },
+    time_of_impact_support_map_support_map::time_of_impact_support_map_support_map,
 };
-pub use self::time_of_impact_support_map_support_map::time_of_impact_support_map_support_map;
 
 mod time_of_impact;
 mod time_of_impact_ball_ball;
 #[cfg(feature = "std")]
 mod time_of_impact_composite_shape_shape;
 mod time_of_impact_halfspace_support_map;
+#[cfg(feature = "std")]
 mod time_of_impact_heightfield_shape;
+#[cfg(feature = "std")]
 mod time_of_impact_support_map_support_map;

--- a/src/query/time_of_impact/time_of_impact.rs
+++ b/src/query/time_of_impact/time_of_impact.rs
@@ -90,8 +90,9 @@ pub fn time_of_impact(
     vel2: &Vector<Real>,
     g2: &dyn Shape,
     max_toi: Real,
+    stop_at_penetration: bool,
 ) -> Result<Option<TOI>, Unsupported> {
     let pos12 = pos1.inv_mul(pos2);
     let vel12 = pos1.inverse_transform_vector(&(vel2 - vel1));
-    DefaultQueryDispatcher.time_of_impact(&pos12, &vel12, g1, g2, max_toi)
+    DefaultQueryDispatcher.time_of_impact(&pos12, &vel12, g1, g2, max_toi, stop_at_penetration)
 }

--- a/src/query/time_of_impact/time_of_impact_halfspace_support_map.rs
+++ b/src/query/time_of_impact/time_of_impact_halfspace_support_map.rs
@@ -9,12 +9,17 @@ pub fn time_of_impact_halfspace_support_map<G: ?Sized>(
     halfspace: &HalfSpace,
     other: &G,
     max_toi: Real,
+    stop_at_penetration: bool,
 ) -> Option<TOI>
 where
     G: SupportMap,
 {
     // FIXME: add method to get only the local support point.
     // This would avoid the `inverse_transform_point` later.
+    if !stop_at_penetration && vel12.dot(&halfspace.normal) > 0.0 {
+        return None;
+    }
+
     let support_point = other.support_point(pos12, &-halfspace.normal);
     let closest_point = support_point;
     let ray = Ray::new(closest_point, *vel12);
@@ -57,6 +62,7 @@ pub fn time_of_impact_support_map_halfspace<G: ?Sized>(
     other: &G,
     halfspace: &HalfSpace,
     max_toi: Real,
+    stop_at_penetration: bool,
 ) -> Option<TOI>
 where
     G: SupportMap,
@@ -67,6 +73,7 @@ where
         halfspace,
         other,
         max_toi,
+        stop_at_penetration,
     )
     .map(|toi| toi.swapped())
 }

--- a/src/query/time_of_impact/time_of_impact_heightfield_shape.rs
+++ b/src/query/time_of_impact/time_of_impact_heightfield_shape.rs
@@ -1,0 +1,310 @@
+use crate::math::{Isometry, Real, Vector};
+use crate::query::{QueryDispatcher, Ray, Unsupported, TOI};
+use crate::shape::{GenericHeightField, HeightFieldCellStatus, HeightFieldStorage, Shape};
+#[cfg(feature = "dim3")]
+use crate::{bounding_volume::AABB, query::RayCast};
+
+/// Time Of Impact between a moving shape and a heightfield.
+#[cfg(feature = "dim2")]
+pub fn time_of_impact_heightfield_shape<Heights, Status, D: ?Sized>(
+    dispatcher: &D,
+    pos12: &Isometry<Real>,
+    vel12: &Vector<Real>,
+    heightfield1: &GenericHeightField<Heights, Status>,
+    g2: &dyn Shape,
+    max_toi: Real,
+    stop_at_penetration: bool,
+) -> Result<Option<TOI>, Unsupported>
+where
+    Heights: HeightFieldStorage<Item = Real>,
+    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
+    D: QueryDispatcher,
+{
+    let aabb2_1 = g2.compute_aabb(pos12);
+    let ray = Ray::new(aabb2_1.center(), *vel12);
+
+    let mut curr_range = heightfield1.unclamped_elements_range_in_local_aabb(&aabb2_1);
+    // Enlarge the range by 1 to account for movement within a cell.
+    let right = ray.dir.x > 0.0;
+
+    if right {
+        curr_range.end += 1;
+    } else {
+        curr_range.start -= 1;
+    }
+
+    let mut best_hit = None::<TOI>;
+
+    /*
+     * Test the segment under the ray.
+     */
+    let clamped_curr_range = curr_range.start.clamp(0, heightfield1.num_cells() as isize) as usize
+        ..curr_range.end.clamp(0, heightfield1.num_cells() as isize) as usize;
+    for curr in clamped_curr_range {
+        if let Some(seg) = heightfield1.segment_at(curr) {
+            // TODO: pre-check using a ray-cast on the AABBs first?
+            if let Some(hit) =
+                dispatcher.time_of_impact(pos12, vel12, &seg, g2, max_toi, stop_at_penetration)?
+            {
+                if hit.toi < best_hit.map(|toi| toi.toi).unwrap_or(Real::MAX) {
+                    best_hit = Some(hit);
+                }
+            }
+        }
+    }
+
+    /*
+     * Test other segments in the path of the ray.
+     */
+    if ray.dir.x == 0.0 {
+        return Ok(best_hit);
+    }
+
+    let cell_width = heightfield1.cell_width();
+    let start_x = heightfield1.start_x();
+
+    let mut curr_elt = if right {
+        (curr_range.end - 1).max(0)
+    } else {
+        curr_range.start.min(heightfield1.num_cells() as isize - 1)
+    };
+
+    while (right && curr_elt < heightfield1.num_cells() as isize - 1) || (!right && curr_elt > 0) {
+        let curr_param;
+
+        if right {
+            curr_elt += 1;
+            curr_param = (cell_width * na::convert::<f64, Real>(curr_elt as f64) + start_x
+                - ray.origin.x)
+                / ray.dir.x;
+        } else {
+            curr_param =
+                (ray.origin.x - cell_width * na::convert::<f64, Real>(curr_elt as f64) - start_x)
+                    / ray.dir.x;
+            curr_elt -= 1;
+        }
+
+        if curr_param >= max_toi {
+            break;
+        }
+
+        if let Some(seg) = heightfield1.segment_at(curr_elt as usize) {
+            // TODO: pre-check using a ray-cast on the AABBs first?
+            if let Some(hit) =
+                dispatcher.time_of_impact(pos12, vel12, &seg, g2, max_toi, stop_at_penetration)?
+            {
+                if hit.toi < best_hit.map(|toi| toi.toi).unwrap_or(Real::MAX) {
+                    best_hit = Some(hit);
+                }
+            }
+        }
+    }
+
+    Ok(best_hit)
+}
+
+/// Time Of Impact between a moving shape and a heightfield.
+#[cfg(feature = "dim3")]
+pub fn time_of_impact_heightfield_shape<Heights, Status, D: ?Sized>(
+    dispatcher: &D,
+    pos12: &Isometry<Real>,
+    vel12: &Vector<Real>,
+    heightfield1: &GenericHeightField<Heights, Status>,
+    g2: &dyn Shape,
+    max_toi: Real,
+    stop_at_penetration: bool,
+) -> Result<Option<TOI>, Unsupported>
+where
+    Heights: HeightFieldStorage<Item = Real>,
+    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
+    D: QueryDispatcher,
+{
+    let aabb1 = heightfield1.local_aabb();
+    let mut aabb2_1 = g2.compute_aabb(pos12);
+    let ray = Ray::new(aabb2_1.center(), *vel12);
+
+    // Find the first hit between the aabbs.
+    let hext2_1 = aabb2_1.half_extents();
+    let msum = AABB::new(aabb1.mins - hext2_1, aabb1.maxs + hext2_1);
+    if let Some(toi) = msum.cast_local_ray(&ray, max_toi, true) {
+        // Advance the aabb2 to the hit point.
+        aabb2_1.mins += ray.dir * toi;
+        aabb2_1.maxs += ray.dir * toi;
+    } else {
+        return Ok(None);
+    }
+
+    let (mut curr_range_i, mut curr_range_j) =
+        heightfield1.unclamped_elements_range_in_local_aabb(&aabb2_1);
+    let (ncells_i, ncells_j) = heightfield1.num_cells_ij();
+    let mut best_hit = None::<TOI>;
+
+    /*
+     * Enlarge the ranges by 1 to account for any movement within one cell.
+     */
+    if ray.dir.z > 0.0 {
+        curr_range_i.end += 1;
+    } else if ray.dir.z < 0.0 {
+        curr_range_i.start -= 1;
+    }
+
+    if ray.dir.x > 0.0 {
+        curr_range_j.end += 1;
+    } else if ray.dir.x < 0.0 {
+        curr_range_j.start -= 1;
+    }
+
+    /*
+     * Test the segment under the ray.
+     */
+    let clamped_curr_range_i = curr_range_i.start.clamp(0, ncells_i as isize)
+        ..curr_range_i.end.clamp(0, ncells_i as isize);
+    let clamped_curr_range_j = curr_range_j.start.clamp(0, ncells_j as isize)
+        ..curr_range_j.end.clamp(0, ncells_j as isize);
+
+    let mut hit_triangles = |i, j| {
+        if i >= 0 && j >= 0 {
+            let (tri_a, tri_b) = heightfield1.triangles_at(i as usize, j as usize);
+            for tri in [tri_a, tri_b] {
+                if let Some(tri) = tri {
+                    // TODO: pre-check using a ray-cast on the AABBs first?
+                    if let Some(hit) = dispatcher.time_of_impact(
+                        pos12,
+                        vel12,
+                        &tri,
+                        g2,
+                        max_toi,
+                        stop_at_penetration,
+                    )? {
+                        if hit.toi < best_hit.map(|toi| toi.toi).unwrap_or(Real::MAX) {
+                            best_hit = Some(hit);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    };
+
+    for i in clamped_curr_range_i {
+        for j in clamped_curr_range_j.clone() {
+            hit_triangles(i, j)?;
+        }
+    }
+
+    if ray.dir.y == 0.0 {
+        return Ok(best_hit);
+    }
+
+    let mut cell = heightfield1.unclamped_cell_at_point(&aabb2_1.center());
+
+    loop {
+        let prev_cell = cell;
+
+        /*
+         * Find the next cell to cast the ray on.
+         */
+        let toi_x = if ray.dir.x > 0.0 {
+            let x = heightfield1.signed_x_at(cell.1 + 1);
+            (x - ray.origin.x) / ray.dir.x
+        } else if ray.dir.x < 0.0 {
+            let x = heightfield1.signed_x_at(cell.1 + 0);
+            (x - ray.origin.x) / ray.dir.x
+        } else {
+            Real::MAX
+        };
+
+        let toi_z = if ray.dir.z > 0.0 {
+            let z = heightfield1.signed_z_at(cell.0 + 1);
+            (z - ray.origin.z) / ray.dir.z
+        } else if ray.dir.z < 0.0 {
+            let z = heightfield1.signed_z_at(cell.0 + 0);
+            (z - ray.origin.z) / ray.dir.z
+        } else {
+            Real::MAX
+        };
+
+        if toi_x > max_toi && toi_z > max_toi {
+            break;
+        }
+
+        if toi_x >= 0.0 && toi_x <= toi_z {
+            cell.1 += ray.dir.x.signum() as isize;
+        }
+
+        if toi_z >= 0.0 && toi_z <= toi_x {
+            cell.0 += ray.dir.z.signum() as isize;
+        }
+
+        if cell == prev_cell {
+            break;
+        }
+
+        let cell_diff = (cell.0 - prev_cell.0, cell.1 - prev_cell.1);
+        curr_range_i.start += cell_diff.0;
+        curr_range_i.end += cell_diff.0;
+        curr_range_j.start += cell_diff.1;
+        curr_range_j.end += cell_diff.1;
+
+        let new_line_i = if cell_diff.0 > 0 {
+            curr_range_i.end
+        } else {
+            curr_range_i.start
+        };
+
+        let new_line_j = if cell_diff.1 > 0 {
+            curr_range_j.end
+        } else {
+            curr_range_j.start
+        };
+
+        let ignore_line_i = new_line_i < 0 || new_line_i >= ncells_i as isize;
+        let ignore_line_j = new_line_j < 0 || new_line_j >= ncells_j as isize;
+
+        if ignore_line_i && ignore_line_j {
+            break;
+        }
+
+        if !ignore_line_i && cell_diff.0 != 0 {
+            for j in curr_range_j.clone() {
+                hit_triangles(new_line_i, j)?;
+            }
+        }
+
+        if !ignore_line_j && cell_diff.1 != 0 {
+            for i in curr_range_i.clone() {
+                hit_triangles(i, new_line_j)?;
+            }
+        }
+    }
+
+    Ok(best_hit)
+}
+
+/// Time Of Impact between a moving shape and a heightfield.
+pub fn time_of_impact_shape_heightfield<Heights, Status, D: ?Sized>(
+    dispatcher: &D,
+    pos12: &Isometry<Real>,
+    vel12: &Vector<Real>,
+    g1: &dyn Shape,
+    heightfield2: &GenericHeightField<Heights, Status>,
+    max_toi: Real,
+    stop_at_penetration: bool,
+) -> Result<Option<TOI>, Unsupported>
+where
+    Heights: HeightFieldStorage<Item = Real>,
+    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
+    D: QueryDispatcher,
+{
+    Ok(time_of_impact_heightfield_shape(
+        dispatcher,
+        &pos12.inverse(),
+        &-pos12.inverse_transform_vector(&vel12),
+        heightfield2,
+        g1,
+        max_toi,
+        stop_at_penetration,
+    )?
+    .map(|toi| toi.swapped()))
+}

--- a/src/query/time_of_impact/time_of_impact_support_map_support_map.rs
+++ b/src/query/time_of_impact/time_of_impact_support_map_support_map.rs
@@ -1,6 +1,7 @@
 use na::Unit;
 
 use crate::math::{Isometry, Real, Vector};
+use crate::query::details;
 use crate::query::gjk::{self, VoronoiSimplex};
 use crate::query::{TOIStatus, TOI};
 use crate::shape::SupportMap;
@@ -13,6 +14,7 @@ pub fn time_of_impact_support_map_support_map<G1: ?Sized, G2: ?Sized>(
     g1: &G1,
     g2: &G2,
     max_toi: Real,
+    stop_at_penetration: bool,
 ) -> Option<TOI>
 where
     G1: SupportMap,
@@ -22,6 +24,22 @@ where
         |(toi, normal1, witness1, witness2)| {
             if toi > max_toi {
                 None
+            } else if !stop_at_penetration && toi < 1.0e-5 {
+                let contact = details::contact_support_map_support_map(pos12, g1, g2, Real::MAX)?;
+                let normal_vel = contact.normal1.dot(&vel12);
+
+                if normal_vel >= 0.0 {
+                    None
+                } else {
+                    Some(TOI {
+                        toi,
+                        normal1: contact.normal1,
+                        normal2: contact.normal2,
+                        witness1: contact.point1,
+                        witness2: contact.point2,
+                        status: TOIStatus::Penetrating,
+                    })
+                }
             } else {
                 Some(TOI {
                     toi,

--- a/src/transformation/to_polyline/heightfield_to_polyline.rs
+++ b/src/transformation/to_polyline/heightfield_to_polyline.rs
@@ -1,0 +1,25 @@
+use crate::math::Real;
+use crate::shape::HeightField;
+use na::Point2;
+
+impl HeightField {
+    /// Rasterize this heightfield as a (potentially discontinuous) polyline.
+    pub fn to_polyline(&self) -> (Vec<Point2<Real>>, Vec<[u32; 2]>) {
+        let mut vertices = vec![];
+        let mut indices = vec![];
+
+        for seg in self.segments() {
+            let base_id = vertices.len() as u32;
+            if vertices.last().map(|pt| seg.a != *pt).unwrap_or(true) {
+                indices.push([base_id, base_id + 1]);
+                vertices.push(seg.a);
+            } else {
+                indices.push([base_id - 1, base_id]);
+            }
+
+            vertices.push(seg.b);
+        }
+
+        (vertices, indices)
+    }
+}

--- a/src/transformation/to_polyline/mod.rs
+++ b/src/transformation/to_polyline/mod.rs
@@ -1,5 +1,6 @@
 mod ball_to_polyline;
 mod capsule_to_polyline;
 mod cuboid_to_polyline;
+mod heightfield_to_polyline;
 mod round_convex_polygon_to_polyline;
 mod round_cuboid_to_polyline;


### PR DESCRIPTION
### Modified
- Add to `query::time_of_impact` a boolean argument `stop_at_penetration`. If set to `false`
  the linear shape-cast won’t immediately stop if the shape is penetrating another shape at its
  starting point **and** its trajectory is such that it’s existing that penetration configuration.
  Needed by: https://github.com/dimforge/rapier/issues/266

### Added
- Add 2D `Heightfield::to_polyline` to get the explicit vertices/indices of a 2D heightfield
  seen as a polyline.
- Add the support for linear shape-cast (`query::time_of_impact`) for heightfields.
