### PR TITLE
Address the internal edges problem in 3D

### DIFF
--- a/src/query/contact_manifolds/contact_manifold.rs
+++ b/src/query/contact_manifolds/contact_manifold.rs
@@ -1,4 +1,5 @@
 use crate::math::{Isometry, Point, Real, Vector};
+use crate::shape::PackedFeatureId;
 
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -16,9 +17,9 @@ pub struct TrackedContact<Data> {
     pub dist: Real,
 
     /// The feature ID of the first shape involved in the contact.
-    pub fid1: u32,
+    pub fid1: PackedFeatureId,
     /// The feature ID of the second shape involved in the contact.
-    pub fid2: u32,
+    pub fid2: PackedFeatureId,
     /// User-data associated to this contact.
     pub data: Data,
 }
@@ -28,8 +29,8 @@ impl<Data: Default + Copy> TrackedContact<Data> {
     pub fn new(
         local_p1: Point<Real>,
         local_p2: Point<Real>,
-        fid1: u32,
-        fid2: u32,
+        fid1: PackedFeatureId,
+        fid2: PackedFeatureId,
         dist: Real,
     ) -> Self {
         Self {
@@ -46,8 +47,8 @@ impl<Data: Default + Copy> TrackedContact<Data> {
     pub fn flipped(
         local_p1: Point<Real>,
         local_p2: Point<Real>,
-        fid1: u32,
-        fid2: u32,
+        fid1: PackedFeatureId,
+        fid2: PackedFeatureId,
         dist: Real,
         flipped: bool,
     ) -> Self {

--- a/src/query/contact_manifolds/contact_manifolds_ball_ball.rs
+++ b/src/query/contact_manifolds/contact_manifolds_ball_ball.rs
@@ -1,6 +1,6 @@
 use crate::math::{Isometry, Real, Vector};
 use crate::query::{ContactManifold, TrackedContact};
-use crate::shape::{Ball, Shape};
+use crate::shape::{Ball, PackedFeatureId, Shape};
 
 /// Computes the contact manifold between two balls given as `Shape` trait-objects.
 pub fn contact_manifold_ball_ball_shapes<ManifoldData, ContactData: Default + Copy>(
@@ -40,7 +40,8 @@ pub fn contact_manifold_ball_ball<ManifoldData, ContactData: Default + Copy>(
         let local_n2 = pos12.inverse_transform_vector(&-local_n1);
         let local_p1 = local_n1 * radius_a;
         let local_p2 = local_n2 * radius_b;
-        let contact = TrackedContact::new(local_p1.into(), local_p2.into(), 0, 0, dist);
+        let fid = PackedFeatureId::face(0);
+        let contact = TrackedContact::new(local_p1.into(), local_p2.into(), fid, fid, dist);
 
         if manifold.points.len() != 0 {
             manifold.points[0].copy_geometry_from(contact);

--- a/src/query/contact_manifolds/contact_manifolds_capsule_capsule.rs
+++ b/src/query/contact_manifolds/contact_manifolds_capsule_capsule.rs
@@ -2,7 +2,7 @@ use crate::math::{Isometry, Real, Vector};
 use crate::query::{ContactManifold, TrackedContact};
 #[cfg(feature = "dim2")]
 use crate::shape::SegmentPointLocation;
-use crate::shape::{Capsule, Shape};
+use crate::shape::{Capsule, PackedFeatureId, Shape};
 use approx::AbsDiffEq;
 use na::Unit;
 
@@ -156,11 +156,12 @@ pub fn contact_manifold_capsule_capsule<'a, ManifoldData, ContactData>(
 
     if dist <= prediction {
         let local_n2 = pos12.inverse_transform_unit_vector(&-local_n1);
+        let fid = PackedFeatureId::face(0);
         let contact = TrackedContact::new(
             local_p1 + *local_n1 * capsule1.radius,
             pos12.inverse_transform_point(&local_p2_1) + *local_n2 * capsule2.radius,
-            0,
-            0,
+            fid,
+            fid,
             dist,
         );
 

--- a/src/query/contact_manifolds/contact_manifolds_capsule_capsule.rs
+++ b/src/query/contact_manifolds/contact_manifolds_capsule_capsule.rs
@@ -70,7 +70,13 @@ pub fn contact_manifold_capsule_capsule<'a, ManifoldData, ContactData>(
     if dist <= prediction + capsule1.radius + capsule2.radius {
         let local_n2 = pos12.inverse_transform_unit_vector(&-local_n1);
         let local_p2 = pos12.inverse_transform_point(&local_p2_1);
-        let contact = TrackedContact::new(local_p1, local_p2, fid1, fid2, dist);
+        let contact = TrackedContact::new(
+            local_p1,
+            local_p2,
+            PackedFeatureId::face(fid1),
+            PackedFeatureId::face(fid2),
+            dist,
+        );
         manifold.points.push(contact);
 
         manifold.local_n1 = *local_n1;
@@ -97,8 +103,8 @@ pub fn contact_manifold_capsule_capsule<'a, ManifoldData, ContactData>(
                         TrackedContact::new(
                             clip_a.0,
                             pos12.inverse_transform_point(&clip_a.1),
-                            clip_a.2 as u32,
-                            clip_a.3 as u32,
+                            PackedFeatureId::face(clip_a.2 as u32),
+                            PackedFeatureId::face(clip_a.3 as u32),
                             (clip_a.1 - clip_a.0).dot(&local_n1),
                         )
                     } else {
@@ -106,8 +112,8 @@ pub fn contact_manifold_capsule_capsule<'a, ManifoldData, ContactData>(
                         TrackedContact::new(
                             clip_b.0,
                             pos12.inverse_transform_point(&clip_b.1),
-                            clip_b.2 as u32,
-                            clip_b.3 as u32,
+                            PackedFeatureId::face(clip_b.2 as u32),
+                            PackedFeatureId::face(clip_b.3 as u32),
                             (clip_b.1 - clip_b.0).dot(&local_n1),
                         )
                     };

--- a/src/query/contact_manifolds/contact_manifolds_convex_ball.rs
+++ b/src/query/contact_manifolds/contact_manifolds_convex_ball.rs
@@ -1,6 +1,6 @@
 use crate::math::{Isometry, Point, Real};
 use crate::query::{ContactManifold, TrackedContact};
-use crate::shape::{Ball, Shape};
+use crate::shape::{Ball, PackedFeatureId, Shape};
 use na::Unit;
 
 /// Computes the contact manifold between a convex shape and a ball, both represented as a `Shape` trait-object.
@@ -33,7 +33,7 @@ pub fn contact_manifold_convex_ball<'a, ManifoldData, ContactData, S1>(
     ContactData: Default + Copy,
 {
     let local_p2_1 = Point::from(pos12.translation.vector);
-    let proj = shape1.project_local_point(&local_p2_1, false);
+    let (proj, fid1) = shape1.project_local_point_and_get_feature(&local_p2_1);
     let dpos = local_p2_1 - proj.point;
 
     if let Some((mut local_n1, mut dist)) = Unit::try_new_and_get(dpos, 0.0) {
@@ -45,8 +45,14 @@ pub fn contact_manifold_convex_ball<'a, ManifoldData, ContactData, S1>(
         if dist <= ball2.radius + prediction {
             let local_n2 = pos12.inverse_transform_vector(&-*local_n1);
             let local_p2 = (local_n2 * ball2.radius).into();
-            let contact_point =
-                TrackedContact::flipped(proj.point, local_p2, 0, 0, dist - ball2.radius, flipped);
+            let contact_point = TrackedContact::flipped(
+                proj.point,
+                local_p2,
+                fid1.into(),
+                PackedFeatureId::face(0),
+                dist - ball2.radius,
+                flipped,
+            );
 
             if manifold.points.len() != 1 {
                 manifold.clear();

--- a/src/query/contact_manifolds/contact_manifolds_halfspace_pfm.rs
+++ b/src/query/contact_manifolds/contact_manifolds_halfspace_pfm.rs
@@ -1,6 +1,6 @@
 use crate::math::{Isometry, Real};
 use crate::query::{ContactManifold, TrackedContact};
-use crate::shape::{HalfSpace, PolygonalFeature, PolygonalFeatureMap, Shape};
+use crate::shape::{HalfSpace, PackedFeatureId, PolygonalFeature, PolygonalFeatureMap, Shape};
 
 /// Computes the contact manifold between a convex shape and a ball, both represented as a `Shape` trait-object.
 pub fn contact_manifold_halfspace_pfm_shapes<ManifoldData, ContactData>(
@@ -70,7 +70,7 @@ pub fn contact_manifold_halfspace_pfm<'a, ManifoldData, ContactData, S2>(
             manifold.points.push(TrackedContact::flipped(
                 vtx2_1 - *halfspace1.normal * dist_to_plane,
                 vtx2 - *normal1_2 * border_radius2,
-                0,
+                PackedFeatureId::face(0),
                 feature2.vids[i],
                 dist_to_plane - border_radius2,
                 flipped,

--- a/src/query/contact_manifolds/contact_manifolds_heightfield_composite_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_heightfield_composite_shape.rs
@@ -3,7 +3,7 @@ use crate::math::{Isometry, Real};
 use crate::query::contact_manifolds::contact_manifolds_workspace::{
     TypedWorkspaceData, WorkspaceData,
 };
-use crate::query::contact_manifolds::{ContactManifoldsWorkspace, InternalEdgesFixer};
+use crate::query::contact_manifolds::ContactManifoldsWorkspace;
 use crate::query::query_dispatcher::PersistentQueryDispatcher;
 use crate::query::visitors::BoundingVolumeIntersectionsVisitor;
 use crate::query::ContactManifold;
@@ -12,6 +12,9 @@ use crate::shape::Capsule;
 use crate::shape::{HeightField, Shape, SimdCompositeShape};
 use crate::utils::hashmap::{Entry, HashMap};
 use crate::utils::IsometryOpt;
+
+#[cfg(feature = "dim3")]
+use crate::query::contact_manifolds::InternalEdgesFixer;
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
@@ -29,6 +32,7 @@ struct SubDetector {
 pub struct HeightFieldCompositeShapeContactManifoldsWorkspace {
     timestamp: bool,
     sub_detectors: HashMap<(u32, u32), SubDetector>,
+    #[cfg(feature = "dim3")]
     internal_edges: InternalEdgesFixer,
 }
 
@@ -37,6 +41,7 @@ impl HeightFieldCompositeShapeContactManifoldsWorkspace {
         Self {
             timestamp: false,
             sub_detectors: HashMap::default(),
+            #[cfg(feature = "dim3")]
             internal_edges: InternalEdgesFixer::default(),
         }
     }

--- a/src/query/contact_manifolds/contact_manifolds_heightfield_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_heightfield_shape.rs
@@ -3,13 +3,16 @@ use crate::math::{Isometry, Real};
 use crate::query::contact_manifolds::contact_manifolds_workspace::{
     TypedWorkspaceData, WorkspaceData,
 };
-use crate::query::contact_manifolds::{ContactManifoldsWorkspace, InternalEdgesFixer};
+use crate::query::contact_manifolds::ContactManifoldsWorkspace;
 use crate::query::query_dispatcher::PersistentQueryDispatcher;
 use crate::query::ContactManifold;
 #[cfg(feature = "dim2")]
 use crate::shape::Capsule;
 use crate::shape::{HeightField, Shape};
 use crate::utils::hashmap::{Entry, HashMap};
+
+#[cfg(feature = "dim3")]
+use crate::query::contact_manifolds::InternalEdgesFixer;
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
@@ -27,6 +30,7 @@ struct SubDetector {
 pub struct HeightFieldShapeContactManifoldsWorkspace {
     timestamp: bool,
     sub_detectors: HashMap<u32, SubDetector>,
+    #[cfg(feature = "dim3")]
     internal_edges: InternalEdgesFixer,
 }
 
@@ -35,6 +39,7 @@ impl HeightFieldShapeContactManifoldsWorkspace {
         Self {
             timestamp: false,
             sub_detectors: HashMap::default(),
+            #[cfg(feature = "dim3")]
             internal_edges: InternalEdgesFixer::default(),
         }
     }

--- a/src/query/contact_manifolds/contact_manifolds_pfm_pfm.rs
+++ b/src/query/contact_manifolds/contact_manifolds_pfm_pfm.rs
@@ -4,7 +4,7 @@ use crate::query::{
     gjk::{GJKResult, VoronoiSimplex},
     ContactManifold, TrackedContact,
 };
-use crate::shape::{PolygonalFeature, PolygonalFeatureMap, Shape};
+use crate::shape::{PackedFeatureId, PolygonalFeature, PolygonalFeatureMap, Shape};
 use na::Unit;
 
 /// Computes the contact manifold between two convex shapes implementing the `PolygonalSupportMap`
@@ -92,12 +92,13 @@ pub fn contact_manifold_pfm_pfm<'a, ManifoldData, ContactData, S1, S2>(
                 false,
             );
 
-            if cfg!(feature = "dim3") || (cfg!(feature = "dim2") && manifold.points.is_empty()) {
+            if manifold.points.is_empty() {
+                // cfg!(feature = "dim3") || (cfg!(feature = "dim2") && manifold.points.is_empty()) {
                 let contact = TrackedContact::new(
                     p1,
                     pos12.inverse_transform_point(&p2_1),
-                    u32::MAX, // We don't know what features are involved.
-                    u32::MAX,
+                    PackedFeatureId::UNKNOWN, // FIXME: We don't know what features are involved.
+                    PackedFeatureId::UNKNOWN, // FIXME
                     (p2_1 - p1).dot(&dir),
                 );
                 manifold.points.push(contact);

--- a/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
@@ -7,6 +7,7 @@ use crate::query::contact_manifolds::ContactManifoldsWorkspace;
 use crate::query::query_dispatcher::PersistentQueryDispatcher;
 use crate::query::ContactManifold;
 use crate::shape::{Shape, TriMesh};
+use crate::utils::hashmap::HashMap;
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
@@ -18,6 +19,8 @@ pub struct TriMeshShapeContactManifoldsWorkspace {
     interferences: Vec<u32>,
     local_aabb2: AABB,
     old_interferences: Vec<u32>,
+    delayed_manifolds: Vec<u32>,
+    vertex_set: HashMap<u32, ()>,
 }
 
 impl TriMeshShapeContactManifoldsWorkspace {
@@ -26,6 +29,8 @@ impl TriMeshShapeContactManifoldsWorkspace {
             interferences: Vec::new(),
             local_aabb2: AABB::new_invalid(),
             old_interferences: Vec::new(),
+            delayed_manifolds: Vec::new(),
+            vertex_set: HashMap::default(),
         }
     }
 }
@@ -191,6 +196,130 @@ pub fn contact_manifolds_trimesh_shape<ManifoldData, ContactData>(
             let _ = dispatcher
                 .contact_manifold_convex_convex(pos12, &triangle1, shape2, prediction, manifold);
         }
+    }
+
+    /*
+     *
+     * Deal with internal edges.
+     *
+     */
+    #[cfg(feature = "dim3")]
+    {
+        use crate::shape::FeatureId;
+        use std::cmp::Ordering;
+
+        // 1. Ingest all the face contacts.
+        for (mid, manifold) in manifolds.iter().enumerate() {
+            if let Some(deepest) = manifold.find_deepest_contact() {
+                let tri_fid = if flipped { deepest.fid2 } else { deepest.fid1 };
+
+                if tri_fid.is_face() {
+                    let (tri_idx, tri) = if flipped {
+                        (
+                            trimesh1.indices()[manifold.subshape2 as usize],
+                            trimesh1.triangle(manifold.subshape2),
+                        )
+                    } else {
+                        (
+                            trimesh1.indices()[manifold.subshape1 as usize],
+                            trimesh1.triangle(manifold.subshape1),
+                        )
+                    };
+
+                    let normal = if flipped {
+                        manifold.local_n2
+                    } else {
+                        manifold.local_n1
+                    };
+
+                    if let Some(tri_normal) = tri.normal() {
+                        // We check normal collinearity with an epsilon because sometimes,
+                        // because of rounding errors, a contact may be identified as a face
+                        // contact where it’s really just an edge contact.
+                        if normal.dot(&tri_normal).abs() > 1.0 - 1.0e-4 {
+                            let _ = workspace.vertex_set.insert(tri_idx[0], ());
+                            let _ = workspace.vertex_set.insert(tri_idx[1], ());
+                            let _ = workspace.vertex_set.insert(tri_idx[2], ());
+                            // This as an actual face contact, continue without pushing to delayed_manifolds.
+                            continue;
+                        }
+                    }
+                }
+
+                // NOTE: if we reach this line, then the contact isn’t an actual face contact.
+                workspace.delayed_manifolds.push(mid as u32);
+            }
+        }
+
+        // 2. Order by distance.
+        workspace.delayed_manifolds.sort_by(|a, b| {
+            let a = &manifolds[*a as usize];
+            let b = &manifolds[*b as usize];
+
+            let dist_a = a
+                .find_deepest_contact()
+                .map(|c| c.dist)
+                .unwrap_or(Real::MAX);
+            let dist_b = b
+                .find_deepest_contact()
+                .map(|c| c.dist)
+                .unwrap_or(Real::MAX);
+
+            dist_a.partial_cmp(&dist_b).unwrap_or(Ordering::Equal)
+        });
+
+        // 3. Deal with the edge/vertex contacts.
+        for mid in &workspace.delayed_manifolds {
+            let manifold = &mut manifolds[*mid as usize];
+
+            let tri_idx = if flipped {
+                trimesh1.indices()[manifold.subshape2 as usize]
+            } else {
+                trimesh1.indices()[manifold.subshape1 as usize]
+            };
+
+            manifold.points.retain(|pt| {
+                let tri_fid = if flipped { pt.fid2 } else { pt.fid1 };
+
+                match tri_fid.unpack() {
+                    FeatureId::Face(_) => {
+                        !workspace.vertex_set.contains_key(&tri_idx[0])
+                            && !workspace.vertex_set.contains_key(&tri_idx[1])
+                            && !workspace.vertex_set.contains_key(&tri_idx[2])
+                    }
+                    FeatureId::Edge(id) => {
+                        !workspace.vertex_set.contains_key(&tri_idx[id as usize])
+                            || !workspace
+                                .vertex_set
+                                .contains_key(&tri_idx[(id as usize + 1) % 3])
+                    }
+                    FeatureId::Vertex(id) => {
+                        !workspace.vertex_set.contains_key(&tri_idx[id as usize])
+                    }
+                    FeatureId::Unknown => {
+                        !workspace.vertex_set.contains_key(&tri_idx[0])
+                            && !workspace.vertex_set.contains_key(&tri_idx[1])
+                            && !workspace.vertex_set.contains_key(&tri_idx[2])
+                    }
+                }
+            });
+
+            // if !manifold.points.is_empty() {
+            //     let normal = if flipped {
+            //         manifold.local_n2
+            //     } else {
+            //         manifold.local_n1
+            //     };
+            //     println!("Keeping other contact: {:?}, {:?}", tri_idx, normal);
+            // }
+
+            let _ = workspace.vertex_set.insert(tri_idx[0], ());
+            let _ = workspace.vertex_set.insert(tri_idx[1], ());
+            let _ = workspace.vertex_set.insert(tri_idx[2], ());
+        }
+
+        workspace.vertex_set.clear();
+        workspace.delayed_manifolds.clear();
     }
 }
 

--- a/src/query/contact_manifolds/internal_edges_fixer.rs
+++ b/src/query/contact_manifolds/internal_edges_fixer.rs
@@ -121,6 +121,10 @@ impl InternalEdgesFixer {
 
                 match tri_fid.unpack() {
                     FeatureId::Face(_) => {
+                        // This is a "false face" contact (a contact identified as face because
+                        // of rounding errors but it’s probably just an edge contact.
+                        // We don’t know exactly which edge it is, so we just ignore it
+                        // if any of the vertices already exist in the set.
                         !self.vertex_set.contains_key(&tri_idx[0])
                             && !self.vertex_set.contains_key(&tri_idx[1])
                             && !self.vertex_set.contains_key(&tri_idx[2])
@@ -133,6 +137,8 @@ impl InternalEdgesFixer {
                     }
                     FeatureId::Vertex(id) => !self.vertex_set.contains_key(&tri_idx[id as usize]),
                     FeatureId::Unknown => {
+                        // We don’t know the feature type here, so we just ignore it
+                        // if any of the vertices already exist in the set.
                         !self.vertex_set.contains_key(&tri_idx[0])
                             && !self.vertex_set.contains_key(&tri_idx[1])
                             && !self.vertex_set.contains_key(&tri_idx[2])

--- a/src/query/contact_manifolds/internal_edges_fixer.rs
+++ b/src/query/contact_manifolds/internal_edges_fixer.rs
@@ -1,0 +1,157 @@
+use crate::math::Real;
+use crate::query::ContactManifold;
+use crate::shape::Triangle;
+use crate::utils::hashmap::HashMap;
+
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[derive(Default, Clone)]
+pub struct InternalEdgesFixer {
+    delayed_manifolds: Vec<u32>,
+    vertex_set: HashMap<u32, ()>,
+}
+
+impl InternalEdgesFixer {
+    #[cfg(feature = "dim2")]
+    pub fn remove_invalid_contacts<ManifoldData, ContactData>(
+        &mut self,
+        _manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+        _flipped: bool,
+        _get_triangle: impl Fn(u32) -> Triangle,
+        _get_triangle_indices: impl Fn(u32) -> [u32; 3],
+    ) where
+        ManifoldData: Default,
+        ContactData: Default + Copy,
+    {
+        // Not yet implemented.
+    }
+
+    #[cfg(feature = "dim3")]
+    pub fn remove_invalid_contacts<ManifoldData, ContactData>(
+        &mut self,
+        manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+        flipped: bool,
+        get_triangle: impl Fn(u32) -> Triangle,
+        get_triangle_indices: impl Fn(u32) -> [u32; 3],
+    ) where
+        ManifoldData: Default,
+        ContactData: Default + Copy,
+    {
+        use crate::shape::FeatureId;
+        use std::cmp::Ordering;
+
+        // 1. Ingest all the face contacts.
+        for (mid, manifold) in manifolds.iter().enumerate() {
+            if let Some(deepest) = manifold.find_deepest_contact() {
+                let tri_fid = if flipped { deepest.fid2 } else { deepest.fid1 };
+
+                if tri_fid.is_face() {
+                    let (tri_idx, tri) = if flipped {
+                        (
+                            get_triangle_indices(manifold.subshape2),
+                            get_triangle(manifold.subshape2),
+                        )
+                    } else {
+                        (
+                            get_triangle_indices(manifold.subshape1),
+                            get_triangle(manifold.subshape1),
+                        )
+                    };
+
+                    let normal = if flipped {
+                        manifold.local_n2
+                    } else {
+                        manifold.local_n1
+                    };
+
+                    if let Some(tri_normal) = tri.normal() {
+                        // We check normal collinearity with an epsilon because sometimes,
+                        // because of rounding errors, a contact may be identified as a face
+                        // contact where it’s really just an edge contact.
+                        if normal.dot(&tri_normal).abs() > 1.0 - 1.0e-4 {
+                            let _ = self.vertex_set.insert(tri_idx[0], ());
+                            let _ = self.vertex_set.insert(tri_idx[1], ());
+                            let _ = self.vertex_set.insert(tri_idx[2], ());
+                            // This as an actual face contact, continue without pushing to delayed_manifolds.
+                            continue;
+                        }
+                    }
+                }
+
+                // NOTE: if we reach this line, then the contact isn’t an actual face contact.
+                self.delayed_manifolds.push(mid as u32);
+            }
+        }
+
+        // 2. Order by distance.
+        self.delayed_manifolds.sort_by(|a, b| {
+            let a = &manifolds[*a as usize];
+            let b = &manifolds[*b as usize];
+
+            let dist_a = a
+                .find_deepest_contact()
+                .map(|c| c.dist)
+                .unwrap_or(Real::MAX);
+            let dist_b = b
+                .find_deepest_contact()
+                .map(|c| c.dist)
+                .unwrap_or(Real::MAX);
+
+            dist_a.partial_cmp(&dist_b).unwrap_or(Ordering::Equal)
+        });
+
+        // 3. Deal with the edge/vertex contacts.
+        for mid in &self.delayed_manifolds {
+            let manifold = &mut manifolds[*mid as usize];
+
+            let tri_idx = if flipped {
+                get_triangle_indices(manifold.subshape2)
+            } else {
+                get_triangle_indices(manifold.subshape1)
+            };
+
+            manifold.points.retain(|pt| {
+                let tri_fid = if flipped { pt.fid2 } else { pt.fid1 };
+
+                match tri_fid.unpack() {
+                    FeatureId::Face(_) => {
+                        !self.vertex_set.contains_key(&tri_idx[0])
+                            && !self.vertex_set.contains_key(&tri_idx[1])
+                            && !self.vertex_set.contains_key(&tri_idx[2])
+                    }
+                    FeatureId::Edge(id) => {
+                        !self.vertex_set.contains_key(&tri_idx[id as usize])
+                            || !self
+                                .vertex_set
+                                .contains_key(&tri_idx[(id as usize + 1) % 3])
+                    }
+                    FeatureId::Vertex(id) => !self.vertex_set.contains_key(&tri_idx[id as usize]),
+                    FeatureId::Unknown => {
+                        !self.vertex_set.contains_key(&tri_idx[0])
+                            && !self.vertex_set.contains_key(&tri_idx[1])
+                            && !self.vertex_set.contains_key(&tri_idx[2])
+                    }
+                }
+            });
+
+            // if !manifold.points.is_empty() {
+            //     let normal = if flipped {
+            //         manifold.local_n2
+            //     } else {
+            //         manifold.local_n1
+            //     };
+            //     println!("Keeping other contact: {:?}, {:?}", tri_idx, normal);
+            // }
+
+            let _ = self.vertex_set.insert(tri_idx[0], ());
+            let _ = self.vertex_set.insert(tri_idx[1], ());
+            let _ = self.vertex_set.insert(tri_idx[2], ());
+        }
+
+        self.vertex_set.clear();
+        self.delayed_manifolds.clear();
+    }
+}

--- a/src/query/contact_manifolds/internal_edges_fixer.rs
+++ b/src/query/contact_manifolds/internal_edges_fixer.rs
@@ -1,7 +1,9 @@
-use crate::math::Real;
 use crate::query::ContactManifold;
 use crate::shape::Triangle;
 use crate::utils::hashmap::HashMap;
+
+#[cfg(feature = "dim3")]
+use crate::math::Real;
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
@@ -9,6 +11,7 @@ use crate::utils::hashmap::HashMap;
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
 #[derive(Default, Clone)]
+#[allow(dead_code)] // We will need these for 2D too in the future.
 pub struct InternalEdgesFixer {
     delayed_manifolds: Vec<u32>,
     vertex_set: HashMap<u32, ()>,

--- a/src/query/contact_manifolds/mod.rs
+++ b/src/query/contact_manifolds/mod.rs
@@ -42,6 +42,7 @@ pub(self) use {
     self::contact_manifolds_heightfield_composite_shape::HeightFieldCompositeShapeContactManifoldsWorkspace,
     self::contact_manifolds_heightfield_shape::HeightFieldShapeContactManifoldsWorkspace,
     self::contact_manifolds_trimesh_shape::TriMeshShapeContactManifoldsWorkspace,
+    self::internal_edges_fixer::InternalEdgesFixer,
 };
 
 mod contact_manifold;
@@ -59,3 +60,4 @@ mod contact_manifolds_heightfield_shape;
 mod contact_manifolds_pfm_pfm;
 mod contact_manifolds_trimesh_shape;
 mod contact_manifolds_workspace;
+mod internal_edges_fixer;

--- a/src/shape/convex_polygon.rs
+++ b/src/shape/convex_polygon.rs
@@ -1,5 +1,5 @@
 use crate::math::{Point, Real, Vector};
-use crate::shape::{FeatureId, PolygonalFeature, PolygonalFeatureMap, SupportMap};
+use crate::shape::{FeatureId, PackedFeatureId, PolygonalFeature, PolygonalFeatureMap, SupportMap};
 use crate::utils;
 use na::{self, ComplexField, RealField, Unit};
 
@@ -164,8 +164,8 @@ impl PolygonalFeatureMap for ConvexPolygon {
         let i2 = (best_face + 1) % self.points.len();
         *out_feature = PolygonalFeature {
             vertices: [self.points[i1], self.points[i2]],
-            vids: [i1 as u32 * 2, i2 as u32 * 2],
-            fid: i1 as u32 * 2 + 1,
+            vids: PackedFeatureId::vertices([i1 as u32 * 2, i2 as u32 * 2]),
+            fid: PackedFeatureId::face(i1 as u32 * 2 + 1),
             num_vertices: 2,
         };
     }

--- a/src/shape/convex_polyhedron.rs
+++ b/src/shape/convex_polyhedron.rs
@@ -1,5 +1,5 @@
 use crate::math::{Point, Real, Vector, DIM};
-use crate::shape::{FeatureId, PolygonalFeature, PolygonalFeatureMap, SupportMap};
+use crate::shape::{FeatureId, PackedFeatureId, PolygonalFeature, PolygonalFeatureMap, SupportMap};
 // use crate::transformation;
 use crate::utils::hashmap::{Entry, HashMap};
 use crate::utils::{self, SortedPair};
@@ -548,11 +548,11 @@ impl PolygonalFeatureMap for ConvexPolyhedron {
             .enumerate()
         {
             out_feature.vertices[i] = self.points[*vid as usize];
-            out_feature.vids[i] = *vid;
-            out_feature.eids[i] = *eid;
+            out_feature.vids[i] = PackedFeatureId::vertex(*vid);
+            out_feature.eids[i] = PackedFeatureId::edge(*eid);
         }
 
-        out_feature.fid = best_fid as u32;
+        out_feature.fid = PackedFeatureId::face(best_fid as u32);
         out_feature.num_vertices = num_vertices as usize;
     }
 }

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -76,8 +76,8 @@ impl Cuboid {
 
         PolygonalFeature {
             vertices: [a, b],
-            vids: [vid1, vid2],
-            fid,
+            vids: PackedFeatureId::vertices([vid1, vid2]),
+            fid: PackedFeatureId::face(fid),
             num_vertices: 2,
         }
     }

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -3,7 +3,7 @@
 use crate::math::{Point, Real, Vector};
 #[cfg(feature = "dim3")]
 use crate::shape::Segment;
-use crate::shape::{FeatureId, PolygonalFeature, SupportMap};
+use crate::shape::{FeatureId, PackedFeatureId, PolygonalFeature, SupportMap};
 use crate::utils::WSign;
 use na::Unit;
 
@@ -220,9 +220,9 @@ impl Cuboid {
 
         PolygonalFeature {
             vertices,
-            vids,
-            eids,
-            fid: fid as u32,
+            vids: PackedFeatureId::vertices(vids),
+            eids: PackedFeatureId::edges(eids),
+            fid: PackedFeatureId::face(fid as u32),
             num_vertices: 4,
         }
     }

--- a/src/shape/feature_id.rs
+++ b/src/shape/feature_id.rs
@@ -71,6 +71,7 @@ impl PackedFeatureId {
     const CODE_MASK: u32 = 0x3fff_ffff;
     const HEADER_MASK: u32 = !Self::CODE_MASK;
     const HEADER_VERTEX: u32 = 0b01 << 30;
+    #[cfg(feature = "dim3")]
     const HEADER_EDGE: u32 = 0b10 << 30;
     const HEADER_FACE: u32 = 0b11 << 30;
 
@@ -81,6 +82,7 @@ impl PackedFeatureId {
     }
 
     /// Converts a edge feature id into a packed feature id.
+    #[cfg(feature = "dim3")]
     pub fn edge(code: u32) -> Self {
         assert_eq!(code & Self::HEADER_MASK, 0);
         Self(Self::HEADER_EDGE | code)
@@ -109,12 +111,6 @@ impl PackedFeatureId {
         ]
     }
 
-    #[cfg(feature = "dim2")]
-    /// Converts an array of edge feature ids into an array of packed feature ids.
-    pub(crate) fn edges(code: [u32; 2]) -> [Self; 2] {
-        [Self::edge(code[0]), Self::edge(code[1])]
-    }
-
     #[cfg(feature = "dim3")]
     /// Converts an array of edge feature ids into an array of packed feature ids.
     pub(crate) fn edges(code: [u32; 4]) -> [Self; 4] {
@@ -132,6 +128,7 @@ impl PackedFeatureId {
         let code = self.0 & Self::CODE_MASK;
         match header {
             Self::HEADER_VERTEX => FeatureId::Vertex(code),
+            #[cfg(feature = "dim3")]
             Self::HEADER_EDGE => FeatureId::Edge(code),
             Self::HEADER_FACE => FeatureId::Face(code),
             _ => FeatureId::Unknown,
@@ -149,6 +146,7 @@ impl PackedFeatureId {
     }
 
     /// Is the identified feature an edge?
+    #[cfg(feature = "dim3")]
     pub fn is_edge(self) -> bool {
         self.0 & Self::HEADER_MASK == Self::HEADER_EDGE
     }
@@ -163,6 +161,7 @@ impl From<FeatureId> for PackedFeatureId {
     fn from(value: FeatureId) -> Self {
         match value {
             FeatureId::Face(fid) => Self::face(fid),
+            #[cfg(feature = "dim3")]
             FeatureId::Edge(fid) => Self::edge(fid),
             FeatureId::Vertex(fid) => Self::vertex(fid),
             FeatureId::Unknown => Self::UNKNOWN,

--- a/src/shape/feature_id.rs
+++ b/src/shape/feature_id.rs
@@ -54,3 +54,118 @@ impl FeatureId {
         }
     }
 }
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+/// A feature id where the feature type is packed into the same value as the feature index.
+pub struct PackedFeatureId(pub u32);
+
+impl PackedFeatureId {
+    /// Packed feature id identifying an unknown feature.
+    pub const UNKNOWN: Self = Self(0);
+
+    const CODE_MASK: u32 = 0x3fff_ffff;
+    const HEADER_MASK: u32 = !Self::CODE_MASK;
+    const HEADER_VERTEX: u32 = 0b01 << 30;
+    const HEADER_EDGE: u32 = 0b10 << 30;
+    const HEADER_FACE: u32 = 0b11 << 30;
+
+    /// Converts a vertex feature id into a packed feature id.
+    pub fn vertex(code: u32) -> Self {
+        assert_eq!(code & Self::HEADER_MASK, 0);
+        Self(Self::HEADER_VERTEX | code)
+    }
+
+    /// Converts a edge feature id into a packed feature id.
+    pub fn edge(code: u32) -> Self {
+        assert_eq!(code & Self::HEADER_MASK, 0);
+        Self(Self::HEADER_EDGE | code)
+    }
+
+    /// Converts a face feature id into a packed feature id.
+    pub fn face(code: u32) -> Self {
+        assert_eq!(code & Self::HEADER_MASK, 0);
+        Self(Self::HEADER_FACE | code)
+    }
+
+    #[cfg(feature = "dim2")]
+    /// Converts an array of vertex feature ids into an array of packed feature ids.
+    pub(crate) fn vertices(code: [u32; 2]) -> [Self; 2] {
+        [Self::vertex(code[0]), Self::vertex(code[1])]
+    }
+
+    #[cfg(feature = "dim3")]
+    /// Converts an array of vertex feature ids into an array of packed feature ids.
+    pub(crate) fn vertices(code: [u32; 4]) -> [Self; 4] {
+        [
+            Self::vertex(code[0]),
+            Self::vertex(code[1]),
+            Self::vertex(code[2]),
+            Self::vertex(code[3]),
+        ]
+    }
+
+    #[cfg(feature = "dim2")]
+    /// Converts an array of edge feature ids into an array of packed feature ids.
+    pub(crate) fn edges(code: [u32; 2]) -> [Self; 2] {
+        [Self::edge(code[0]), Self::edge(code[1])]
+    }
+
+    #[cfg(feature = "dim3")]
+    /// Converts an array of edge feature ids into an array of packed feature ids.
+    pub(crate) fn edges(code: [u32; 4]) -> [Self; 4] {
+        [
+            Self::edge(code[0]),
+            Self::edge(code[1]),
+            Self::edge(code[2]),
+            Self::edge(code[3]),
+        ]
+    }
+
+    /// Unpacks this feature id into an explicit enum.
+    pub fn unpack(self) -> FeatureId {
+        let header = self.0 & Self::HEADER_MASK;
+        let code = self.0 & Self::CODE_MASK;
+        match header {
+            Self::HEADER_VERTEX => FeatureId::Vertex(code),
+            Self::HEADER_EDGE => FeatureId::Edge(code),
+            Self::HEADER_FACE => FeatureId::Face(code),
+            _ => FeatureId::Unknown,
+        }
+    }
+
+    /// Is the identified feature a face?
+    pub fn is_face(self) -> bool {
+        self.0 & Self::HEADER_MASK == Self::HEADER_FACE
+    }
+
+    /// Is the identified feature a vertex?
+    pub fn is_vertex(self) -> bool {
+        self.0 & Self::HEADER_MASK == Self::HEADER_VERTEX
+    }
+
+    /// Is the identified feature an edge?
+    pub fn is_edge(self) -> bool {
+        self.0 & Self::HEADER_MASK == Self::HEADER_EDGE
+    }
+
+    /// Is the identified feature unknown?
+    pub fn is_unknown(self) -> bool {
+        self == Self::UNKNOWN
+    }
+}
+
+impl From<FeatureId> for PackedFeatureId {
+    fn from(value: FeatureId) -> Self {
+        match value {
+            FeatureId::Face(fid) => Self::face(fid),
+            FeatureId::Edge(fid) => Self::edge(fid),
+            FeatureId::Vertex(fid) => Self::vertex(fid),
+            FeatureId::Unknown => Self::UNKNOWN,
+        }
+    }
+}

--- a/src/shape/heightfield3.rs
+++ b/src/shape/heightfield3.rs
@@ -324,10 +324,10 @@ where
         let cell_height = self.unit_cell_height();
 
         let z0 = -0.5 + cell_height * (i as Real);
-        let z1 = z0 + cell_height;
+        let z1 = -0.5 + cell_height * ((i + 1) as Real);
 
         let x0 = -0.5 + cell_width * (j as Real);
-        let x1 = x0 + cell_width;
+        let x1 = -0.5 + cell_width * ((j + 1) as Real);
 
         let y00 = self.heights.get(i + 0, j + 0);
         let y10 = self.heights.get(i + 1, j + 0);

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -8,7 +8,7 @@ pub use self::composite_shape::{SimdCompositeShape, TypedSimdCompositeShape};
 #[cfg(feature = "std")]
 pub use self::compound::Compound;
 pub use self::cuboid::Cuboid;
-pub use self::feature_id::FeatureId;
+pub use self::feature_id::{FeatureId, PackedFeatureId};
 pub use self::half_space::HalfSpace;
 pub use self::polygonal_feature_map::PolygonalFeatureMap;
 #[cfg(feature = "std")]

--- a/src/shape/polygonal_feature2d.rs
+++ b/src/shape/polygonal_feature2d.rs
@@ -1,7 +1,7 @@
 use crate::math::{Isometry, Point, Real, Vector};
 #[cfg(feature = "std")]
 use crate::query::{self, ContactManifold, TrackedContact};
-use crate::shape::Segment;
+use crate::shape::{PackedFeatureId, Segment};
 
 /// A polygonal feature representing the local polygonal approximation of
 /// a vertex, or face, of a convex shape.
@@ -10,9 +10,9 @@ pub struct PolygonalFeature {
     /// Up to two vertices forming this polygonal feature.
     pub vertices: [Point<Real>; 2],
     /// The feature IDs of this polygon's vertices.
-    pub vids: [u32; 2],
+    pub vids: [PackedFeatureId; 2],
     /// The feature ID of this polygonal feature.
-    pub fid: u32,
+    pub fid: PackedFeatureId,
     /// The number of vertices on this polygon (must be <= 4).
     pub num_vertices: usize,
 }
@@ -21,8 +21,8 @@ impl Default for PolygonalFeature {
     fn default() -> Self {
         Self {
             vertices: [Point::origin(); 2],
-            vids: [0; 2],
-            fid: 0,
+            vids: [PackedFeatureId::UNKNOWN; 2],
+            fid: PackedFeatureId::UNKNOWN,
             num_vertices: 0,
         }
     }
@@ -32,8 +32,8 @@ impl From<Segment> for PolygonalFeature {
     fn from(seg: Segment) -> Self {
         PolygonalFeature {
             vertices: [seg.a, seg.b],
-            vids: [0, 2],
-            fid: 1,
+            vids: PackedFeatureId::vertices([0, 2]),
+            fid: PackedFeatureId::face(1),
             num_vertices: 2,
         }
     }

--- a/src/shape/polygonal_feature_map.rs
+++ b/src/shape/polygonal_feature_map.rs
@@ -1,5 +1,5 @@
 use crate::math::{Real, Vector};
-use crate::shape::{Cuboid, PolygonalFeature, Segment, SupportMap, Triangle};
+use crate::shape::{Cuboid, PackedFeatureId, PolygonalFeature, Segment, SupportMap, Triangle};
 use na::Unit;
 #[cfg(feature = "dim3")]
 use {
@@ -69,10 +69,10 @@ impl PolygonalFeatureMap for Cylinder {
             );
             out_features.vertices[1] =
                 Point::new(dir2.x * self.radius, self.half_height, dir2.y * self.radius);
-            out_features.eids = [0, 0, 0, 0];
-            out_features.fid = 0;
+            out_features.eids = PackedFeatureId::edges([0, 0, 0, 0]);
+            out_features.fid = PackedFeatureId::face(0);
             out_features.num_vertices = 2;
-            out_features.vids = [1, 11, 11, 11];
+            out_features.vids = PackedFeatureId::vertices([1, 11, 11, 11]);
         } else {
             // We return a square approximation of the cylinder cap.
             let y = self.half_height.copysign(dir.y);
@@ -82,15 +82,15 @@ impl PolygonalFeatureMap for Cylinder {
             out_features.vertices[3] = Point::new(dir2.y * self.radius, y, -dir2.x * self.radius);
 
             if dir.y < 0.0 {
-                out_features.eids = [2, 4, 6, 8];
-                out_features.fid = 9;
+                out_features.eids = PackedFeatureId::edges([2, 4, 6, 8]);
+                out_features.fid = PackedFeatureId::face(9);
                 out_features.num_vertices = 4;
-                out_features.vids = [1, 3, 5, 7];
+                out_features.vids = PackedFeatureId::vertices([1, 3, 5, 7]);
             } else {
-                out_features.eids = [12, 14, 16, 18];
-                out_features.fid = 19;
+                out_features.eids = PackedFeatureId::edges([12, 14, 16, 18]);
+                out_features.fid = PackedFeatureId::face(19);
                 out_features.num_vertices = 4;
-                out_features.vids = [11, 13, 15, 17];
+                out_features.vids = PackedFeatureId::vertices([11, 13, 15, 17]);
             }
         }
     }
@@ -125,10 +125,10 @@ impl PolygonalFeatureMap for Cone {
                 dir2.y * self.radius,
             );
             out_features.vertices[1] = Point::new(0.0, self.half_height, 0.0);
-            out_features.eids = [0, 0, 0, 0];
-            out_features.fid = 0;
+            out_features.eids = PackedFeatureId::edges([0, 0, 0, 0]);
+            out_features.fid = PackedFeatureId::face(0);
             out_features.num_vertices = 2;
-            out_features.vids = [1, 11, 11, 11];
+            out_features.vids = PackedFeatureId::vertices([1, 11, 11, 11]);
         } else {
             // We return a square approximation of the cone cap.
             let y = -self.half_height;
@@ -137,10 +137,10 @@ impl PolygonalFeatureMap for Cone {
             out_features.vertices[2] = Point::new(-dir2.x * self.radius, y, -dir2.y * self.radius);
             out_features.vertices[3] = Point::new(dir2.y * self.radius, y, -dir2.x * self.radius);
 
-            out_features.eids = [2, 4, 6, 8];
-            out_features.fid = 9;
+            out_features.eids = PackedFeatureId::edges([2, 4, 6, 8]);
+            out_features.fid = PackedFeatureId::face(9);
             out_features.num_vertices = 4;
-            out_features.vids = [1, 3, 5, 7];
+            out_features.vids = PackedFeatureId::vertices([1, 3, 5, 7]);
         }
     }
 }

--- a/src/shape/polygonal_feature_map.rs
+++ b/src/shape/polygonal_feature_map.rs
@@ -1,11 +1,11 @@
 use crate::math::{Real, Vector};
-use crate::shape::{Cuboid, PackedFeatureId, PolygonalFeature, Segment, SupportMap, Triangle};
+use crate::shape::{Cuboid, PolygonalFeature, Segment, SupportMap, Triangle};
 use na::Unit;
 #[cfg(feature = "dim3")]
 use {
     crate::{
         math::Point,
-        shape::{Cone, Cylinder},
+        shape::{Cone, Cylinder, PackedFeatureId},
     },
     approx::AbsDiffEq,
 };

--- a/src/shape/triangle.rs
+++ b/src/shape/triangle.rs
@@ -1,7 +1,7 @@
 //! Definition of the triangle shape.
 
 use crate::math::{Isometry, Point, Real, Vector};
-use crate::shape::{FeatureId, PackedFeatureId, SupportMap};
+use crate::shape::{FeatureId, SupportMap};
 use crate::shape::{PolygonalFeature, Segment};
 use crate::utils;
 
@@ -10,6 +10,9 @@ use num::Zero;
 #[cfg(feature = "dim3")]
 use std::f64;
 use std::mem;
+
+#[cfg(feature = "dim2")]
+use crate::shape::PackedFeatureId;
 
 /// A triangle shape.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/shape/triangle.rs
+++ b/src/shape/triangle.rs
@@ -1,7 +1,7 @@
 //! Definition of the triangle shape.
 
 use crate::math::{Isometry, Point, Real, Vector};
-use crate::shape::{FeatureId, SupportMap};
+use crate::shape::{FeatureId, PackedFeatureId, SupportMap};
 use crate::shape::{PolygonalFeature, Segment};
 use crate::utils;
 
@@ -217,8 +217,8 @@ impl Triangle {
 
         PolygonalFeature {
             vertices: [pts[i1], pts[i2]],
-            vids: [i1 as u32, i2 as u32],
-            fid: i1 as u32,
+            vids: PackedFeatureId::vertices([i1 as u32, i2 as u32]),
+            fid: PackedFeatureId::face(i1 as u32),
             num_vertices: 2,
         }
     }

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -136,7 +136,7 @@ pub struct TopoFace {
 pub struct TopoHalfEdge {
     /// The next half-edge.
     pub next: u32,
-    /// This half-edge twin on the adjascent triangle.
+    /// This half-edge twin on the adjacent triangle.
     ///
     /// This is `u32::MAX` if there is no twin.
     pub twin: u32,
@@ -643,13 +643,11 @@ impl TriMesh {
     /// It may be useful to call `self.remove_duplicate_vertices()` before this method, in order to fix the
     /// index buffer if some of the vertices of this trimesh are duplicated.
     fn compute_pseudo_normals(&mut self) {
-        use na::RealField;
-
         let mut vertices_pseudo_normal = vec![Vector::zeros(); self.vertices().len()];
         let mut edges_pseudo_normal = HashMap::default();
         let mut edges_multiplicity = HashMap::default();
 
-        for (k, idx) in self.indices().iter().enumerate() {
+        for idx in self.indices() {
             let vtx = self.vertices();
             let tri = Triangle::new(
                 vtx[idx[0] as usize],


### PR DESCRIPTION
This PR addresses the internal edges problem for 3D meshes and 3D heightfields by removing contacts that are detected as invalid because they happen at internal edges or internal vertices on a flat surface.
The solution isn’t perfect as some edge contacts may still happen if the flat surface has many small triangles (but, in this case, it is strongly recommended to simplify the mesh anyway for better performances).