### PR TITLE
Make the triangle mesh partially compatible with CUDA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## Unreleased
+
+### Modified
+- Rename `AABB` to `Aabb` to comply with Rust’s style guide.
+- Rename `QBVH` to `Qbvh` to comply with Rust’s style guide.
+
+### Added
+- Add `CudaTriMesh` and `CudaTriMeshPtr` for triangle-meshes usable with CUDA.
+- Add a no-std implementation of point-projection on a triangle mesh.
+
+### Fixed
+- Fix ghost collisions on internal edges on flat 3D meshed and flat 3D heightfields.
+- Fix pseudo-normals calculation that could generated invalid normals for triangles with
+  some small vertex angles.
+
+
 ## v0.10.0 (02 Oct. 2022)
 
 ### Modified
@@ -16,8 +32,8 @@
 - Add the support of Heightfields on CUDA kernels written in Rust using the `cust` crate.
 - Add the `rkyv-serialize` feature that enables the implementation of `rkyv` serialization/deserialization
   for most shapes.
-- Add the `parallel` feature that enables methods for the parallel traversal of QBVH trees: `QBVH::traverse_bvtt_parallel`,
-  `QBVH::traverse_bvtt_node_parallel`, `QBVH::traverse_depth_first_parallel`, `QBVH::traverse_depth_first_node_parallel`.
+- Add the `parallel` feature that enables methods for the parallel traversal of Qbvh trees: `Qbvh::traverse_bvtt_parallel`,
+  `Qbvh::traverse_bvtt_node_parallel`, `Qbvh::traverse_depth_first_parallel`, `Qbvh::traverse_depth_first_node_parallel`.
 
 ### Fixed
 - Fix the application of non-uniform scaling to balls.
@@ -30,10 +46,10 @@
 - Rename `RoundShape::base_shape` to `RoundShape::inner_shape`.
 
 ### Added
-- Allow custom balancing strategies for the QBVH construction. Some strategies are allowed to generate
+- Allow custom balancing strategies for the Qbvh construction. Some strategies are allowed to generate
   new leaves during the splitting process.
 - Allow using point projection on heightfields from a CUDA kernel.
-- Add the simultaneous traversal of two QBVHs.
+- Add the simultaneous traversal of two Qbvhs.
 - Add computation of `MassProperties` for a `TriMesh`.
 - Add `.to_outline` methods to compute the outline of a 3D shape (useful for debug-rendering).
 - Add method to apply a scaling factor to some shapes. Shapes not supporting non-uniform scaling (like balls)
@@ -70,7 +86,7 @@
 
 ## v0.7.1
 ### Added
-- Add the method `AABB::volume` to compute the volume of an AABB.
+- Add the method `Aabb::volume` to compute the volume of an Aabb.
 
 ## v0.7.0
 ### Modified
@@ -84,9 +100,9 @@
 - Implement `Debug, Clone, PartialEq` for `VHACDParameters`.
 - Add a method to reverse the order of a polyline.
 - Add a method to remove duplicate vertices form a `TriMesh` (and adjusting the index buffer accordingly).
-- Add a method to iterate through all the lean data stored by a QBVH.
+- Add a method to iterate through all the lean data stored by a Qbvh.
 - Implement the Interval Newton Method for computing all the roots of a non-linear scalar function.
-- Implement the intersection test between a spiral and an AABB.
+- Implement the intersection test between a spiral and an Aabb.
 
 ### Modified
 - Rename all occurrences of `quadtree` to `qbvh`. Using the term `quadtree` was not representative of the actual acceleration structure being used (which is a BVH).
@@ -122,9 +138,9 @@
 - Add the optional method `Shape::compute_swept_aabb` to the `Shape` trait.
 
 ### Modified
-- Renamed `SimdQuadTree` to `QBVH` (Quaternary Bounding Volume Hierarchy). The
+- Renamed `SimdQuadTree` to `Qbvh` (Quaternary Bounding Volume Hierarchy). The
   incorrect name `SimdQuadTree` is now deprecated.
-- `QBVH::clear_and_rebuild` is now slightly more general.
+- `Qbvh::clear_and_rebuild` is now slightly more general.
 
 
 ## v0.4.0
@@ -142,8 +158,8 @@
 - Add `MassProperties::set_mass` as a simple way to modify the mass while automatically adjusting
   the angular inertia.
 - Make the fields of `BoundingSphere` public.
-- Add `AABB::EDGES_VERTEX_IDS` and `AABB::FACES_VERTEX_IDS` which are index tables describing
-  the vertices of a given edge, or of a given face, of the AABB.
+- Add `Aabb::EDGES_VERTEX_IDS` and `Aabb::FACES_VERTEX_IDS` which are index tables describing
+  the vertices of a given edge, or of a given face, of the Aabb.
 
 ### Modified
 - Remove the `target_dist` argument from `query::time_of_impact`.
@@ -164,9 +180,9 @@
   (except for user-defined custom shapes).
 - Add dedicated algorithms for the projection of a point on a cone or a cylinder.
 - Improve the overall shape serialization performance.
-- Add `AABB::vertices` to get an array containing its vertices.
-- Add `AABB::split_at_center` to split an AABB into 4 (in 2D) or 8 (in 3D) parts.
-- Add `AABB::to_trimesh` to compute the mesh representation of an AABB.
+- Add `Aabb::vertices` to get an array containing its vertices.
+- Add `Aabb::split_at_center` to split an Aabb into 4 (in 2D) or 8 (in 3D) parts.
+- Add `Aabb::to_trimesh` to compute the mesh representation of an Aabb.
 
 ### Removed
 - Remove the `Shape::as_serialize` method.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ parry2d-f64 = { path = "crates/parry2d-f64" }
 parry3d-f64 = { path = "crates/parry3d-f64" }
 
 #simba = { path = "../simba" }
-simba = { git = "https://github.com/dimforge/simba", rev = "d928e4aedbf8ee03043abae38c8f846dba4801e5" }
+#simba = { git = "https://github.com/dimforge/simba", rev = "d928e4aedbf8ee03043abae38c8f846dba4801e5" }
 # nalgebra = { git = "https://github.com/dimforge/nalgebra" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ parry2d-f64 = { path = "crates/parry2d-f64" }
 parry3d-f64 = { path = "crates/parry3d-f64" }
 
 #simba = { path = "../simba" }
-#simba = { git = "https://github.com/dimforge/simba", rev = "b1392df62a0f4cf91e397bbb6bd41b7731afb6ab" }
+simba = { git = "https://github.com/dimforge/simba", rev = "d928e4aedbf8ee03043abae38c8f846dba4801e5" }
 # nalgebra = { git = "https://github.com/dimforge/nalgebra" }

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -47,7 +47,7 @@ num-traits      = { version = "0.2", default-features = false }
 smallvec        = "1"
 slab            = { version = "0.4", optional = true }
 arrayvec        = { version = "0.7", default-features = false }
-simba           = { version = "^0.7.2", default-features = false }
+simba           = { version = "^0.7.3", default-features = false }
 nalgebra        = { version = "0.31", default-features = false, features = [ "libm" ] }
 approx          = { version = "0.5", default-features = false }
 serde           = { version = "1.0", optional = true, features = ["derive"] }

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -47,7 +47,7 @@ num-traits      = { version = "0.2", default-features = false }
 smallvec        = "1"
 slab            = { version = "0.4", optional = true }
 arrayvec        = { version = "0.7", default-features = false }
-simba           = { version = "^0.7.2", default-features = false }
+simba           = { version = "^0.7.3", default-features = false }
 nalgebra        = { version = "0.31", default-features = false, features = [ "libm" ] }
 approx          = { version = "0.5", default-features = false }
 serde           = { version = "1.0", optional = true, features = ["derive"] }

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -47,7 +47,7 @@ num-traits = { version = "0.2", default-features = false }
 smallvec   = "1"
 slab       = { version = "0.4", optional = true }
 arrayvec   = { version = "0.7", default-features = false }
-simba      = { version = "^0.7.2", default-features = false }
+simba      = { version = "^0.7.3", default-features = false }
 nalgebra   = { version = "0.31", default-features = false, features = [ "libm" ] }
 approx     = { version = "0.5", default-features = false }
 serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -48,7 +48,7 @@ num-traits = { version = "0.2", default-features = false }
 smallvec   = "1"
 slab       = { version = "0.4", optional = true }
 arrayvec   = { version = "0.7", default-features = false }
-simba      = { version = "^0.7.2", default-features = false }
+simba      = { version = "^0.7.3", default-features = false }
 nalgebra   = { version = "0.31", default-features = false, features = [ "libm" ] }
 approx     = { version = "0.5", default-features = false }
 serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}

--- a/crates/parry3d/benches/bounding_volume/mod.rs
+++ b/crates/parry3d/benches/bounding_volume/mod.rs
@@ -1,7 +1,7 @@
 use crate::common::{generate, generate_trimesh_around_origin, unref};
 use na::Isometry3;
 use parry3d::bounding_volume::BoundingVolume;
-use parry3d::bounding_volume::{BoundingSphere, AABB};
+use parry3d::bounding_volume::{Aabb, BoundingSphere};
 use parry3d::shape::{
     Ball, Capsule, Cone, ConvexHull, Cuboid, Cylinder, Segment, TriMesh, Triangle,
 };
@@ -19,8 +19,8 @@ mod macros;
 bench_method!(
     bench_aabb_intersects_aabb_always_true,
     intersects,
-    aabb1: AABB,
-    aabb2: AABB
+    aabb1: Aabb,
+    aabb2: Aabb
 );
 bench_method!(
     bench_bounding_sphere_intersects_bounding_sphere_always_true,
@@ -29,7 +29,7 @@ bench_method!(
     bs2: BoundingSphere
 );
 
-bench_method!(bench_aabb_contains_aabb, contains, aabb1: AABB, aabb2: AABB);
+bench_method!(bench_aabb_contains_aabb, contains, aabb1: Aabb, aabb2: Aabb);
 bench_method!(
     bench_bounding_sphere_contains_bounding_sphere,
     contains,
@@ -37,7 +37,7 @@ bench_method!(
     bs2: BoundingSphere
 );
 
-bench_method!(bench_aabb_merged_aabb, merged, aabb1: AABB, aabb2: AABB);
+bench_method!(bench_aabb_merged_aabb, merged, aabb1: Aabb, aabb2: Aabb);
 bench_method!(
     bench_bounding_sphere_merged_bounding_sphere,
     merged,
@@ -45,7 +45,7 @@ bench_method!(
     bs2: BoundingSphere
 );
 
-bench_method!(bench_aabb_loosened_aabb, loosened, aabb1: AABB, margin: f32);
+bench_method!(bench_aabb_loosened_aabb, loosened, aabb1: Aabb, margin: f32);
 bench_method!(
     bench_bounding_sphere_loosened_bounding_sphere,
     loosened,
@@ -56,7 +56,7 @@ bench_method!(
 /*
  * Bounding volume construction.
  */
-bench_method!(bench_cuboid_aabb, aabb: AABB, c: Cuboid, m: Isometry3<f32>);
+bench_method!(bench_cuboid_aabb, aabb: Aabb, c: Cuboid, m: Isometry3<f32>);
 bench_method!(
     bench_cuboid_bounding_sphere,
     bounding_sphere: BoundingSphere,
@@ -64,7 +64,7 @@ bench_method!(
     m: Isometry3<f32>
 );
 
-bench_method!(bench_ball_aabb, aabb: AABB, b: Ball, m: Isometry3<f32>);
+bench_method!(bench_ball_aabb, aabb: Aabb, b: Ball, m: Isometry3<f32>);
 bench_method!(
     bench_ball_bounding_sphere,
     bounding_sphere: BoundingSphere,
@@ -74,7 +74,7 @@ bench_method!(
 
 bench_method!(
     bench_capsule_aabb,
-    aabb: AABB,
+    aabb: Aabb,
     c: Capsule,
     m: Isometry3<f32>
 );
@@ -85,7 +85,7 @@ bench_method!(
     m: Isometry3<f32>
 );
 
-bench_method!(bench_cone_aabb, aabb: AABB, c: Cone, m: Isometry3<f32>);
+bench_method!(bench_cone_aabb, aabb: Aabb, c: Cone, m: Isometry3<f32>);
 bench_method!(
     bench_cone_bounding_sphere,
     bounding_sphere: BoundingSphere,
@@ -95,7 +95,7 @@ bench_method!(
 
 bench_method!(
     bench_cylinder_aabb,
-    aabb: AABB,
+    aabb: Aabb,
     c: Cylinder,
     m: Isometry3<f32>
 );
@@ -108,7 +108,7 @@ bench_method!(
 
 bench_method!(
     bench_segment_aabb,
-    aabb: AABB,
+    aabb: Aabb,
     c: Segment,
     m: Isometry3<f32>
 );
@@ -121,7 +121,7 @@ bench_method!(
 
 bench_method!(
     bench_triangle_aabb,
-    aabb: AABB,
+    aabb: Aabb,
     c: Triangle,
     m: Isometry3<f32>
 );
@@ -134,7 +134,7 @@ bench_method!(
 
 bench_method!(
     bench_convex_aabb,
-    aabb: AABB,
+    aabb: Aabb,
     c: ConvexHull,
     m: Isometry3<f32>
 );
@@ -147,7 +147,7 @@ bench_method!(
 
 bench_method_gen!(
     bench_mesh_aabb,
-    aabb: AABB,
+    aabb: Aabb,
     mesh: TriMesh = generate_trimesh_around_origin,
     m: Isometry3<f32> = generate
 );

--- a/crates/parry3d/benches/common/default_gen.rs
+++ b/crates/parry3d/benches/common/default_gen.rs
@@ -2,7 +2,7 @@ use na::{
     self, Isometry2, Isometry3, Matrix2, Matrix3, Matrix4, Point2, Point3, Point4, RealField,
     Vector2, Vector3, Vector4,
 };
-use parry3d::bounding_volume::{BoundingSphere, AABB};
+use parry3d::bounding_volume::{Aabb, BoundingSphere};
 use parry3d::math::{Point, Real, Vector};
 use parry3d::query::Ray;
 use parry3d::shape::{Ball, Capsule, Cone, ConvexHull, Cuboid, Cylinder, Segment, Triangle};
@@ -140,14 +140,14 @@ where
     }
 }
 
-impl DefaultGen for AABB
+impl DefaultGen for Aabb
 where
     Standard: Distribution<Vector<Real>>,
 {
-    fn generate<R: Rng>(rng: &mut R) -> AABB {
-        // an AABB centered at the origin.
+    fn generate<R: Rng>(rng: &mut R) -> Aabb {
+        // an Aabb centered at the origin.
         let half_extents = rng.gen::<Vector<Real>>().abs();
-        AABB::new(
+        Aabb::new(
             Point::origin() + (-half_extents),
             Point::origin() + half_extents,
         )

--- a/crates/parry3d/benches/query/ray.rs
+++ b/crates/parry3d/benches/query/ray.rs
@@ -1,6 +1,6 @@
 use crate::common::{generate, generate_trimesh_around_origin, unref};
 use na::Isometry3;
-use parry3d::bounding_volume::{BoundingSphere, AABB};
+use parry3d::bounding_volume::{Aabb, BoundingSphere};
 use parry3d::query::{Ray, RayCast};
 use parry3d::shape::{
     Ball, Capsule, Cone, ConvexHull, Cuboid, Cylinder, Segment, TriMesh, Triangle,
@@ -67,7 +67,7 @@ bench_method!(
 bench_method!(
     bench_ray_against_aabb,
     cast_ray,
-    a: AABB,
+    a: Aabb,
     pos: Isometry3<f32>,
     ray: Ray,
     max_toi: f32,

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -19,15 +19,15 @@ use na::ComplexField; // for .abs()
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub struct AABB {
+pub struct Aabb {
     pub mins: Point<Real>,
     pub maxs: Point<Real>,
 }
 
-impl AABB {
-    /// The vertex indices of each edge of this AABB.
+impl Aabb {
+    /// The vertex indices of each edge of this Aabb.
     ///
-    /// This gives, for each edge of this AABB, the indices of its
+    /// This gives, for each edge of this Aabb, the indices of its
     /// vertices when taken from the `self.vertices()` array.
     /// Here is how the faces are numbered, assuming
     /// a right-handed coordinate system:
@@ -53,9 +53,9 @@ impl AABB {
         (3, 7),
     ];
 
-    /// The vertex indices of each face of this AABB.
+    /// The vertex indices of each face of this Aabb.
     ///
-    /// This gives, for each face of this AABB, the indices of its
+    /// This gives, for each face of this Aabb, the indices of its
     /// vertices when taken from the `self.vertices()` array.
     /// Here is how the faces are numbered, assuming
     /// a right-handed coordinate system:
@@ -75,20 +75,20 @@ impl AABB {
         (0, 1, 2, 3),
     ];
 
-    /// Creates a new AABB.
+    /// Creates a new Aabb.
     ///
     /// # Arguments:
     ///   * `mins` - position of the point with the smallest coordinates.
     ///   * `maxs` - position of the point with the highest coordinates. Each component of `mins`
     ///   must be smaller than the related components of `maxs`.
     #[inline]
-    pub fn new(mins: Point<Real>, maxs: Point<Real>) -> AABB {
-        AABB { mins, maxs }
+    pub fn new(mins: Point<Real>, maxs: Point<Real>) -> Aabb {
+        Aabb { mins, maxs }
     }
 
-    /// Creates an invalid AABB with `mins` components set to `Real::max_values` and `maxs`components set to `-Real::max_values`.
+    /// Creates an invalid Aabb with `mins` components set to `Real::max_values` and `maxs`components set to `-Real::max_values`.
     ///
-    /// This is often used as the initial values of some AABB merging algorithms.
+    /// This is often used as the initial values of some Aabb merging algorithms.
     #[inline]
     pub fn new_invalid() -> Self {
         Self::new(
@@ -97,13 +97,13 @@ impl AABB {
         )
     }
 
-    /// Creates a new AABB from its center and its half-extents.
+    /// Creates a new Aabb from its center and its half-extents.
     #[inline]
     pub fn from_half_extents(center: Point<Real>, half_extents: Vector<Real>) -> Self {
         Self::new(center - half_extents, center + half_extents)
     }
 
-    /// Creates a new AABB from a set of points.
+    /// Creates a new Aabb from a set of points.
     pub fn from_points<'a, I>(pts: I) -> Self
     where
         I: IntoIterator<Item = &'a Point<Real>>,
@@ -111,20 +111,20 @@ impl AABB {
         super::aabb_utils::local_point_cloud_aabb(pts)
     }
 
-    /// The center of this AABB.
+    /// The center of this Aabb.
     #[inline]
     pub fn center(&self) -> Point<Real> {
         na::center(&self.mins, &self.maxs)
     }
 
-    /// The half extents of this AABB.
+    /// The half extents of this Aabb.
     #[inline]
     pub fn half_extents(&self) -> Vector<Real> {
         let half: Real = na::convert::<f64, Real>(0.5);
         (self.maxs - self.mins) * half
     }
 
-    /// The volume of this AABB.
+    /// The volume of this Aabb.
     #[inline]
     pub fn volume(&self) -> Real {
         let extents = self.extents();
@@ -134,26 +134,26 @@ impl AABB {
         return extents.x * extents.y * extents.z;
     }
 
-    /// The extents of this AABB.
+    /// The extents of this Aabb.
     #[inline]
     pub fn extents(&self) -> Vector<Real> {
         self.maxs - self.mins
     }
 
-    /// Enlarges this AABB so it also contains the point `pt`.
+    /// Enlarges this Aabb so it also contains the point `pt`.
     pub fn take_point(&mut self, pt: Point<Real>) {
         self.mins = self.mins.coords.inf(&pt.coords).into();
         self.maxs = self.maxs.coords.sup(&pt.coords).into();
     }
 
-    /// Computes the AABB bounding `self` transformed by `m`.
+    /// Computes the Aabb bounding `self` transformed by `m`.
     #[inline]
     pub fn transform_by(&self, m: &Isometry<Real>) -> Self {
         let ls_center = self.center();
         let center = m * ls_center;
         let ws_half_extents = m.absolute_transform_vector(&self.half_extents());
 
-        AABB::new(center + (-ws_half_extents), center + ws_half_extents)
+        Aabb::new(center + (-ws_half_extents), center + ws_half_extents)
     }
 
     #[inline]
@@ -166,7 +166,7 @@ impl AABB {
         }
     }
 
-    /// The smallest bounding sphere containing this AABB.
+    /// The smallest bounding sphere containing this Aabb.
     #[inline]
     pub fn bounding_sphere(&self) -> BoundingSphere {
         let center = self.center();
@@ -186,9 +186,9 @@ impl AABB {
         true
     }
 
-    /// Computes the intersection of this AABB and another one.
-    pub fn intersection(&self, other: &AABB) -> Option<AABB> {
-        let result = AABB {
+    /// Computes the intersection of this Aabb and another one.
+    pub fn intersection(&self, other: &Aabb) -> Option<Aabb> {
+        let result = Aabb {
             mins: Point::from(self.mins.coords.sup(&other.mins.coords)),
             maxs: Point::from(self.maxs.coords.inf(&other.maxs.coords)),
         };
@@ -202,22 +202,22 @@ impl AABB {
         Some(result)
     }
 
-    /// Returns the difference between this AABB and `rhs`.
+    /// Returns the difference between this Aabb and `rhs`.
     ///
-    /// Removing another AABB from `self` will result in zero, one, or up to 4 (in 2D) or 8 (in 3D)
-    /// new smaller AABBs.
-    pub fn difference(&self, rhs: &AABB) -> ArrayVec<Self, TWO_DIM> {
+    /// Removing another Aabb from `self` will result in zero, one, or up to 4 (in 2D) or 8 (in 3D)
+    /// new smaller Aabbs.
+    pub fn difference(&self, rhs: &Aabb) -> ArrayVec<Self, TWO_DIM> {
         self.difference_with_cut_sequence(rhs).0
     }
 
-    /// Returns the difference between this AABB and `rhs`.
+    /// Returns the difference between this Aabb and `rhs`.
     ///
-    /// Removing another AABB from `self` will result in zero, one, or up to 4 (in 2D) or 8 (in 3D)
-    /// new smaller AABBs.
+    /// Removing another Aabb from `self` will result in zero, one, or up to 4 (in 2D) or 8 (in 3D)
+    /// new smaller Aabbs.
     ///
     /// # Return
-    /// This returns a pair where the first item are the new AABBs and the the second item is
-    /// the sequance of cuts applied to `self` to obtain the new AABBs. Each cut is performed
+    /// This returns a pair where the first item are the new Aabbs and the the second item is
+    /// the sequance of cuts applied to `self` to obtain the new Aabbs. Each cut is performed
     /// along one axis identified by `-1, -2, -3` for `-X, -Y, -Z` and `1, 2, 3` for `+X, +Y, +Z`, and
     /// the plane’s bias.
     /// The cuts are applied sequancially. For example, if `result.1[0]` contains `1`, then it means
@@ -229,7 +229,7 @@ impl AABB {
     /// The returned cut sequence will be empty if the aabbs are disjoint.
     pub fn difference_with_cut_sequence(
         &self,
-        rhs: &AABB,
+        rhs: &Aabb,
     ) -> (ArrayVec<Self, TWO_DIM>, ArrayVec<(i8, Real), TWO_DIM>) {
         let mut result = ArrayVec::new();
         let mut cut_sequence = ArrayVec::new();
@@ -267,7 +267,7 @@ impl AABB {
         (result, cut_sequence)
     }
 
-    /// Computes the vertices of this AABB.
+    /// Computes the vertices of this Aabb.
     #[inline]
     #[cfg(feature = "dim2")]
     pub fn vertices(&self) -> [Point<Real>; 4] {
@@ -279,7 +279,7 @@ impl AABB {
         ]
     }
 
-    /// Computes the vertices of this AABB.
+    /// Computes the vertices of this Aabb.
     #[inline]
     #[cfg(feature = "dim3")]
     pub fn vertices(&self) -> [Point<Real>; 8] {
@@ -295,69 +295,69 @@ impl AABB {
         ]
     }
 
-    /// Splits this AABB at its center, into four parts (as in a quad-tree).
+    /// Splits this Aabb at its center, into four parts (as in a quad-tree).
     #[inline]
     #[cfg(feature = "dim2")]
-    pub fn split_at_center(&self) -> [AABB; 4] {
+    pub fn split_at_center(&self) -> [Aabb; 4] {
         let center = self.center();
 
         [
-            AABB::new(self.mins, center),
-            AABB::new(
+            Aabb::new(self.mins, center),
+            Aabb::new(
                 Point::new(center.x, self.mins.y),
                 Point::new(self.maxs.x, center.y),
             ),
-            AABB::new(center, self.maxs),
-            AABB::new(
+            Aabb::new(center, self.maxs),
+            Aabb::new(
                 Point::new(self.mins.x, center.y),
                 Point::new(center.x, self.maxs.y),
             ),
         ]
     }
 
-    /// Splits this AABB at its center, into height parts (as in an octree).
+    /// Splits this Aabb at its center, into height parts (as in an octree).
     #[inline]
     #[cfg(feature = "dim3")]
-    pub fn split_at_center(&self) -> [AABB; 8] {
+    pub fn split_at_center(&self) -> [Aabb; 8] {
         let center = self.center();
 
         [
-            AABB::new(
+            Aabb::new(
                 Point::new(self.mins.x, self.mins.y, self.mins.z),
                 Point::new(center.x, center.y, center.z),
             ),
-            AABB::new(
+            Aabb::new(
                 Point::new(center.x, self.mins.y, self.mins.z),
                 Point::new(self.maxs.x, center.y, center.z),
             ),
-            AABB::new(
+            Aabb::new(
                 Point::new(center.x, center.y, self.mins.z),
                 Point::new(self.maxs.x, self.maxs.y, center.z),
             ),
-            AABB::new(
+            Aabb::new(
                 Point::new(self.mins.x, center.y, self.mins.z),
                 Point::new(center.x, self.maxs.y, center.z),
             ),
-            AABB::new(
+            Aabb::new(
                 Point::new(self.mins.x, self.mins.y, center.z),
                 Point::new(center.x, center.y, self.maxs.z),
             ),
-            AABB::new(
+            Aabb::new(
                 Point::new(center.x, self.mins.y, center.z),
                 Point::new(self.maxs.x, center.y, self.maxs.z),
             ),
-            AABB::new(
+            Aabb::new(
                 Point::new(center.x, center.y, center.z),
                 Point::new(self.maxs.x, self.maxs.y, self.maxs.z),
             ),
-            AABB::new(
+            Aabb::new(
                 Point::new(self.mins.x, center.y, center.z),
                 Point::new(center.x, self.maxs.y, self.maxs.z),
             ),
         ]
     }
 
-    /// Projects every point of AABB on an arbitrary axis.
+    /// Projects every point of Aabb on an arbitrary axis.
     pub fn project_on_axis(&self, axis: &UnitVector<Real>) -> (Real, Real) {
         let cuboid = Cuboid::new(self.half_extents());
         let shift = cuboid
@@ -453,7 +453,7 @@ impl AABB {
             bias: 0.0,
         };
 
-        // Check the 8 planar faces of the AABB.
+        // Check the 8 planar faces of the Aabb.
         let mut roots = vec![];
         let mut candidates = vec![];
 
@@ -501,31 +501,31 @@ impl AABB {
     }
 }
 
-impl BoundingVolume for AABB {
+impl BoundingVolume for Aabb {
     #[inline]
     fn center(&self) -> Point<Real> {
         self.center()
     }
 
     #[inline]
-    fn intersects(&self, other: &AABB) -> bool {
+    fn intersects(&self, other: &Aabb) -> bool {
         na::partial_le(&self.mins, &other.maxs) && na::partial_ge(&self.maxs, &other.mins)
     }
 
     #[inline]
-    fn contains(&self, other: &AABB) -> bool {
+    fn contains(&self, other: &Aabb) -> bool {
         na::partial_le(&self.mins, &other.mins) && na::partial_ge(&self.maxs, &other.maxs)
     }
 
     #[inline]
-    fn merge(&mut self, other: &AABB) {
+    fn merge(&mut self, other: &Aabb) {
         self.mins = self.mins.inf(&other.mins);
         self.maxs = self.maxs.sup(&other.maxs);
     }
 
     #[inline]
-    fn merged(&self, other: &AABB) -> AABB {
-        AABB {
+    fn merged(&self, other: &Aabb) -> Aabb {
+        Aabb {
             mins: self.mins.inf(&other.mins),
             maxs: self.maxs.sup(&other.maxs),
         }
@@ -539,9 +539,9 @@ impl BoundingVolume for AABB {
     }
 
     #[inline]
-    fn loosened(&self, amount: Real) -> AABB {
+    fn loosened(&self, amount: Real) -> Aabb {
         assert!(amount >= 0.0, "The loosening margin must be positive.");
-        AABB {
+        Aabb {
             mins: self.mins + Vector::repeat(-amount),
             maxs: self.maxs + Vector::repeat(amount),
         }
@@ -559,10 +559,10 @@ impl BoundingVolume for AABB {
     }
 
     #[inline]
-    fn tightened(&self, amount: Real) -> AABB {
+    fn tightened(&self, amount: Real) -> Aabb {
         assert!(amount >= 0.0, "The tightening margin must be positive.");
 
-        AABB::new(
+        Aabb::new(
             self.mins + Vector::repeat(amount),
             self.maxs + Vector::repeat(-amount),
         )

--- a/src/bounding_volume/aabb_ball.rs
+++ b/src/bounding_volume/aabb_ball.rs
@@ -1,11 +1,11 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::shape::Ball;
 
 /// Computes the Axis-Aligned Bounding Box of a ball transformed by `center`.
 #[inline]
-pub fn ball_aabb(center: &Point<Real>, radius: Real) -> AABB {
-    AABB::new(
+pub fn ball_aabb(center: &Point<Real>, radius: Real) -> Aabb {
+    Aabb::new(
         *center + Vector::repeat(-radius),
         *center + Vector::repeat(radius),
     )
@@ -13,22 +13,22 @@ pub fn ball_aabb(center: &Point<Real>, radius: Real) -> AABB {
 
 /// Computes the Axis-Aligned Bounding Box of a ball.
 #[inline]
-pub fn local_ball_aabb(radius: Real) -> AABB {
+pub fn local_ball_aabb(radius: Real) -> Aabb {
     let half_extents = Point::from(Vector::repeat(radius));
 
-    AABB::new(-half_extents, half_extents)
+    Aabb::new(-half_extents, half_extents)
 }
 
 impl Ball {
-    /// Computes the world-space AABB of this ball transformed by `pos`.
+    /// Computes the world-space Aabb of this ball transformed by `pos`.
     #[inline]
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
         ball_aabb(&Point::<Real>::from(pos.translation.vector), self.radius)
     }
 
-    /// Computes the local-space AABB of this ball.
+    /// Computes the local-space Aabb of this ball.
     #[inline]
-    pub fn local_aabb(&self) -> AABB {
+    pub fn local_aabb(&self) -> Aabb {
         local_ball_aabb(self.radius)
     }
 }

--- a/src/bounding_volume/aabb_capsule.rs
+++ b/src/bounding_volume/aabb_capsule.rs
@@ -1,21 +1,21 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Real, Vector};
 use crate::shape::Capsule;
 
 impl Capsule {
     /// The axis-aligned bounding box of this capsule.
     #[inline]
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
         self.transform_by(pos).local_aabb()
     }
 
     /// The axis-aligned bounding box of this capsule.
     #[inline]
-    pub fn local_aabb(&self) -> AABB {
+    pub fn local_aabb(&self) -> Aabb {
         let a = self.segment.a;
         let b = self.segment.b;
         let mins = a.coords.inf(&b.coords) - Vector::repeat(self.radius);
         let maxs = a.coords.sup(&b.coords) + Vector::repeat(self.radius);
-        AABB::new(mins.into(), maxs.into())
+        Aabb::new(mins.into(), maxs.into())
     }
 }

--- a/src/bounding_volume/aabb_convex_polygon.rs
+++ b/src/bounding_volume/aabb_convex_polygon.rs
@@ -1,17 +1,17 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Real};
 use crate::shape::ConvexPolygon;
 
 impl ConvexPolygon {
-    /// Computes the world-space AABB of this convex polygon, transformed by `pos`.
+    /// Computes the world-space Aabb of this convex polygon, transformed by `pos`.
     #[inline]
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
         super::details::point_cloud_aabb(pos, self.points())
     }
 
-    /// Computes the local-space AABB of this convex polygon.
+    /// Computes the local-space Aabb of this convex polygon.
     #[inline]
-    pub fn local_aabb(&self) -> AABB {
+    pub fn local_aabb(&self) -> Aabb {
         super::details::local_point_cloud_aabb(self.points())
     }
 }

--- a/src/bounding_volume/aabb_convex_polyhedron.rs
+++ b/src/bounding_volume/aabb_convex_polyhedron.rs
@@ -1,17 +1,17 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Real};
 use crate::shape::ConvexPolyhedron;
 
 impl ConvexPolyhedron {
-    /// Computes the world-space AABB of this convex polyhedron, transformed by `pos`.
+    /// Computes the world-space Aabb of this convex polyhedron, transformed by `pos`.
     #[inline]
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
         super::details::point_cloud_aabb(pos, self.points())
     }
 
-    /// Computes the local-space AABB of this convex polyhedron.
+    /// Computes the local-space Aabb of this convex polyhedron.
     #[inline]
-    pub fn local_aabb(&self) -> AABB {
+    pub fn local_aabb(&self) -> Aabb {
         super::details::local_point_cloud_aabb(self.points())
     }
 }

--- a/src/bounding_volume/aabb_cuboid.rs
+++ b/src/bounding_volume/aabb_cuboid.rs
@@ -1,23 +1,23 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Point, Real};
 use crate::shape::Cuboid;
 use crate::utils::IsometryOps;
 
 impl Cuboid {
-    /// Computes the world-space AABB of this cuboid, transformed by `pos`.
+    /// Computes the world-space Aabb of this cuboid, transformed by `pos`.
     #[inline]
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
         let center = Point::from(pos.translation.vector);
         let ws_half_extents = pos.absolute_transform_vector(&self.half_extents);
 
-        AABB::from_half_extents(center, ws_half_extents)
+        Aabb::from_half_extents(center, ws_half_extents)
     }
 
-    /// Computes the local-space AABB of this cuboid.
+    /// Computes the local-space Aabb of this cuboid.
     #[inline]
-    pub fn local_aabb(&self) -> AABB {
+    pub fn local_aabb(&self) -> Aabb {
         let half_extents = Point::from(self.half_extents);
 
-        AABB::new(-half_extents, half_extents)
+        Aabb::new(-half_extents, half_extents)
     }
 }

--- a/src/bounding_volume/aabb_halfspace.rs
+++ b/src/bounding_volume/aabb_halfspace.rs
@@ -1,22 +1,22 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Point, Real};
 use crate::num::Bounded;
 use crate::shape::HalfSpace;
 use na;
 
 impl HalfSpace {
-    /// Computes the world-space AABB of this half-space.
+    /// Computes the world-space Aabb of this half-space.
     #[inline]
-    pub fn aabb(&self, _pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, _pos: &Isometry<Real>) -> Aabb {
         self.local_aabb()
     }
 
-    /// Computes the local-space AABB of this half-space.
+    /// Computes the local-space Aabb of this half-space.
     #[inline]
-    pub fn local_aabb(&self) -> AABB {
+    pub fn local_aabb(&self) -> Aabb {
         // We divide by 2.0  so that we can still make some operations with it (like loosening)
         // without breaking the box.
         let max = Point::max_value() * na::convert::<f64, Real>(0.5f64);
-        AABB::new(-max, max)
+        Aabb::new(-max, max)
     }
 }

--- a/src/bounding_volume/aabb_heightfield.rs
+++ b/src/bounding_volume/aabb_heightfield.rs
@@ -1,17 +1,17 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Real};
 use crate::shape::{GenericHeightField, HeightFieldStorage};
 
 impl<Storage: HeightFieldStorage> GenericHeightField<Storage> {
-    /// Computes the world-space AABB of this heightfield, transformed by `pos`.
+    /// Computes the world-space Aabb of this heightfield, transformed by `pos`.
     #[inline]
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
         self.root_aabb().transform_by(pos)
     }
 
-    /// Computes the local-space AABB of this heightfield.
+    /// Computes the local-space Aabb of this heightfield.
     #[inline]
-    pub fn local_aabb(&self) -> AABB {
+    pub fn local_aabb(&self) -> Aabb {
         self.root_aabb().clone()
     }
 }

--- a/src/bounding_volume/aabb_heightfield.rs
+++ b/src/bounding_volume/aabb_heightfield.rs
@@ -1,12 +1,8 @@
 use crate::bounding_volume::AABB;
 use crate::math::{Isometry, Real};
-use crate::shape::{GenericHeightField, HeightFieldCellStatus, HeightFieldStorage};
+use crate::shape::{GenericHeightField, HeightFieldStorage};
 
-impl<Heights, Status> GenericHeightField<Heights, Status>
-where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
-{
+impl<Storage: HeightFieldStorage> GenericHeightField<Storage> {
     /// Computes the world-space AABB of this heightfield, transformed by `pos`.
     #[inline]
     pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {

--- a/src/bounding_volume/aabb_support_map.rs
+++ b/src/bounding_volume/aabb_support_map.rs
@@ -1,5 +1,5 @@
 use crate::bounding_volume;
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Real};
 use crate::shape::Segment;
 #[cfg(feature = "dim3")]
@@ -7,44 +7,44 @@ use crate::shape::{Cone, Cylinder};
 
 #[cfg(feature = "dim3")]
 impl Cone {
-    /// Computes the world-space AABB of this cone, transformed by `pos`.
+    /// Computes the world-space Aabb of this cone, transformed by `pos`.
     #[inline]
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
         bounding_volume::details::support_map_aabb(pos, self)
     }
 
-    /// Computes the local-space AABB of this cone.
+    /// Computes the local-space Aabb of this cone.
     #[inline]
-    pub fn local_aabb(&self) -> AABB {
+    pub fn local_aabb(&self) -> Aabb {
         bounding_volume::details::local_support_map_aabb(self)
     }
 }
 
 #[cfg(feature = "dim3")]
 impl Cylinder {
-    /// Computes the world-space AABB of this cylinder, transformed by `pos`.
+    /// Computes the world-space Aabb of this cylinder, transformed by `pos`.
     #[inline]
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
         bounding_volume::details::support_map_aabb(pos, self)
     }
 
-    /// Computes the local-space AABB of this cylinder.
+    /// Computes the local-space Aabb of this cylinder.
     #[inline]
-    pub fn local_aabb(&self) -> AABB {
+    pub fn local_aabb(&self) -> Aabb {
         bounding_volume::details::local_support_map_aabb(self)
     }
 }
 
 impl Segment {
-    /// Computes the world-space AABB of this segment, transformed by `pos`.
+    /// Computes the world-space Aabb of this segment, transformed by `pos`.
     #[inline]
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
         self.transformed(pos).local_aabb()
     }
 
-    /// Computes the local-space AABB of this segment.
+    /// Computes the local-space Aabb of this segment.
     #[inline]
-    pub fn local_aabb(&self) -> AABB {
+    pub fn local_aabb(&self) -> Aabb {
         bounding_volume::details::local_support_map_aabb(self)
     }
 }

--- a/src/bounding_volume/aabb_triangle.rs
+++ b/src/bounding_volume/aabb_triangle.rs
@@ -1,19 +1,19 @@
 use crate::{
-    bounding_volume::AABB,
+    bounding_volume::Aabb,
     math::{Isometry, Point, Real, DIM},
     shape::Triangle,
 };
 
 impl Triangle {
-    /// Computes the world-space AABB of this triangle, transformed by `pos`.
+    /// Computes the world-space Aabb of this triangle, transformed by `pos`.
     #[inline]
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
         self.transformed(pos).local_aabb()
     }
 
-    /// Computes the local-space AABB of this triangle.
+    /// Computes the local-space Aabb of this triangle.
     #[inline]
-    pub fn local_aabb(&self) -> AABB {
+    pub fn local_aabb(&self) -> Aabb {
         let a = self.a.coords;
         let b = self.b.coords;
         let c = self.c.coords;
@@ -26,7 +26,7 @@ impl Triangle {
             max.coords[d] = a[d].max(b[d]).max(c[d]);
         }
 
-        AABB::new(min, max)
+        Aabb::new(min, max)
     }
 }
 
@@ -55,7 +55,7 @@ mod test {
 
         assert_eq!(t.aabb(&m), support_map_aabb(&m, &t));
 
-        // TODO: also test local AABB once support maps have a local AABB
+        // TODO: also test local Aabb once support maps have a local Aabb
         // function too
     }
 }

--- a/src/bounding_volume/aabb_utils.rs
+++ b/src/bounding_volume/aabb_utils.rs
@@ -1,13 +1,13 @@
 use std::iter::IntoIterator;
 
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Point, Real, Vector, DIM};
 use crate::shape::SupportMap;
 use na;
 
-/// Computes the AABB of an support mapped shape.
+/// Computes the Aabb of an support mapped shape.
 #[cfg(feature = "dim3")]
-pub fn support_map_aabb<G>(m: &Isometry<Real>, i: &G) -> AABB
+pub fn support_map_aabb<G>(m: &Isometry<Real>, i: &G) -> Aabb
 where
     G: SupportMap,
 {
@@ -27,11 +27,11 @@ where
         basis[d] = 0.0;
     }
 
-    AABB::new(Point::from(min), Point::from(max))
+    Aabb::new(Point::from(min), Point::from(max))
 }
 
-/// Computes the AABB of an support mapped shape.
-pub fn local_support_map_aabb<G>(i: &G) -> AABB
+/// Computes the Aabb of an support mapped shape.
+pub fn local_support_map_aabb<G>(i: &G) -> Aabb
 where
     G: SupportMap,
 {
@@ -51,18 +51,18 @@ where
         basis[d] = 0.0;
     }
 
-    AABB::new(Point::from(min), Point::from(max))
+    Aabb::new(Point::from(min), Point::from(max))
 }
 
-/// Computes the AABB of a set of points transformed by `m`.
-pub fn point_cloud_aabb<'a, I>(m: &Isometry<Real>, pts: I) -> AABB
+/// Computes the Aabb of a set of points transformed by `m`.
+pub fn point_cloud_aabb<'a, I>(m: &Isometry<Real>, pts: I) -> Aabb
 where
     I: IntoIterator<Item = &'a Point<Real>>,
 {
     let mut it = pts.into_iter();
 
     let p0 = it.next().expect(
-        "Point cloud AABB construction: the input iterator should yield at least one point.",
+        "Point cloud Aabb construction: the input iterator should yield at least one point.",
     );
     let wp0 = m.transform_point(&p0);
     let mut min: Point<Real> = wp0;
@@ -74,18 +74,18 @@ where
         max = max.sup(&wpt);
     }
 
-    AABB::new(min, max)
+    Aabb::new(min, max)
 }
 
-/// Computes the AABB of a set of points.
-pub fn local_point_cloud_aabb<'a, I>(pts: I) -> AABB
+/// Computes the Aabb of a set of points.
+pub fn local_point_cloud_aabb<'a, I>(pts: I) -> Aabb
 where
     I: IntoIterator<Item = &'a Point<Real>>,
 {
     let mut it = pts.into_iter();
 
     let p0 = it.next().expect(
-        "Point cloud AABB construction: the input iterator should yield at least one point.",
+        "Point cloud Aabb construction: the input iterator should yield at least one point.",
     );
     let mut min: Point<Real> = *p0;
     let mut max: Point<Real> = *p0;
@@ -95,5 +95,5 @@ where
         max = max.sup(&pt);
     }
 
-    AABB::new(min, max)
+    Aabb::new(min, max)
 }

--- a/src/bounding_volume/bounding_sphere_ball.rs
+++ b/src/bounding_volume/bounding_sphere_ball.rs
@@ -10,7 +10,7 @@ impl Ball {
         bv.transform_by(pos)
     }
 
-    /// Computes the local-space AABB of this ball.
+    /// Computes the local-space Aabb of this ball.
     #[inline]
     pub fn local_bounding_sphere(&self) -> BoundingSphere {
         BoundingSphere::new(Point::origin(), self.radius)

--- a/src/bounding_volume/bounding_sphere_heightfield.rs
+++ b/src/bounding_volume/bounding_sphere_heightfield.rs
@@ -1,12 +1,8 @@
 use crate::bounding_volume::BoundingSphere;
 use crate::math::{Isometry, Real};
-use crate::shape::{GenericHeightField, HeightFieldCellStatus, HeightFieldStorage};
+use crate::shape::{GenericHeightField, HeightFieldStorage};
 
-impl<Heights, Status> GenericHeightField<Heights, Status>
-where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
-{
+impl<Storage: HeightFieldStorage> GenericHeightField<Storage> {
     /// Computes the world-space bounding sphere of this height-field, transformed by `pos`.
     #[inline]
     pub fn bounding_sphere(&self, pos: &Isometry<Real>) -> BoundingSphere {

--- a/src/bounding_volume/mod.rs
+++ b/src/bounding_volume/mod.rs
@@ -1,8 +1,8 @@
 //! Bounding volumes.
 
 #[doc(inline)]
-pub use crate::bounding_volume::aabb::AABB;
-pub use crate::bounding_volume::simd_aabb::SimdAABB;
+pub use crate::bounding_volume::aabb::Aabb;
+pub use crate::bounding_volume::simd_aabb::SimdAabb;
 
 #[doc(inline)]
 pub use crate::bounding_volume::bounding_sphere::BoundingSphere;

--- a/src/bounding_volume/simd_aabb.rs
+++ b/src/bounding_volume/simd_aabb.rs
@@ -11,6 +11,7 @@ use simba::simd::{SimdPartialOrd, SimdValue};
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
+#[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct SimdAABB {
     /// The min coordinates of the AABBs.
     pub mins: Point<SimdReal>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ pub extern crate simba;
 
 pub mod bounding_volume;
 pub mod mass_properties;
-#[cfg(feature = "std")]
 pub mod partitioning;
 pub mod query;
 pub mod shape;

--- a/src/partitioning/mod.rs
+++ b/src/partitioning/mod.rs
@@ -1,9 +1,9 @@
 //! Spatial partitioning tools.
 
 #[cfg(feature = "std")]
-pub use self::qbvh::{CenterDataSplitter, QBVHDataGenerator, QBVHNonOverlappingDataSplitter};
+pub use self::qbvh::{CenterDataSplitter, QbvhDataGenerator, QbvhNonOverlappingDataSplitter};
 pub use self::qbvh::{
-    GenericQBVH, IndexedData, NodeIndex, QBVHNode, QBVHProxy, QBVHStorage, SimdNodeIndex, QBVH,
+    GenericQbvh, IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhProxy, QbvhStorage, SimdNodeIndex,
 };
 #[cfg(feature = "parallel")]
 pub use self::visitor::{ParallelSimdSimultaneousVisitor, ParallelSimdVisitor};
@@ -13,8 +13,8 @@ pub use self::visitor::{
 };
 
 /// A quaternary bounding-volume-hierarchy.
-#[deprecated(note = "Renamed to QBVH")]
-pub type SimdQBVH<T> = QBVH<T>;
+#[deprecated(note = "Renamed to Qbvh")]
+pub type SimdQbvh<T> = Qbvh<T>;
 
 mod qbvh;
 mod visitor;

--- a/src/partitioning/mod.rs
+++ b/src/partitioning/mod.rs
@@ -1,8 +1,9 @@
 //! Spatial partitioning tools.
 
+#[cfg(feature = "std")]
+pub use self::qbvh::{CenterDataSplitter, QBVHDataGenerator, QBVHNonOverlappingDataSplitter};
 pub use self::qbvh::{
-    CenterDataSplitter, IndexedData, NodeIndex, QBVHDataGenerator, QBVHNode, QBVHProxy,
-    QbvhNonOverlappingDataSplitter, SimdNodeIndex, QBVH,
+    GenericQBVH, IndexedData, NodeIndex, QBVHNode, QBVHProxy, QBVHStorage, SimdNodeIndex, QBVH,
 };
 #[cfg(feature = "parallel")]
 pub use self::visitor::{ParallelSimdSimultaneousVisitor, ParallelSimdVisitor};
@@ -13,7 +14,7 @@ pub use self::visitor::{
 
 /// A quaternary bounding-volume-hierarchy.
 #[deprecated(note = "Renamed to QBVH")]
-pub type SimdQbvh<T> = QBVH<T>;
+pub type SimdQBVH<T> = QBVH<T>;
 
 mod qbvh;
 mod visitor;

--- a/src/partitioning/qbvh/build.rs
+++ b/src/partitioning/qbvh/build.rs
@@ -115,14 +115,14 @@ impl CenterDataSplitter {
 /// can intersect slightly at their boundaries with an error of `epsilon`). Given this set,
 /// the QBVH constructed using this splitter will be such that no pair of intermediate nodes
 /// with the same depth have overlapping AABBs.
-pub struct QbvhNonOverlappingDataSplitter<F> {
+pub struct QBVHNonOverlappingDataSplitter<F> {
     /// The leaf data-splitting function.
     pub canonical_split: F,
     /// Allowed overlap between two leaf AABBs.
     pub epsilon: Real,
 }
 
-impl<LeafData, F> QBVHDataSplitter<LeafData> for QbvhNonOverlappingDataSplitter<F>
+impl<LeafData, F> QBVHDataSplitter<LeafData> for QBVHNonOverlappingDataSplitter<F>
 where
     LeafData: IndexedData,
     F: FnMut(LeafData, usize, Real, Real, AABB, AABB) -> SplitResult<(LeafData, AABB)>,

--- a/src/partitioning/qbvh/mod.rs
+++ b/src/partitioning/qbvh/mod.rs
@@ -1,10 +1,22 @@
+#[cfg(feature = "std")]
 pub use self::build::{
-    BuilderProxies, CenterDataSplitter, QBVHDataGenerator, QbvhNonOverlappingDataSplitter,
+    BuilderProxies, CenterDataSplitter, QBVHDataGenerator, QBVHNonOverlappingDataSplitter,
 };
-pub use self::qbvh::{IndexedData, NodeIndex, QBVHNode, QBVHProxy, SimdNodeIndex, QBVH};
 
-mod build;
+pub use self::qbvh::{
+    GenericQBVH, IndexedData, NodeIndex, QBVHNode, QBVHProxy, SimdNodeIndex, QBVH,
+};
+pub use self::storage::QBVHStorage;
+
 mod qbvh;
-mod traversal;
-mod update;
+mod storage;
 pub(self) mod utils;
+
+#[cfg(feature = "std")]
+mod build;
+#[cfg(feature = "std")]
+mod traversal;
+#[cfg(not(feature = "std"))]
+mod traversal_no_std;
+#[cfg(feature = "std")]
+mod update;

--- a/src/partitioning/qbvh/mod.rs
+++ b/src/partitioning/qbvh/mod.rs
@@ -1,12 +1,12 @@
 #[cfg(feature = "std")]
 pub use self::build::{
-    BuilderProxies, CenterDataSplitter, QBVHDataGenerator, QBVHNonOverlappingDataSplitter,
+    BuilderProxies, CenterDataSplitter, QbvhDataGenerator, QbvhNonOverlappingDataSplitter,
 };
 
 pub use self::qbvh::{
-    GenericQBVH, IndexedData, NodeIndex, QBVHNode, QBVHProxy, SimdNodeIndex, QBVH,
+    GenericQbvh, IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhProxy, SimdNodeIndex,
 };
-pub use self::storage::QBVHStorage;
+pub use self::storage::QbvhStorage;
 
 mod qbvh;
 mod storage;

--- a/src/partitioning/qbvh/qbvh.rs
+++ b/src/partitioning/qbvh/qbvh.rs
@@ -156,10 +156,15 @@ pub struct GenericQBVH<LeafData, Storage: QBVHStorage<LeafData>> {
     pub(super) proxies: Storage::ArrayProxies,
 }
 
+/// A quaternary bounding-volume-hierarchy.
+///
+/// This is a bounding-volume-hierarchy where each node has either four children or none.
 pub type QBVH<LeafData> = GenericQBVH<LeafData, DefaultStorage>;
 #[cfg(feature = "cuda")]
+/// A QBVH stored in CUDA memory.
 pub type CudaQBVH<LeafData> = GenericQBVH<LeafData, CudaStorage>;
 #[cfg(feature = "cuda")]
+/// A QBVH accessible from CUDA kernels.
 pub type CudaQBVHPtr<LeafData> = GenericQBVH<LeafData, CudaStoragePtr>;
 
 impl<LeafData, Storage> Clone for GenericQBVH<LeafData, Storage>

--- a/src/partitioning/qbvh/storage.rs
+++ b/src/partitioning/qbvh/storage.rs
@@ -1,4 +1,4 @@
-use crate::partitioning::{QBVHNode, QBVHProxy};
+use crate::partitioning::{QbvhNode, QbvhProxy};
 use crate::utils::{Array1, DefaultStorage};
 
 #[cfg(all(feature = "std", feature = "cuda"))]
@@ -6,33 +6,33 @@ use crate::utils::CudaArray1;
 #[cfg(feature = "cuda")]
 use crate::utils::{CudaArrayPointer1, CudaStorage, CudaStoragePtr};
 
-/// Trait describing all the types needed for storing a QBVH’s data.
-pub trait QBVHStorage<LeafData> {
-    /// Type of the array containing the QBVH nodes.
-    type Nodes: Array1<QBVHNode>;
+/// Trait describing all the types needed for storing a Qbvh’s data.
+pub trait QbvhStorage<LeafData> {
+    /// Type of the array containing the Qbvh nodes.
+    type Nodes: Array1<QbvhNode>;
     /// Type of an array containing u32.
     type ArrayU32: Array1<u32>;
-    /// Type of the array containing the QBVH leaves.
-    type ArrayProxies: Array1<QBVHProxy<LeafData>>;
+    /// Type of the array containing the Qbvh leaves.
+    type ArrayProxies: Array1<QbvhProxy<LeafData>>;
 }
 
 #[cfg(feature = "std")]
-impl<LeafData> QBVHStorage<LeafData> for DefaultStorage {
-    type Nodes = Vec<QBVHNode>;
+impl<LeafData> QbvhStorage<LeafData> for DefaultStorage {
+    type Nodes = Vec<QbvhNode>;
     type ArrayU32 = Vec<u32>;
-    type ArrayProxies = Vec<QBVHProxy<LeafData>>;
+    type ArrayProxies = Vec<QbvhProxy<LeafData>>;
 }
 
 #[cfg(all(feature = "std", feature = "cuda"))]
-impl<LeafData: cust_core::DeviceCopy> QBVHStorage<LeafData> for CudaStorage {
-    type Nodes = CudaArray1<QBVHNode>;
+impl<LeafData: cust_core::DeviceCopy> QbvhStorage<LeafData> for CudaStorage {
+    type Nodes = CudaArray1<QbvhNode>;
     type ArrayU32 = CudaArray1<u32>;
-    type ArrayProxies = CudaArray1<QBVHProxy<LeafData>>;
+    type ArrayProxies = CudaArray1<QbvhProxy<LeafData>>;
 }
 
 #[cfg(feature = "cuda")]
-impl<LeafData: cust_core::DeviceCopy> QBVHStorage<LeafData> for CudaStoragePtr {
-    type Nodes = CudaArrayPointer1<QBVHNode>;
+impl<LeafData: cust_core::DeviceCopy> QbvhStorage<LeafData> for CudaStoragePtr {
+    type Nodes = CudaArrayPointer1<QbvhNode>;
     type ArrayU32 = CudaArrayPointer1<u32>;
-    type ArrayProxies = CudaArrayPointer1<QBVHProxy<LeafData>>;
+    type ArrayProxies = CudaArrayPointer1<QbvhProxy<LeafData>>;
 }

--- a/src/partitioning/qbvh/storage.rs
+++ b/src/partitioning/qbvh/storage.rs
@@ -6,9 +6,13 @@ use crate::utils::CudaArray1;
 #[cfg(feature = "cuda")]
 use crate::utils::{CudaArrayPointer1, CudaStorage, CudaStoragePtr};
 
+/// Trait describing all the types needed for storing a QBVH’s data.
 pub trait QBVHStorage<LeafData> {
+    /// Type of the array containing the QBVH nodes.
     type Nodes: Array1<QBVHNode>;
+    /// Type of an array containing u32.
     type ArrayU32: Array1<u32>;
+    /// Type of the array containing the QBVH leaves.
     type ArrayProxies: Array1<QBVHProxy<LeafData>>;
 }
 

--- a/src/partitioning/qbvh/storage.rs
+++ b/src/partitioning/qbvh/storage.rs
@@ -1,0 +1,34 @@
+use crate::partitioning::{QBVHNode, QBVHProxy};
+use crate::utils::{Array1, DefaultStorage};
+
+#[cfg(all(feature = "std", feature = "cuda"))]
+use crate::utils::CudaArray1;
+#[cfg(feature = "cuda")]
+use crate::utils::{CudaArrayPointer1, CudaStorage, CudaStoragePtr};
+
+pub trait QBVHStorage<LeafData> {
+    type Nodes: Array1<QBVHNode>;
+    type ArrayU32: Array1<u32>;
+    type ArrayProxies: Array1<QBVHProxy<LeafData>>;
+}
+
+#[cfg(feature = "std")]
+impl<LeafData> QBVHStorage<LeafData> for DefaultStorage {
+    type Nodes = Vec<QBVHNode>;
+    type ArrayU32 = Vec<u32>;
+    type ArrayProxies = Vec<QBVHProxy<LeafData>>;
+}
+
+#[cfg(all(feature = "std", feature = "cuda"))]
+impl<LeafData: cust_core::DeviceCopy> QBVHStorage<LeafData> for CudaStorage {
+    type Nodes = CudaArray1<QBVHNode>;
+    type ArrayU32 = CudaArray1<u32>;
+    type ArrayProxies = CudaArray1<QBVHProxy<LeafData>>;
+}
+
+#[cfg(feature = "cuda")]
+impl<LeafData: cust_core::DeviceCopy> QBVHStorage<LeafData> for CudaStoragePtr {
+    type Nodes = CudaArrayPointer1<QBVHNode>;
+    type ArrayU32 = CudaArrayPointer1<u32>;
+    type ArrayProxies = CudaArrayPointer1<QBVHProxy<LeafData>>;
+}

--- a/src/partitioning/qbvh/traversal_no_std.rs
+++ b/src/partitioning/qbvh/traversal_no_std.rs
@@ -1,0 +1,187 @@
+use crate::bounding_volume::{SimdAABB, AABB};
+use crate::math::Real;
+use crate::partitioning::visitor::SimdSimultaneousVisitStatus;
+use crate::partitioning::{
+    GenericQBVH, QBVHStorage, SimdBestFirstVisitStatus, SimdBestFirstVisitor,
+    SimdSimultaneousVisitor, SimdVisitStatus, SimdVisitor,
+};
+use crate::simd::SIMD_WIDTH;
+use crate::utils::{Array1, WeightedValue};
+use arrayvec::ArrayVec;
+use num::Bounded;
+use simba::simd::SimdBool;
+
+use super::{IndexedData, NodeIndex, QBVH};
+
+impl<LeafData: IndexedData, Storage: QBVHStorage<LeafData>> GenericQBVH<LeafData, Storage> {
+    /// Performs a depth-first traversal on the BVH.
+    ///
+    /// # Return
+    ///
+    /// Returns `false` if the traversal exited early, and `true` otherwise.
+    pub fn traverse_depth_first(&self, visitor: &mut impl SimdVisitor<LeafData, SimdAABB>) -> bool {
+        self.traverse_depth_first_node(visitor, 0)
+    }
+
+    /// Performs a depth-first traversal on the BVH starting at the given node.
+    ///
+    /// # Return
+    ///
+    /// Returns `false` if the traversal exited early, and `true` otherwise.
+    pub fn traverse_depth_first_node(
+        &self,
+        visitor: &mut impl SimdVisitor<LeafData, SimdAABB>,
+        curr_node: u32,
+    ) -> bool {
+        let node = &self.nodes[curr_node as usize];
+        let leaf_data = if node.leaf {
+            Some(
+                array![|ii| Some(&self.proxies.get_at(node.children[ii] as usize)?.data); SIMD_WIDTH],
+            )
+        } else {
+            None
+        };
+
+        match visitor.visit(&node.simd_aabb, leaf_data) {
+            SimdVisitStatus::ExitEarly => {
+                return false;
+            }
+            SimdVisitStatus::MaybeContinue(mask) => {
+                let bitmask = mask.bitmask();
+
+                for ii in 0..SIMD_WIDTH {
+                    if (bitmask & (1 << ii)) != 0 {
+                        if !node.leaf {
+                            // Internal node, visit the child.
+                            // Unfortunately, we have this check because invalid AABBs
+                            // return a hit as well.
+                            if node.children[ii] as usize <= self.nodes.len() {
+                                if !self.traverse_depth_first_node(visitor, node.children[ii]) {
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        true
+    }
+
+    /// Performs a best-first-search on the BVH.
+    ///
+    /// Returns the content of the leaf with the smallest associated cost, and a result of
+    /// user-defined type.
+    pub fn traverse_best_first<BFS>(&self, visitor: &mut BFS) -> Option<(NodeIndex, BFS::Result)>
+    where
+        BFS: SimdBestFirstVisitor<LeafData, SimdAABB>,
+        BFS::Result: Clone, // Because we cannot move out of an array…
+    {
+        self.traverse_best_first_node(visitor, 0, Real::MAX)
+    }
+
+    /// Performs a best-first-search on the BVH.
+    ///
+    /// Returns the content of the leaf with the smallest associated cost, and a result of
+    /// user-defined type.
+    pub fn traverse_best_first_node<BFS>(
+        &self,
+        visitor: &mut BFS,
+        start_node: u32,
+        init_cost: Real,
+    ) -> Option<(NodeIndex, BFS::Result)>
+    where
+        BFS: SimdBestFirstVisitor<LeafData, SimdAABB>,
+        BFS::Result: Clone, // Because we cannot move out of an array…
+    {
+        if self.nodes.is_empty() {
+            return None;
+        }
+
+        let mut best_cost = init_cost;
+        let mut result = None;
+
+        // NOTE: a stack with 64 elements is enough for a depth-first search
+        //       on a tree with up to about 4.000.000.000 triangles.
+        //       See https://math.stackexchange.com/a/2739663 for the max
+        //       stack depth on a depth-first search.
+        let mut stack: ArrayVec<_, 64> = ArrayVec::new();
+        stack.push(WeightedValue::new(start_node, -best_cost / 2.0));
+
+        self.traverse_best_first_node_recursive(visitor, &mut stack, &mut best_cost, &mut result);
+        result
+    }
+
+    fn traverse_best_first_node_recursive<BFS>(
+        &self,
+        visitor: &mut BFS,
+        stack: &mut ArrayVec<WeightedValue<u32>, 64>,
+        best_cost: &mut Real,
+        best_result: &mut Option<(NodeIndex, BFS::Result)>,
+    ) where
+        BFS: SimdBestFirstVisitor<LeafData, SimdAABB>,
+        BFS::Result: Clone, // Because we cannot move out of an array…
+    {
+        while let Some(entry) = stack.pop() {
+            // NOTE: since we are not actually allowed to allocate, we can’t use the binary heap.
+            //       So we are really just running a recursive depth-first traversal, with early
+            //       exit on the current best cost.
+            if -entry.cost >= *best_cost {
+                continue;
+            }
+
+            let node = &self.nodes[entry.value as usize];
+            let leaf_data = if node.leaf {
+                Some(
+                    array![|ii| Some(&self.proxies.get_at(node.children[ii] as usize)?.data); SIMD_WIDTH],
+                )
+            } else {
+                None
+            };
+
+            match visitor.visit(*best_cost, &node.simd_aabb, leaf_data) {
+                SimdBestFirstVisitStatus::ExitEarly(result) => {
+                    if result.is_some() {
+                        *best_result = result.map(|r| (node.parent, r));
+                        return;
+                    }
+                }
+                SimdBestFirstVisitStatus::MaybeContinue {
+                    weights,
+                    mask,
+                    results,
+                } => {
+                    let bitmask = mask.bitmask();
+                    let weights: [Real; SIMD_WIDTH] = weights.into();
+
+                    for ii in 0..SIMD_WIDTH {
+                        if (bitmask & (1 << ii)) != 0 {
+                            if node.leaf {
+                                if weights[ii] < *best_cost && results[ii].is_some() {
+                                    // We found a leaf!
+                                    if let Some(proxy) =
+                                        self.proxies.get_at(node.children[ii] as usize)
+                                    {
+                                        *best_cost = weights[ii];
+                                        *best_result =
+                                            Some((proxy.node, results[ii].clone().unwrap()))
+                                    }
+                                }
+                            } else {
+                                // Internal node, visit the child.
+                                // Unfortunately, we have this check because invalid AABBs
+                                // return a hit as well.
+                                if (node.children[ii] as usize) < self.nodes.len() {
+                                    let child_node =
+                                        WeightedValue::new(node.children[ii], -weights[ii]);
+                                    stack.push(child_node);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/partitioning/qbvh/utils.rs
+++ b/src/partitioning/qbvh/utils.rs
@@ -1,9 +1,9 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real};
 
 pub fn split_indices_wrt_dim<'a>(
     indices: &'a mut [usize],
-    aabbs: &[AABB],
+    aabbs: &[Aabb],
     split_point: &Point<Real>,
     dim: usize,
     enable_fallback_split: bool,

--- a/src/partitioning/visitor.rs
+++ b/src/partitioning/visitor.rs
@@ -1,5 +1,5 @@
 use crate::math::{Real, SimdBool, SimdReal, SIMD_WIDTH};
-use crate::partitioning::qbvh::QBVHNode;
+use crate::partitioning::qbvh::QbvhNode;
 use crate::partitioning::SimdNodeIndex;
 
 /// The next action to be taken by a BVH traversal algorithm after having visited a node with some data.
@@ -108,19 +108,19 @@ pub trait ParallelSimdVisitor<LeafData>: Sync {
     fn visit(
         &self,
         node_id: SimdNodeIndex,
-        bv: &QBVHNode,
+        bv: &QbvhNode,
         data: Option<[Option<&LeafData>; SIMD_WIDTH]>,
     ) -> SimdVisitStatus;
 }
 
 impl<F, LeafData> ParallelSimdVisitor<LeafData> for F
 where
-    F: Sync + Fn(&QBVHNode, Option<[Option<&LeafData>; SIMD_WIDTH]>) -> SimdVisitStatus,
+    F: Sync + Fn(&QbvhNode, Option<[Option<&LeafData>; SIMD_WIDTH]>) -> SimdVisitStatus,
 {
     fn visit(
         &self,
         _node_id: SimdNodeIndex,
-        node: &QBVHNode,
+        node: &QbvhNode,
         data: Option<[Option<&LeafData>; SIMD_WIDTH]>,
     ) -> SimdVisitStatus {
         (self)(node, data)
@@ -141,10 +141,10 @@ pub trait ParallelSimdSimultaneousVisitor<LeafData1, LeafData2>: Sync {
     fn visit(
         &self,
         left_node_id: SimdNodeIndex,
-        left_node: &QBVHNode,
+        left_node: &QbvhNode,
         left_data: Option<[Option<&LeafData1>; SIMD_WIDTH]>,
         right_node_id: SimdNodeIndex,
-        right_node: &QBVHNode,
+        right_node: &QbvhNode,
         right_data: Option<[Option<&LeafData2>; SIMD_WIDTH]>,
         visitor_data: Self::Data,
     ) -> (SimdSimultaneousVisitStatus, Self::Data);

--- a/src/query/clip/clip_aabb_line.rs
+++ b/src/query/clip/clip_aabb_line.rs
@@ -1,11 +1,11 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector, DIM};
 use crate::query::Ray;
 use crate::shape::Segment;
 use num::{Bounded, Zero};
 
-impl AABB {
-    /// Computes the intersection of a segment with this AABB.
+impl Aabb {
+    /// Computes the intersection of a segment with this Aabb.
     ///
     /// Returns `None` if there is no intersection.
     #[inline]
@@ -15,7 +15,7 @@ impl AABB {
             .map(|clip| Segment::new(pa + ab * (clip.0).0.max(0.0), pa + ab * (clip.1).0.min(1.0)))
     }
 
-    /// Computes the parameters of the two intersection points between a line and this AABB.
+    /// Computes the parameters of the two intersection points between a line and this Aabb.
     ///
     /// The parameters are such that the point are given by `orig + dir * parameter`.
     /// Returns `None` if there is no intersection.
@@ -28,7 +28,7 @@ impl AABB {
         clip_aabb_line(self, orig, dir).map(|clip| ((clip.0).0, (clip.1).0))
     }
 
-    /// Computes the intersection segment between a line and this AABB.
+    /// Computes the intersection segment between a line and this Aabb.
     ///
     /// Returns `None` if there is no intersection.
     #[inline]
@@ -37,7 +37,7 @@ impl AABB {
             .map(|clip| Segment::new(orig + dir * (clip.0).0, orig + dir * (clip.1).0))
     }
 
-    /// Computes the parameters of the two intersection points between a ray and this AABB.
+    /// Computes the parameters of the two intersection points between a ray and this Aabb.
     ///
     /// The parameters are such that the point are given by `ray.orig + ray.dir * parameter`.
     /// Returns `None` if there is no intersection.
@@ -56,7 +56,7 @@ impl AABB {
             })
     }
 
-    /// Computes the intersection segment between a ray and this AABB.
+    /// Computes the intersection segment between a ray and this Aabb.
     ///
     /// Returns `None` if there is no intersection.
     #[inline]
@@ -66,9 +66,9 @@ impl AABB {
     }
 }
 
-/// Computes the segment given by the intersection of a line and an AABB.
+/// Computes the segment given by the intersection of a line and an Aabb.
 pub fn clip_aabb_line(
-    aabb: &AABB,
+    aabb: &Aabb,
     origin: &Point<Real>,
     dir: &Vector<Real>,
 ) -> Option<((Real, Vector<Real>, isize), (Real, Vector<Real>, isize))> {

--- a/src/query/clip/clip_aabb_polygon.rs
+++ b/src/query/clip/clip_aabb_polygon.rs
@@ -1,8 +1,8 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 
-impl AABB {
-    /// Computes the intersections between this AABB and the given polygon.
+impl Aabb {
+    /// Computes the intersections between this Aabb and the given polygon.
     ///
     /// The results is written into `points` directly. The input points are
     /// assumed to form a convex polygon where all points lie on the same plane.
@@ -14,7 +14,7 @@ impl AABB {
         self.clip_polygon_with_workspace(points, &mut workspace)
     }
 
-    /// Computes the intersections between this AABB and the given polygon.
+    /// Computes the intersections between this Aabb and the given polygon.
     ///
     /// The results is written into `points` directly. The input points are
     /// assumed to form a convex polygon where all points lie on the same plane.

--- a/src/query/closest_points/closest_points_composite_shape_shape.rs
+++ b/src/query/closest_points/closest_points_composite_shape_shape.rs
@@ -3,7 +3,7 @@ use crate::math::{Isometry, Real, SimdBool, SimdReal, Vector, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::{ClosestPoints, QueryDispatcher};
 use crate::shape::{Shape, TypedSimdCompositeShape};
-use crate::utils::IsometryOpt;
+use crate::utils::{DefaultStorage, IsometryOpt};
 use na;
 use simba::simd::{SimdBool as _, SimdPartialOrd, SimdValue};
 
@@ -17,7 +17,7 @@ pub fn closest_points_composite_shape_shape<D: ?Sized, G1: ?Sized>(
 ) -> ClosestPoints
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     let mut visitor =
         CompositeShapeAgainstShapeClosestPointsVisitor::new(dispatcher, pos12, g1, g2, margin);
@@ -39,7 +39,7 @@ pub fn closest_points_shape_composite_shape<D: ?Sized, G2: ?Sized>(
 ) -> ClosestPoints
 where
     D: QueryDispatcher,
-    G2: TypedSimdCompositeShape,
+    G2: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     closest_points_composite_shape_shape(dispatcher, &pos12.inverse(), g2, g1, margin).flipped()
 }
@@ -59,7 +59,7 @@ pub struct CompositeShapeAgainstShapeClosestPointsVisitor<'a, D: ?Sized, G1: ?Si
 impl<'a, D: ?Sized, G1: ?Sized> CompositeShapeAgainstShapeClosestPointsVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     /// Initializes a visitor for computing the closest points between a composite-shape and a shape.
     pub fn new(
@@ -87,7 +87,7 @@ impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAABB>
     for CompositeShapeAgainstShapeClosestPointsVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     type Result = (G1::PartId, ClosestPoints);
 

--- a/src/query/closest_points/closest_points_composite_shape_shape.rs
+++ b/src/query/closest_points/closest_points_composite_shape_shape.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::SimdAABB;
+use crate::bounding_volume::SimdAabb;
 use crate::math::{Isometry, Real, SimdBool, SimdReal, Vector, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::{ClosestPoints, QueryDispatcher};
@@ -17,7 +17,7 @@ pub fn closest_points_composite_shape_shape<D: ?Sized, G1: ?Sized>(
 ) -> ClosestPoints
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     let mut visitor =
         CompositeShapeAgainstShapeClosestPointsVisitor::new(dispatcher, pos12, g1, g2, margin);
@@ -39,7 +39,7 @@ pub fn closest_points_shape_composite_shape<D: ?Sized, G2: ?Sized>(
 ) -> ClosestPoints
 where
     D: QueryDispatcher,
-    G2: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G2: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     closest_points_composite_shape_shape(dispatcher, &pos12.inverse(), g2, g1, margin).flipped()
 }
@@ -59,7 +59,7 @@ pub struct CompositeShapeAgainstShapeClosestPointsVisitor<'a, D: ?Sized, G1: ?Si
 impl<'a, D: ?Sized, G1: ?Sized> CompositeShapeAgainstShapeClosestPointsVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     /// Initializes a visitor for computing the closest points between a composite-shape and a shape.
     pub fn new(
@@ -83,22 +83,22 @@ where
     }
 }
 
-impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAABB>
+impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAabb>
     for CompositeShapeAgainstShapeClosestPointsVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     type Result = (G1::PartId, ClosestPoints);
 
     fn visit(
         &mut self,
         best: Real,
-        bv: &SimdAABB,
+        bv: &SimdAabb,
         data: Option<[Option<&G1::PartId>; SIMD_WIDTH]>,
     ) -> SimdBestFirstVisitStatus<Self::Result> {
-        // Compute the minkowski sum of the two AABBs.
-        let msum = SimdAABB {
+        // Compute the minkowski sum of the two Aabbs.
+        let msum = SimdAabb {
             mins: bv.mins + self.msum_shift + (-self.msum_margin),
             maxs: bv.maxs + self.msum_shift + self.msum_margin,
         };

--- a/src/query/contact_manifolds/contact_manifolds_heightfield_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_heightfield_shape.rs
@@ -99,7 +99,7 @@ fn ensure_workspace_exists(workspace: &mut Option<ContactManifoldsWorkspace>) {
     )));
 }
 
-/// Computes the contact manifold between an heigthfield and an abstract shape.
+/// Computes the contact manifold between an heightfield and an abstract shape.
 pub fn contact_manifolds_heightfield_shape<ManifoldData, ContactData>(
     dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
     pos12: &Isometry<Real>,
@@ -122,7 +122,7 @@ pub fn contact_manifolds_heightfield_shape<ManifoldData, ContactData>(
     /*
      * Compute interferences.
      */
-    // TODO: somehow precompute the AABB and reuse it?
+    // TODO: somehow precompute the Aabb and reuse it?
     let ls_aabb2 = shape2.compute_aabb(&pos12).loosened(prediction);
     let mut old_manifolds = std::mem::replace(manifolds, Vec::new());
 

--- a/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::{BoundingVolume, AABB};
+use crate::bounding_volume::{Aabb, BoundingVolume};
 use crate::math::{Isometry, Real};
 use crate::query::contact_manifolds::contact_manifolds_workspace::{
     TypedWorkspaceData, WorkspaceData,
@@ -16,7 +16,7 @@ use crate::shape::{Shape, TriMesh};
 #[derive(Clone)]
 pub struct TriMeshShapeContactManifoldsWorkspace {
     interferences: Vec<u32>,
-    local_aabb2: AABB,
+    local_aabb2: Aabb,
     old_interferences: Vec<u32>,
     internal_edges: InternalEdgesFixer,
 }
@@ -25,7 +25,7 @@ impl TriMeshShapeContactManifoldsWorkspace {
     pub fn new() -> Self {
         Self {
             interferences: Vec::new(),
-            local_aabb2: AABB::new_invalid(),
+            local_aabb2: Aabb::new_invalid(),
             old_interferences: Vec::new(),
             internal_edges: InternalEdgesFixer::default(),
         }
@@ -98,7 +98,7 @@ pub fn contact_manifolds_trimesh_shape<ManifoldData, ContactData>(
     /*
      * Compute interferences.
      */
-    // TODO: somehow precompute the AABB and reuse it?
+    // TODO: somehow precompute the Aabb and reuse it?
     let mut new_local_aabb2 = shape2.compute_aabb(&pos12).loosened(prediction);
     let same_local_aabb2 = workspace.local_aabb2.contains(&new_local_aabb2);
     let mut old_manifolds = Vec::new();

--- a/src/query/distance/distance_composite_shape_shape.rs
+++ b/src/query/distance/distance_composite_shape_shape.rs
@@ -3,7 +3,7 @@ use crate::math::{Isometry, Real, SimdBool, SimdReal, Vector, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::QueryDispatcher;
 use crate::shape::{Shape, TypedSimdCompositeShape};
-use crate::utils::IsometryOpt;
+use crate::utils::{DefaultStorage, IsometryOpt};
 use simba::simd::{SimdBool as _, SimdPartialOrd, SimdValue};
 
 /// Smallest distance between a composite shape and any other shape.
@@ -15,7 +15,7 @@ pub fn distance_composite_shape_shape<D: ?Sized, G1: ?Sized>(
 ) -> Real
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     let mut visitor = CompositeShapeAgainstAnyDistanceVisitor::new(dispatcher, pos12, g1, g2);
     g1.typed_qbvh()
@@ -34,7 +34,7 @@ pub fn distance_shape_composite_shape<D: ?Sized, G2: ?Sized>(
 ) -> Real
 where
     D: QueryDispatcher,
-    G2: TypedSimdCompositeShape,
+    G2: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     distance_composite_shape_shape(dispatcher, &pos12.inverse(), g2, g1)
 }
@@ -75,7 +75,7 @@ impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAABB>
     for CompositeShapeAgainstAnyDistanceVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     type Result = (G1::PartId, Real);
 

--- a/src/query/distance/distance_composite_shape_shape.rs
+++ b/src/query/distance/distance_composite_shape_shape.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::SimdAABB;
+use crate::bounding_volume::SimdAabb;
 use crate::math::{Isometry, Real, SimdBool, SimdReal, Vector, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::QueryDispatcher;
@@ -15,7 +15,7 @@ pub fn distance_composite_shape_shape<D: ?Sized, G1: ?Sized>(
 ) -> Real
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     let mut visitor = CompositeShapeAgainstAnyDistanceVisitor::new(dispatcher, pos12, g1, g2);
     g1.typed_qbvh()
@@ -34,7 +34,7 @@ pub fn distance_shape_composite_shape<D: ?Sized, G2: ?Sized>(
 ) -> Real
 where
     D: QueryDispatcher,
-    G2: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G2: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     distance_composite_shape_shape(dispatcher, &pos12.inverse(), g2, g1)
 }
@@ -71,22 +71,22 @@ impl<'a, D: ?Sized, G1: ?Sized + 'a> CompositeShapeAgainstAnyDistanceVisitor<'a,
     }
 }
 
-impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAABB>
+impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAabb>
     for CompositeShapeAgainstAnyDistanceVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     type Result = (G1::PartId, Real);
 
     fn visit(
         &mut self,
         best: Real,
-        bv: &SimdAABB,
+        bv: &SimdAabb,
         data: Option<[Option<&G1::PartId>; SIMD_WIDTH]>,
     ) -> SimdBestFirstVisitStatus<Self::Result> {
-        // Compute the minkowski sum of the two AABBs.
-        let msum = SimdAABB {
+        // Compute the minkowski sum of the two Aabbs.
+        let msum = SimdAabb {
             mins: bv.mins + self.msum_shift + (-self.msum_margin),
             maxs: bv.maxs + self.msum_shift + self.msum_margin,
         };

--- a/src/query/intersection_test/intersection_test_composite_shape_shape.rs
+++ b/src/query/intersection_test/intersection_test_composite_shape_shape.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::SimdAABB;
+use crate::bounding_volume::SimdAabb;
 use crate::math::{Isometry, Real, SimdReal, Vector, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::QueryDispatcher;
@@ -15,7 +15,7 @@ pub fn intersection_test_composite_shape_shape<D: ?Sized, G1: ?Sized>(
 ) -> bool
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     let mut visitor =
         IntersectionCompositeShapeShapeBestFirstVisitor::new(dispatcher, pos12, g1, g2);
@@ -35,7 +35,7 @@ pub fn intersection_test_shape_composite_shape<D: ?Sized, G2: ?Sized>(
 ) -> bool
 where
     D: QueryDispatcher,
-    G2: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G2: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     intersection_test_composite_shape_shape(dispatcher, &pos12.inverse(), g2, g1)
 }
@@ -54,7 +54,7 @@ pub struct IntersectionCompositeShapeShapeBestFirstVisitor<'a, D: ?Sized, G1: ?S
 impl<'a, D: ?Sized, G1: ?Sized> IntersectionCompositeShapeShapeBestFirstVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     /// Initialize a visitor for checking if a composite-shape and a shape intersect.
     pub fn new(
@@ -76,22 +76,22 @@ where
     }
 }
 
-impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAABB>
+impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAabb>
     for IntersectionCompositeShapeShapeBestFirstVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     type Result = (G1::PartId, bool);
 
     fn visit(
         &mut self,
         best: Real,
-        bv: &SimdAABB,
+        bv: &SimdAabb,
         data: Option<[Option<&G1::PartId>; SIMD_WIDTH]>,
     ) -> SimdBestFirstVisitStatus<Self::Result> {
-        // Compute the minkowski sum of the two AABBs.
-        let msum = SimdAABB {
+        // Compute the minkowski sum of the two Aabbs.
+        let msum = SimdAabb {
             mins: bv.mins + self.msum_shift + (-self.msum_margin),
             maxs: bv.maxs + self.msum_shift + self.msum_margin,
         };

--- a/src/query/intersection_test/intersection_test_composite_shape_shape.rs
+++ b/src/query/intersection_test/intersection_test_composite_shape_shape.rs
@@ -3,7 +3,7 @@ use crate::math::{Isometry, Real, SimdReal, Vector, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::QueryDispatcher;
 use crate::shape::{Shape, TypedSimdCompositeShape};
-use crate::utils::IsometryOpt;
+use crate::utils::{DefaultStorage, IsometryOpt};
 use simba::simd::{SimdBool as _, SimdPartialOrd, SimdValue};
 
 /// Intersection test between a composite shape (`Mesh`, `Compound`) and any other shape.
@@ -15,7 +15,7 @@ pub fn intersection_test_composite_shape_shape<D: ?Sized, G1: ?Sized>(
 ) -> bool
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     let mut visitor =
         IntersectionCompositeShapeShapeBestFirstVisitor::new(dispatcher, pos12, g1, g2);
@@ -35,7 +35,7 @@ pub fn intersection_test_shape_composite_shape<D: ?Sized, G2: ?Sized>(
 ) -> bool
 where
     D: QueryDispatcher,
-    G2: TypedSimdCompositeShape,
+    G2: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     intersection_test_composite_shape_shape(dispatcher, &pos12.inverse(), g2, g1)
 }
@@ -54,7 +54,7 @@ pub struct IntersectionCompositeShapeShapeBestFirstVisitor<'a, D: ?Sized, G1: ?S
 impl<'a, D: ?Sized, G1: ?Sized> IntersectionCompositeShapeShapeBestFirstVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     /// Initialize a visitor for checking if a composite-shape and a shape intersect.
     pub fn new(
@@ -80,7 +80,7 @@ impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAABB>
     for IntersectionCompositeShapeShapeBestFirstVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     type Result = (G1::PartId, bool);
 

--- a/src/query/intersection_test/intersection_test_cuboid_segment.rs
+++ b/src/query/intersection_test/intersection_test_cuboid_segment.rs
@@ -1,10 +1,10 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Real};
 use crate::query::sat;
 use crate::shape::{Cuboid, Segment};
 
-/// Test if a segment intersects an AABB.
-pub fn intersection_test_aabb_segment(aabb1: &AABB, segment2: &Segment) -> bool {
+/// Test if a segment intersects an Aabb.
+pub fn intersection_test_aabb_segment(aabb1: &Aabb, segment2: &Segment) -> bool {
     let cuboid1 = Cuboid::new(aabb1.half_extents());
     let pos12 = Isometry::from_parts((-aabb1.center().coords).into(), na::one());
     intersection_test_cuboid_segment(&pos12, &cuboid1, segment2)

--- a/src/query/intersection_test/intersection_test_cuboid_triangle.rs
+++ b/src/query/intersection_test/intersection_test_cuboid_triangle.rs
@@ -1,10 +1,10 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Real};
 use crate::query::sat;
 use crate::shape::{Cuboid, Triangle};
 
-/// Tests if a triangle intersects an AABB.
-pub fn intersection_test_aabb_triangle(aabb1: &AABB, triangle2: &Triangle) -> bool {
+/// Tests if a triangle intersects an Aabb.
+pub fn intersection_test_aabb_triangle(aabb1: &Aabb, triangle2: &Triangle) -> bool {
     let cuboid1 = Cuboid::new(aabb1.half_extents());
     let pos12 = Isometry::from_parts((-aabb1.center().coords).into(), na::one());
     intersection_test_cuboid_triangle(&pos12, &cuboid1, triangle2)

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -63,7 +63,6 @@ mod ray;
 pub mod sat;
 mod split;
 mod time_of_impact;
-#[cfg(feature = "std")]
 pub mod visitors;
 
 /// Queries dedicated to specific pairs of shapes.

--- a/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_composite_shape_shape.rs
+++ b/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_composite_shape_shape.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::{BoundingSphere, SimdAABB};
+use crate::bounding_volume::{BoundingSphere, SimdAabb};
 use crate::math::{Real, SimdBool, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::{self, details::NonlinearTOIMode, NonlinearRigidMotion, QueryDispatcher, TOI};
@@ -19,7 +19,7 @@ pub fn nonlinear_time_of_impact_composite_shape_shape<D: ?Sized, G1: ?Sized>(
 ) -> Option<TOI>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     let mut visitor = NonlinearTOICompositeShapeShapeBestFirstVisitor::new(
         dispatcher,
@@ -50,7 +50,7 @@ pub fn nonlinear_time_of_impact_shape_composite_shape<D: ?Sized, G2: ?Sized>(
 ) -> Option<TOI>
 where
     D: QueryDispatcher,
-    G2: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G2: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     nonlinear_time_of_impact_composite_shape_shape(
         dispatcher,
@@ -82,7 +82,7 @@ pub struct NonlinearTOICompositeShapeShapeBestFirstVisitor<'a, D: ?Sized, G1: ?S
 impl<'a, D: ?Sized, G1: ?Sized> NonlinearTOICompositeShapeShapeBestFirstVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     /// Initializes visitor used to determine the non-linear time of impact between
     /// a composite shape and another shape.
@@ -110,11 +110,11 @@ where
     }
 }
 
-impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAABB>
+impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAabb>
     for NonlinearTOICompositeShapeShapeBestFirstVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     type Result = (G1::PartId, TOI);
 
@@ -122,7 +122,7 @@ where
     fn visit(
         &mut self,
         best: Real,
-        bv: &SimdAABB,
+        bv: &SimdAabb,
         data: Option<[Option<&G1::PartId>; SIMD_WIDTH]>,
     ) -> SimdBestFirstVisitStatus<Self::Result> {
         let mut weights = [0.0; SIMD_WIDTH];

--- a/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_composite_shape_shape.rs
+++ b/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_composite_shape_shape.rs
@@ -3,6 +3,7 @@ use crate::math::{Real, SimdBool, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::{self, details::NonlinearTOIMode, NonlinearRigidMotion, QueryDispatcher, TOI};
 use crate::shape::{Ball, Shape, TypedSimdCompositeShape};
+use crate::utils::DefaultStorage;
 use simba::simd::SimdValue;
 
 /// Time Of Impact of a composite shape with any other shape, under a rigid motion (translation + rotation).
@@ -18,7 +19,7 @@ pub fn nonlinear_time_of_impact_composite_shape_shape<D: ?Sized, G1: ?Sized>(
 ) -> Option<TOI>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     let mut visitor = NonlinearTOICompositeShapeShapeBestFirstVisitor::new(
         dispatcher,
@@ -49,7 +50,7 @@ pub fn nonlinear_time_of_impact_shape_composite_shape<D: ?Sized, G2: ?Sized>(
 ) -> Option<TOI>
 where
     D: QueryDispatcher,
-    G2: TypedSimdCompositeShape,
+    G2: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     nonlinear_time_of_impact_composite_shape_shape(
         dispatcher,
@@ -81,7 +82,7 @@ pub struct NonlinearTOICompositeShapeShapeBestFirstVisitor<'a, D: ?Sized, G1: ?S
 impl<'a, D: ?Sized, G1: ?Sized> NonlinearTOICompositeShapeShapeBestFirstVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     /// Initializes visitor used to determine the non-linear time of impact between
     /// a composite shape and another shape.
@@ -113,7 +114,7 @@ impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAABB>
     for NonlinearTOICompositeShapeShapeBestFirstVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     type Result = (G1::PartId, TOI);
 

--- a/src/query/point/mod.rs
+++ b/src/query/point/mod.rs
@@ -14,7 +14,6 @@ mod point_aabb;
 mod point_ball;
 mod point_bounding_sphere;
 mod point_capsule;
-#[cfg(feature = "std")]
 mod point_composite_shape;
 #[cfg(feature = "dim3")]
 mod point_cone;

--- a/src/query/point/point_aabb.rs
+++ b/src/query/point/point_aabb.rs
@@ -1,11 +1,11 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector, DIM};
 use crate::num::{Bounded, Zero};
 use crate::query::{PointProjection, PointQuery};
 use crate::shape::FeatureId;
 use na;
 
-impl AABB {
+impl Aabb {
     fn do_project_local_point(
         &self,
         pt: &Point<Real>,
@@ -57,7 +57,7 @@ impl AABB {
     }
 }
 
-impl PointQuery for AABB {
+impl PointQuery for Aabb {
     #[inline]
     fn project_local_point(&self, pt: &Point<Real>, solid: bool) -> PointProjection {
         let (inside, ls_pt, _) = self.do_project_local_point(pt, solid);

--- a/src/query/point/point_composite_shape.rs
+++ b/src/query/point/point_composite_shape.rs
@@ -6,12 +6,14 @@ use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::visitors::CompositePointContainmentTest;
 use crate::query::{PointProjection, PointQuery, PointQueryWithLocation};
 use crate::shape::{
-    FeatureId, GenericTriMesh, SegmentPointLocation, TriMesh, TriMeshStorage,
-    TrianglePointLocation, TypedSimdCompositeShape,
+    FeatureId, GenericTriMesh, SegmentPointLocation, TriMeshStorage, TrianglePointLocation,
+    TypedSimdCompositeShape,
 };
-use crate::utils::Array1;
 use na;
 use simba::simd::{SimdBool as _, SimdPartialOrd, SimdValue};
+
+#[cfg(feature = "dim3")]
+use crate::utils::Array1;
 
 #[cfg(feature = "std")]
 use crate::shape::{Compound, Polyline};
@@ -165,6 +167,8 @@ impl<Storage: TriMeshStorage> PointQueryWithLocation for GenericTriMesh<Storage>
     ) -> Option<(PointProjection, Self::Location)> {
         let mut visitor =
             PointCompositeShapeProjWithLocationBestFirstVisitor::new(self, point, solid);
+
+        #[allow(unused_mut)] // mut is needed in 3D.
         if let Some((_, (mut proj, (part_id, location)))) =
             self.qbvh()
                 .traverse_best_first_node(&mut visitor, 0, max_dist)

--- a/src/query/point/point_composite_shape.rs
+++ b/src/query/point/point_composite_shape.rs
@@ -1,6 +1,6 @@
 #![allow(unused_parens)] // Needed by the macro.
 
-use crate::bounding_volume::SimdAABB;
+use crate::bounding_volume::SimdAabb;
 use crate::math::{Point, Real, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::visitors::CompositePointContainmentTest;
@@ -230,7 +230,7 @@ macro_rules! gen_visitor(
             }
         }
 
-        impl<'a, S> SimdBestFirstVisitor<S::PartId, SimdAABB> for $Visitor<'a, S>
+        impl<'a, S> SimdBestFirstVisitor<S::PartId, SimdAabb> for $Visitor<'a, S>
         where S: TypedSimdCompositeShape
               $(, $Location: Copy)*
               $(, S::PartShape: $PartShapeBound)* {
@@ -240,7 +240,7 @@ macro_rules! gen_visitor(
             fn visit(
                 &mut self,
                 best: Real,
-                aabb: &SimdAABB,
+                aabb: &SimdAabb,
                 data: Option<[Option<&S::PartId>; SIMD_WIDTH]>,
             ) -> SimdBestFirstVisitStatus<Self::Result> {
                 let dist = aabb.distance_to_local_point(&self.simd_point);

--- a/src/query/point/point_cuboid.rs
+++ b/src/query/point/point_cuboid.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real};
 use crate::query::{PointProjection, PointQuery};
 use crate::shape::{Cuboid, FeatureId};
@@ -8,7 +8,7 @@ impl PointQuery for Cuboid {
     fn project_local_point(&self, pt: &Point<Real>, solid: bool) -> PointProjection {
         let dl = Point::from(-self.half_extents);
         let ur = Point::from(self.half_extents);
-        AABB::new(dl, ur).project_local_point(pt, solid)
+        Aabb::new(dl, ur).project_local_point(pt, solid)
     }
 
     #[inline]
@@ -18,20 +18,20 @@ impl PointQuery for Cuboid {
     ) -> (PointProjection, FeatureId) {
         let dl = Point::from(-self.half_extents);
         let ur = Point::from(self.half_extents);
-        AABB::new(dl, ur).project_local_point_and_get_feature(pt)
+        Aabb::new(dl, ur).project_local_point_and_get_feature(pt)
     }
 
     #[inline]
     fn distance_to_local_point(&self, pt: &Point<Real>, solid: bool) -> Real {
         let dl = Point::from(-self.half_extents);
         let ur = Point::from(self.half_extents);
-        AABB::new(dl, ur).distance_to_local_point(pt, solid)
+        Aabb::new(dl, ur).distance_to_local_point(pt, solid)
     }
 
     #[inline]
     fn contains_local_point(&self, pt: &Point<Real>) -> bool {
         let dl = Point::from(-self.half_extents);
         let ur = Point::from(self.half_extents);
-        AABB::new(dl, ur).contains_local_point(pt)
+        Aabb::new(dl, ur).contains_local_point(pt)
     }
 }

--- a/src/query/point/point_heightfield.rs
+++ b/src/query/point/point_heightfield.rs
@@ -1,17 +1,11 @@
 use crate::bounding_volume::AABB;
 use crate::math::{Point, Real, Vector};
 use crate::query::{PointProjection, PointQuery, PointQueryWithLocation};
-use crate::shape::{
-    FeatureId, GenericHeightField, HeightFieldCellStatus, HeightFieldStorage, TrianglePointLocation,
-};
+use crate::shape::{FeatureId, GenericHeightField, HeightFieldStorage, TrianglePointLocation};
 #[cfg(not(feature = "std"))]
 use na::ComplexField; // For sqrt.
 
-impl<Heights, Status> PointQuery for GenericHeightField<Heights, Status>
-where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
-{
+impl<Storage: HeightFieldStorage> PointQuery for GenericHeightField<Storage> {
     fn project_local_point_with_max_dist(
         &self,
         pt: &Point<Real>,
@@ -77,11 +71,7 @@ where
     }
 }
 
-impl<Heights, Status> PointQueryWithLocation for GenericHeightField<Heights, Status>
-where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
-{
+impl<Storage: HeightFieldStorage> PointQueryWithLocation for GenericHeightField<Storage> {
     type Location = (usize, TrianglePointLocation);
 
     #[inline]

--- a/src/query/point/point_heightfield.rs
+++ b/src/query/point/point_heightfield.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 use crate::query::{PointProjection, PointQuery, PointQueryWithLocation};
 use crate::shape::{FeatureId, GenericHeightField, HeightFieldStorage, TrianglePointLocation};
@@ -12,7 +12,7 @@ impl<Storage: HeightFieldStorage> PointQuery for GenericHeightField<Storage> {
         solid: bool,
         max_dist: Real,
     ) -> Option<PointProjection> {
-        let aabb = AABB::new(pt - Vector::repeat(max_dist), pt + Vector::repeat(max_dist));
+        let aabb = Aabb::new(pt - Vector::repeat(max_dist), pt + Vector::repeat(max_dist));
         let mut sq_smallest_dist = Real::MAX;
         let mut best_proj = None;
 

--- a/src/query/point/point_query.rs
+++ b/src/query/point/point_query.rs
@@ -159,4 +159,35 @@ pub trait PointQueryWithLocation {
         let res = self.project_local_point_and_get_location(&m.inverse_transform_point(pt), solid);
         (res.0.transform_by(m), res.1)
     }
+
+    /// Projects a point on `self`, with a maximum projection distance.
+    fn project_local_point_and_get_location_with_max_dist(
+        &self,
+        pt: &Point<Real>,
+        solid: bool,
+        max_dist: Real,
+    ) -> Option<(PointProjection, Self::Location)> {
+        let (proj, location) = self.project_local_point_and_get_location(pt, solid);
+        if na::distance(&proj.point, pt) > max_dist {
+            None
+        } else {
+            Some((proj, location))
+        }
+    }
+
+    /// Projects a point on `self` transformed by `m`, with a maximum projection distance.
+    fn project_point_and_get_location_with_max_dist(
+        &self,
+        m: &Isometry<Real>,
+        pt: &Point<Real>,
+        solid: bool,
+        max_dist: Real,
+    ) -> Option<(PointProjection, Self::Location)> {
+        self.project_local_point_and_get_location_with_max_dist(
+            &m.inverse_transform_point(pt),
+            solid,
+            max_dist,
+        )
+        .map(|res| (res.0.transform_by(m), res.1))
+    }
 }

--- a/src/query/ray/ray_aabb.rs
+++ b/src/query/ray/ray_aabb.rs
@@ -2,13 +2,13 @@ use std::mem;
 
 use na;
 
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Real, Vector, DIM};
 use crate::query::{Ray, RayCast, RayIntersection};
 use crate::shape::FeatureId;
 use num::Zero;
 
-impl RayCast for AABB {
+impl RayCast for Aabb {
     fn cast_local_ray(&self, ray: &Ray, max_toi: Real, solid: bool) -> Option<Real> {
         let mut tmin: Real = 0.0;
         let mut tmax: Real = max_toi;
@@ -68,7 +68,7 @@ impl RayCast for AABB {
 }
 
 fn ray_aabb(
-    aabb: &AABB,
+    aabb: &Aabb,
     ray: &Ray,
     max_toi: Real,
     solid: bool,

--- a/src/query/ray/ray_composite_shape.rs
+++ b/src/query/ray/ray_composite_shape.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::SimdAABB;
+use crate::bounding_volume::SimdAabb;
 use crate::math::{Real, SimdBool, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::{Ray, RayCast, RayIntersection, SimdRay};
@@ -118,10 +118,10 @@ impl<'a, S> RayCompositeShapeToiBestFirstVisitor<'a, S> {
     }
 }
 
-impl<'a, S> SimdBestFirstVisitor<S::PartId, SimdAABB>
+impl<'a, S> SimdBestFirstVisitor<S::PartId, SimdAabb>
     for RayCompositeShapeToiBestFirstVisitor<'a, S>
 where
-    S: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    S: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     type Result = (S::PartId, Real);
 
@@ -129,7 +129,7 @@ where
     fn visit(
         &mut self,
         best: Real,
-        aabb: &SimdAABB,
+        aabb: &SimdAabb,
         data: Option<[Option<&S::PartId>; SIMD_WIDTH]>,
     ) -> SimdBestFirstVisitStatus<Self::Result> {
         let (hit, toi) = aabb.cast_local_ray(&self.simd_ray, SimdReal::splat(self.max_toi));
@@ -198,10 +198,10 @@ impl<'a, S> RayCompositeShapeToiAndNormalBestFirstVisitor<'a, S> {
     }
 }
 
-impl<'a, S> SimdBestFirstVisitor<S::PartId, SimdAABB>
+impl<'a, S> SimdBestFirstVisitor<S::PartId, SimdAabb>
     for RayCompositeShapeToiAndNormalBestFirstVisitor<'a, S>
 where
-    S: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    S: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     type Result = (S::PartId, RayIntersection);
 
@@ -209,7 +209,7 @@ where
     fn visit(
         &mut self,
         best: Real,
-        aabb: &SimdAABB,
+        aabb: &SimdAabb,
         data: Option<[Option<&S::PartId>; SIMD_WIDTH]>,
     ) -> SimdBestFirstVisitStatus<Self::Result> {
         let (hit, toi) = aabb.cast_local_ray(&self.simd_ray, SimdReal::splat(self.max_toi));

--- a/src/query/ray/ray_composite_shape.rs
+++ b/src/query/ray/ray_composite_shape.rs
@@ -3,6 +3,7 @@ use crate::math::{Real, SimdBool, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::{Ray, RayCast, RayIntersection, SimdRay};
 use crate::shape::{Compound, FeatureId, Polyline, TriMesh, TypedSimdCompositeShape};
+use crate::utils::DefaultStorage;
 use simba::simd::{SimdBool as _, SimdPartialOrd, SimdValue};
 
 impl RayCast for TriMesh {
@@ -120,7 +121,7 @@ impl<'a, S> RayCompositeShapeToiBestFirstVisitor<'a, S> {
 impl<'a, S> SimdBestFirstVisitor<S::PartId, SimdAABB>
     for RayCompositeShapeToiBestFirstVisitor<'a, S>
 where
-    S: TypedSimdCompositeShape,
+    S: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     type Result = (S::PartId, Real);
 
@@ -200,7 +201,7 @@ impl<'a, S> RayCompositeShapeToiAndNormalBestFirstVisitor<'a, S> {
 impl<'a, S> SimdBestFirstVisitor<S::PartId, SimdAABB>
     for RayCompositeShapeToiAndNormalBestFirstVisitor<'a, S>
 where
-    S: TypedSimdCompositeShape,
+    S: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     type Result = (S::PartId, RayIntersection);
 

--- a/src/query/ray/ray_cuboid.rs
+++ b/src/query/ray/ray_cuboid.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real};
 use crate::query::{Ray, RayCast, RayIntersection};
 use crate::shape::Cuboid;
@@ -8,7 +8,7 @@ impl RayCast for Cuboid {
     fn cast_local_ray(&self, ray: &Ray, max_toi: Real, solid: bool) -> Option<Real> {
         let dl = Point::from(-self.half_extents);
         let ur = Point::from(self.half_extents);
-        AABB::new(dl, ur).cast_local_ray(ray, max_toi, solid)
+        Aabb::new(dl, ur).cast_local_ray(ray, max_toi, solid)
     }
 
     #[inline]
@@ -20,6 +20,6 @@ impl RayCast for Cuboid {
     ) -> Option<RayIntersection> {
         let dl = Point::from(-self.half_extents);
         let ur = Point::from(self.half_extents);
-        AABB::new(dl, ur).cast_local_ray_and_get_normal(ray, max_toi, solid)
+        Aabb::new(dl, ur).cast_local_ray_and_get_normal(ray, max_toi, solid)
     }
 }

--- a/src/query/ray/ray_heightfield.rs
+++ b/src/query/ray/ray_heightfield.rs
@@ -87,12 +87,12 @@ impl<Storage: HeightFieldStorage> RayCast for GenericHeightField<Storage> {
             }
 
             if curr_param >= max_t {
-                // The part of the ray after max_t is outside of the heightfield AABB.
+                // The part of the ray after max_t is outside of the heightfield Aabb.
                 return None;
             }
 
             if let Some(seg) = self.segment_at(curr) {
-                // TODO: test the y-coordinates (equivalent to an AABB test) before actually computing the intersection.
+                // TODO: test the y-coordinates (equivalent to an Aabb test) before actually computing the intersection.
                 let (s, t) = query::details::closest_points_line_line_parameters(
                     &ray.origin,
                     &ray.dir,

--- a/src/query/ray/ray_heightfield.rs
+++ b/src/query/ray/ray_heightfield.rs
@@ -4,14 +4,10 @@ use crate::query;
 use crate::query::{Ray, RayCast, RayIntersection};
 #[cfg(feature = "dim2")]
 use crate::shape::FeatureId;
-use crate::shape::{GenericHeightField, HeightFieldCellStatus, HeightFieldStorage};
+use crate::shape::{GenericHeightField, HeightFieldStorage};
 
 #[cfg(feature = "dim2")]
-impl<Heights, Status> RayCast for GenericHeightField<Heights, Status>
-where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
-{
+impl<Storage: HeightFieldStorage> RayCast for GenericHeightField<Storage> {
     #[inline]
     fn cast_local_ray_and_get_normal(
         &self,
@@ -123,11 +119,7 @@ where
 }
 
 #[cfg(feature = "dim3")]
-impl<Heights, Status> RayCast for GenericHeightField<Heights, Status>
-where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
-{
+impl<Storage: HeightFieldStorage> RayCast for GenericHeightField<Storage> {
     #[inline]
     fn cast_local_ray_and_get_normal(
         &self,

--- a/src/query/split/split_aabb.rs
+++ b/src/query/split/split_aabb.rs
@@ -1,17 +1,17 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::Real;
 use crate::query::SplitResult;
 
-impl AABB {
-    /// Splits this AABB along the given canonical axis.
+impl Aabb {
+    /// Splits this Aabb along the given canonical axis.
     ///
-    /// This will split the AABB by a plane with a normal with it’s `axis`-th component set to 1.
+    /// This will split the Aabb by a plane with a normal with it’s `axis`-th component set to 1.
     /// The splitting plane is shifted wrt. the origin by the `bias` (i.e. it passes through the point
     /// equal to `normal * bias`).
     ///
     /// # Result
-    /// Returns the result of the split. The first AABB returned is the piece lying on the negative
-    /// half-space delimited by the splitting plane. The second AABB returned is the piece lying on the
+    /// Returns the result of the split. The first Aabb returned is the piece lying on the negative
+    /// half-space delimited by the splitting plane. The second Aabb returned is the piece lying on the
     /// positive half-space delimited by the splitting plane.
     pub fn canonical_split(&self, axis: usize, bias: Real, epsilon: Real) -> SplitResult<Self> {
         if self.mins[axis] >= bias - epsilon {

--- a/src/query/split/split_trimesh.rs
+++ b/src/query/split/split_trimesh.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Point, Real, UnitVector, Vector};
 use crate::query::visitors::BoundingVolumeIntersectionsVisitor;
 use crate::query::{PointQuery, SplitResult};
@@ -57,7 +57,7 @@ impl Triangulation {
 impl TriMesh {
     /// Splits this `TriMesh` along the given canonical axis.
     ///
-    /// This will split the AABB by a plane with a normal with it’s `axis`-th component set to 1.
+    /// This will split the Aabb by a plane with a normal with it’s `axis`-th component set to 1.
     /// The splitting plane is shifted wrt. the origin by the `bias` (i.e. it passes through the point
     /// equal to `normal * bias`).
     ///
@@ -344,12 +344,12 @@ impl TriMesh {
         }
     }
 
-    /// Computes the intersection mesh between an AABB and this mesh.
+    /// Computes the intersection mesh between an Aabb and this mesh.
     pub fn intersection_with_aabb(
         &self,
         position: &Isometry<Real>,
         flip_mesh: bool,
-        aabb: &AABB,
+        aabb: &Aabb,
         flip_cuboid: bool,
         epsilon: Real,
     ) -> Option<Self> {
@@ -445,9 +445,9 @@ impl TriMesh {
                 inv_pos * vertices[idx[2] as usize],
             ]);
 
-            // There is no need to clip if the triangle is fully inside of the AABB.
+            // There is no need to clip if the triangle is fully inside of the Aabb.
             // Note that we can’t take a shortcut for the case where all the vertices are
-            // outside of the AABB, because the AABB can still instersect the edges or face.
+            // outside of the Aabb, because the Aabb can still instersect the edges or face.
             if !(aabb.contains_local_point(&to_clip[0])
                 && aabb.contains_local_point(&to_clip[1])
                 && aabb.contains_local_point(&to_clip[2]))

--- a/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
+++ b/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
@@ -3,6 +3,7 @@ use crate::math::{Isometry, Point, Real, SimdBool, SimdReal, Vector, SIMD_WIDTH}
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::{QueryDispatcher, Ray, SimdRay, TOI};
 use crate::shape::{Shape, TypedSimdCompositeShape};
+use crate::utils::DefaultStorage;
 use simba::simd::{SimdBool as _, SimdPartialOrd, SimdValue};
 
 /// Time Of Impact of a composite shape with any other shape, under translational movement.
@@ -17,7 +18,7 @@ pub fn time_of_impact_composite_shape_shape<D: ?Sized, G1: ?Sized>(
 ) -> Option<TOI>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     let mut visitor = TOICompositeShapeShapeBestFirstVisitor::new(
         dispatcher,
@@ -45,7 +46,7 @@ pub fn time_of_impact_shape_composite_shape<D: ?Sized, G2: ?Sized>(
 ) -> Option<TOI>
 where
     D: QueryDispatcher,
-    G2: TypedSimdCompositeShape,
+    G2: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     time_of_impact_composite_shape_shape(
         dispatcher,
@@ -77,7 +78,7 @@ pub struct TOICompositeShapeShapeBestFirstVisitor<'a, D: ?Sized, G1: ?Sized + 'a
 impl<'a, D: ?Sized, G1: ?Sized> TOICompositeShapeShapeBestFirstVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     /// Creates a new visitor used to find the time-of-impact between a composite shape and a shape.
     pub fn new(
@@ -111,7 +112,7 @@ impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAABB>
     for TOICompositeShapeShapeBestFirstVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
 {
     type Result = (G1::PartId, TOI);
 

--- a/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
+++ b/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::SimdAABB;
+use crate::bounding_volume::SimdAabb;
 use crate::math::{Isometry, Point, Real, SimdBool, SimdReal, Vector, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::{QueryDispatcher, Ray, SimdRay, TOI};
@@ -18,7 +18,7 @@ pub fn time_of_impact_composite_shape_shape<D: ?Sized, G1: ?Sized>(
 ) -> Option<TOI>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     let mut visitor = TOICompositeShapeShapeBestFirstVisitor::new(
         dispatcher,
@@ -46,7 +46,7 @@ pub fn time_of_impact_shape_composite_shape<D: ?Sized, G2: ?Sized>(
 ) -> Option<TOI>
 where
     D: QueryDispatcher,
-    G2: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G2: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     time_of_impact_composite_shape_shape(
         dispatcher,
@@ -78,7 +78,7 @@ pub struct TOICompositeShapeShapeBestFirstVisitor<'a, D: ?Sized, G1: ?Sized + 'a
 impl<'a, D: ?Sized, G1: ?Sized> TOICompositeShapeShapeBestFirstVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     /// Creates a new visitor used to find the time-of-impact between a composite shape and a shape.
     pub fn new(
@@ -108,11 +108,11 @@ where
     }
 }
 
-impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAABB>
+impl<'a, D: ?Sized, G1: ?Sized> SimdBestFirstVisitor<G1::PartId, SimdAabb>
     for TOICompositeShapeShapeBestFirstVisitor<'a, D, G1>
 where
     D: QueryDispatcher,
-    G1: TypedSimdCompositeShape<QBVHStorage = DefaultStorage>,
+    G1: TypedSimdCompositeShape<QbvhStorage = DefaultStorage>,
 {
     type Result = (G1::PartId, TOI);
 
@@ -120,11 +120,11 @@ where
     fn visit(
         &mut self,
         best: Real,
-        bv: &SimdAABB,
+        bv: &SimdAabb,
         data: Option<[Option<&G1::PartId>; SIMD_WIDTH]>,
     ) -> SimdBestFirstVisitStatus<Self::Result> {
-        // Compute the minkowski sum of the two AABBs.
-        let msum = SimdAABB {
+        // Compute the minkowski sum of the two Aabbs.
+        let msum = SimdAabb {
             mins: bv.mins + self.msum_shift + (-self.msum_margin),
             maxs: bv.maxs + self.msum_shift + self.msum_margin,
         };

--- a/src/query/time_of_impact/time_of_impact_heightfield_shape.rs
+++ b/src/query/time_of_impact/time_of_impact_heightfield_shape.rs
@@ -2,7 +2,7 @@ use crate::math::{Isometry, Real, Vector};
 use crate::query::{QueryDispatcher, Ray, Unsupported, TOI};
 use crate::shape::{GenericHeightField, HeightFieldStorage, Shape};
 #[cfg(feature = "dim3")]
-use crate::{bounding_volume::AABB, query::RayCast};
+use crate::{bounding_volume::Aabb, query::RayCast};
 
 /// Time Of Impact between a moving shape and a heightfield.
 #[cfg(feature = "dim2")]
@@ -41,7 +41,7 @@ where
         ..curr_range.end.clamp(0, heightfield1.num_cells() as isize) as usize;
     for curr in clamped_curr_range {
         if let Some(seg) = heightfield1.segment_at(curr) {
-            // TODO: pre-check using a ray-cast on the AABBs first?
+            // TODO: pre-check using a ray-cast on the Aabbs first?
             if let Some(hit) =
                 dispatcher.time_of_impact(pos12, vel12, &seg, g2, max_toi, stop_at_penetration)?
             {
@@ -88,7 +88,7 @@ where
         }
 
         if let Some(seg) = heightfield1.segment_at(curr_elt as usize) {
-            // TODO: pre-check using a ray-cast on the AABBs first?
+            // TODO: pre-check using a ray-cast on the Aabbs first?
             if let Some(hit) =
                 dispatcher.time_of_impact(pos12, vel12, &seg, g2, max_toi, stop_at_penetration)?
             {
@@ -123,7 +123,7 @@ where
 
     // Find the first hit between the aabbs.
     let hext2_1 = aabb2_1.half_extents();
-    let msum = AABB::new(aabb1.mins - hext2_1, aabb1.maxs + hext2_1);
+    let msum = Aabb::new(aabb1.mins - hext2_1, aabb1.maxs + hext2_1);
     if let Some(toi) = msum.cast_local_ray(&ray, max_toi, true) {
         // Advance the aabb2 to the hit point.
         aabb2_1.mins += ray.dir * toi;
@@ -165,7 +165,7 @@ where
             let (tri_a, tri_b) = heightfield1.triangles_at(i as usize, j as usize);
             for tri in [tri_a, tri_b] {
                 if let Some(tri) = tri {
-                    // TODO: pre-check using a ray-cast on the AABBs first?
+                    // TODO: pre-check using a ray-cast on the Aabbs first?
                     if let Some(hit) = dispatcher.time_of_impact(
                         pos12,
                         vel12,

--- a/src/query/time_of_impact/time_of_impact_heightfield_shape.rs
+++ b/src/query/time_of_impact/time_of_impact_heightfield_shape.rs
@@ -1,23 +1,22 @@
 use crate::math::{Isometry, Real, Vector};
 use crate::query::{QueryDispatcher, Ray, Unsupported, TOI};
-use crate::shape::{GenericHeightField, HeightFieldCellStatus, HeightFieldStorage, Shape};
+use crate::shape::{GenericHeightField, HeightFieldStorage, Shape};
 #[cfg(feature = "dim3")]
 use crate::{bounding_volume::AABB, query::RayCast};
 
 /// Time Of Impact between a moving shape and a heightfield.
 #[cfg(feature = "dim2")]
-pub fn time_of_impact_heightfield_shape<Heights, Status, D: ?Sized>(
+pub fn time_of_impact_heightfield_shape<Storage, D: ?Sized>(
     dispatcher: &D,
     pos12: &Isometry<Real>,
     vel12: &Vector<Real>,
-    heightfield1: &GenericHeightField<Heights, Status>,
+    heightfield1: &GenericHeightField<Storage>,
     g2: &dyn Shape,
     max_toi: Real,
     stop_at_penetration: bool,
 ) -> Result<Option<TOI>, Unsupported>
 where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
+    Storage: HeightFieldStorage,
     D: QueryDispatcher,
 {
     let aabb2_1 = g2.compute_aabb(pos12);
@@ -105,18 +104,17 @@ where
 
 /// Time Of Impact between a moving shape and a heightfield.
 #[cfg(feature = "dim3")]
-pub fn time_of_impact_heightfield_shape<Heights, Status, D: ?Sized>(
+pub fn time_of_impact_heightfield_shape<Storage, D: ?Sized>(
     dispatcher: &D,
     pos12: &Isometry<Real>,
     vel12: &Vector<Real>,
-    heightfield1: &GenericHeightField<Heights, Status>,
+    heightfield1: &GenericHeightField<Storage>,
     g2: &dyn Shape,
     max_toi: Real,
     stop_at_penetration: bool,
 ) -> Result<Option<TOI>, Unsupported>
 where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
+    Storage: HeightFieldStorage,
     D: QueryDispatcher,
 {
     let aabb1 = heightfield1.local_aabb();
@@ -283,18 +281,17 @@ where
 }
 
 /// Time Of Impact between a moving shape and a heightfield.
-pub fn time_of_impact_shape_heightfield<Heights, Status, D: ?Sized>(
+pub fn time_of_impact_shape_heightfield<Storage, D: ?Sized>(
     dispatcher: &D,
     pos12: &Isometry<Real>,
     vel12: &Vector<Real>,
     g1: &dyn Shape,
-    heightfield2: &GenericHeightField<Heights, Status>,
+    heightfield2: &GenericHeightField<Storage>,
     max_toi: Real,
     stop_at_penetration: bool,
 ) -> Result<Option<TOI>, Unsupported>
 where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
+    Storage: HeightFieldStorage,
     D: QueryDispatcher,
 {
     Ok(time_of_impact_heightfield_shape(

--- a/src/query/visitors/aabb_sets_interferences_collector.rs
+++ b/src/query/visitors/aabb_sets_interferences_collector.rs
@@ -1,7 +1,7 @@
 use crate::math::{Isometry, Matrix, Real};
 
 /// Spatial partitioning data structure visitor collecting interferences with a given bounding volume.
-pub struct AABBSetsInterferencesCollector<'a, T: 'a> {
+pub struct AabbSetsInterferencesCollector<'a, T: 'a> {
     /// The transform from the local-space of the second bounding volumes to the local space of the first.
     pub ls_m2: &'a Isometry<Real>,
     /// The absolute value of the rotation matrix representing `ls_m2.rotation`.
@@ -10,22 +10,22 @@ pub struct AABBSetsInterferencesCollector<'a, T: 'a> {
     pub ls_m2_abs_rot: &'a Matrix<Real>,
     /// A tolerance applied to the interference tests.
     ///
-    /// AABB pairs closer than `tolerance` will be reported as intersecting.
+    /// Aabb pairs closer than `tolerance` will be reported as intersecting.
     pub tolerence: Real,
     /// The data contained by the nodes with bounding volumes intersecting `self.bv`.
     pub collector: &'a mut Vec<(T, T)>,
 }
 
-impl<'a, T> AABBSetsInterferencesCollector<'a, T> {
-    /// Creates a new `AABBSetsInterferencesCollector`.
+impl<'a, T> AabbSetsInterferencesCollector<'a, T> {
+    /// Creates a new `AabbSetsInterferencesCollector`.
     #[inline]
     pub fn new(
         tolerence: Real,
         ls_m2: &'a Isometry<Real>,
         ls_m2_abs_rot: &'a Matrix<Real>,
         collector: &'a mut Vec<(T, T)>,
-    ) -> AABBSetsInterferencesCollector<'a, T> {
-        AABBSetsInterferencesCollector {
+    ) -> AabbSetsInterferencesCollector<'a, T> {
+        AabbSetsInterferencesCollector {
             tolerence,
             ls_m2,
             ls_m2_abs_rot,
@@ -34,16 +34,16 @@ impl<'a, T> AABBSetsInterferencesCollector<'a, T> {
     }
 }
 
-// impl<'a, T: Clone> SimultaneousVisitor<T, AABB> for AABBSetsInterferencesCollector<'a, T> {
+// impl<'a, T: Clone> SimultaneousVisitor<T, Aabb> for AabbSetsInterferencesCollector<'a, T> {
 //     #[inline]
 //     fn visit(
 //         &mut self,
-//         left_bv: &AABB,
+//         left_bv: &Aabb,
 //         left_data: Option<&T>,
-//         right_bv: &AABB,
+//         right_bv: &Aabb,
 //         right_data: Option<&T>,
 //     ) -> VisitStatus {
-//         let ls_right_bv = AABB::from_half_extents(
+//         let ls_right_bv = Aabb::from_half_extents(
 //             self.ls_m2 * right_bv.center(),
 //             self.ls_m2_abs_rot * right_bv.half_extents() + Vector::repeat(self.tolerence),
 //         );

--- a/src/query/visitors/bounding_volume_intersections_simultaneous_visitor.rs
+++ b/src/query/visitors/bounding_volume_intersections_simultaneous_visitor.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::SimdAABB;
+use crate::bounding_volume::SimdAabb;
 use crate::math::{Isometry, Real, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdSimultaneousVisitStatus, SimdSimultaneousVisitor};
 use na::SimdValue;
@@ -6,7 +6,7 @@ use simba::simd::SimdBool as _;
 use std::marker::PhantomData;
 
 #[cfg(feature = "parallel")]
-use crate::partitioning::{QBVHNode, SimdNodeIndex};
+use crate::partitioning::{QbvhNode, SimdNodeIndex};
 
 /// Spatial partitioning data structure visitor collecting interferences with a given bounding volume.
 pub struct BoundingVolumeIntersectionsSimultaneousVisitor<T1, T2, F> {
@@ -40,7 +40,7 @@ impl<T1, T2, F> BoundingVolumeIntersectionsSimultaneousVisitor<T1, T2, F> {
     }
 }
 
-impl<T1, T2, F> SimdSimultaneousVisitor<T1, T2, SimdAABB>
+impl<T1, T2, F> SimdSimultaneousVisitor<T1, T2, SimdAabb>
     for BoundingVolumeIntersectionsSimultaneousVisitor<T1, T2, F>
 where
     F: FnMut(&T1, &T2) -> bool,
@@ -48,9 +48,9 @@ where
     #[inline]
     fn visit(
         &mut self,
-        left_bv: &SimdAABB,
+        left_bv: &SimdAabb,
         left_data: Option<[Option<&T1>; SIMD_WIDTH]>,
-        right_bv: &SimdAABB,
+        right_bv: &SimdAabb,
         right_data: Option<[Option<&T2>; SIMD_WIDTH]>,
     ) -> SimdSimultaneousVisitStatus {
         let mask = if let Some(pos12) = &self.pos12 {
@@ -91,10 +91,10 @@ where
     fn visit(
         &self,
         _: SimdNodeIndex,
-        left_node: &QBVHNode,
+        left_node: &QbvhNode,
         left_data: Option<[Option<&LeafData1>; SIMD_WIDTH]>,
         _: SimdNodeIndex,
-        right_node: &QBVHNode,
+        right_node: &QbvhNode,
         right_data: Option<[Option<&LeafData2>; SIMD_WIDTH]>,
         _: (),
     ) -> (SimdSimultaneousVisitStatus, ()) {

--- a/src/query/visitors/bounding_volume_intersections_visitor.rs
+++ b/src/query/visitors/bounding_volume_intersections_visitor.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::{SimdAABB, AABB};
+use crate::bounding_volume::{Aabb, SimdAabb};
 use crate::math::SIMD_WIDTH;
 use crate::partitioning::{SimdVisitStatus, SimdVisitor};
 use simba::simd::SimdBool as _;
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 
 /// Spatial partitioning data structure visitor collecting interferences with a given bounding volume.
 pub struct BoundingVolumeIntersectionsVisitor<T, F> {
-    bv: SimdAABB,
+    bv: SimdAabb,
     callback: F,
     _phantom: PhantomData<T>,
 }
@@ -17,21 +17,21 @@ where
 {
     /// Creates a new `BoundingVolumeIntersectionsVisitor`.
     #[inline]
-    pub fn new(bv: &AABB, callback: F) -> BoundingVolumeIntersectionsVisitor<T, F> {
+    pub fn new(bv: &Aabb, callback: F) -> BoundingVolumeIntersectionsVisitor<T, F> {
         BoundingVolumeIntersectionsVisitor {
-            bv: SimdAABB::splat(*bv),
+            bv: SimdAabb::splat(*bv),
             callback,
             _phantom: PhantomData,
         }
     }
 }
 
-impl<T, F> SimdVisitor<T, SimdAABB> for BoundingVolumeIntersectionsVisitor<T, F>
+impl<T, F> SimdVisitor<T, SimdAabb> for BoundingVolumeIntersectionsVisitor<T, F>
 where
     F: FnMut(&T) -> bool,
 {
     #[inline]
-    fn visit(&mut self, bv: &SimdAABB, b: Option<[Option<&T>; SIMD_WIDTH]>) -> SimdVisitStatus {
+    fn visit(&mut self, bv: &SimdAabb, b: Option<[Option<&T>; SIMD_WIDTH]>) -> SimdVisitStatus {
         let mask = bv.intersects(&self.bv);
 
         if let Some(data) = b {

--- a/src/query/visitors/composite_closest_point_visitor.rs
+++ b/src/query/visitors/composite_closest_point_visitor.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::SimdAABB;
+use crate::bounding_volume::SimdAabb;
 use crate::math::{Point, Real, SimdBool, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::{PointProjection, PointQuery};
@@ -26,7 +26,7 @@ impl<'a, S> CompositeClosestPointVisitor<'a, S> {
     }
 }
 
-impl<'a, S: SimdCompositeShape + PointQuery> SimdBestFirstVisitor<u32, SimdAABB>
+impl<'a, S: SimdCompositeShape + PointQuery> SimdBestFirstVisitor<u32, SimdAabb>
     for CompositeClosestPointVisitor<'a, S>
 {
     type Result = PointProjection;
@@ -35,7 +35,7 @@ impl<'a, S: SimdCompositeShape + PointQuery> SimdBestFirstVisitor<u32, SimdAABB>
     fn visit(
         &mut self,
         best: Real,
-        aabb: &SimdAABB,
+        aabb: &SimdAabb,
         data: Option<[Option<&u32>; SIMD_WIDTH]>,
     ) -> SimdBestFirstVisitStatus<Self::Result> {
         let dist = aabb.distance_to_local_point(&self.simd_point);

--- a/src/query/visitors/composite_point_containment_test.rs
+++ b/src/query/visitors/composite_point_containment_test.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::SimdAABB;
+use crate::bounding_volume::SimdAabb;
 use crate::math::{Point, Real, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdVisitStatus, SimdVisitor};
 use crate::query::point::point_query::PointQuery;
@@ -28,13 +28,13 @@ impl<'a, S> CompositePointContainmentTest<'a, S> {
     }
 }
 
-impl<'a, S: TypedSimdCompositeShape> SimdVisitor<S::PartId, SimdAABB>
+impl<'a, S: TypedSimdCompositeShape> SimdVisitor<S::PartId, SimdAabb>
     for CompositePointContainmentTest<'a, S>
 {
     #[inline]
     fn visit(
         &mut self,
-        bv: &SimdAABB,
+        bv: &SimdAabb,
         b: Option<[Option<&S::PartId>; SIMD_WIDTH]>,
     ) -> SimdVisitStatus {
         let simd_point: Point<SimdReal> = Point::splat(*self.point);

--- a/src/query/visitors/mod.rs
+++ b/src/query/visitors/mod.rs
@@ -1,17 +1,29 @@
 //! Visitors for performing geometric queries exploiting spatial partitioning data structures.
 
+#[cfg(feature = "std")]
 pub use self::aabb_sets_interferences_collector::AABBSetsInterferencesCollector;
+#[cfg(feature = "std")]
 pub use self::bounding_volume_intersections_simultaneous_visitor::BoundingVolumeIntersectionsSimultaneousVisitor;
+#[cfg(feature = "std")]
 pub use self::bounding_volume_intersections_visitor::BoundingVolumeIntersectionsVisitor;
+#[cfg(feature = "std")]
 pub use self::composite_closest_point_visitor::CompositeClosestPointVisitor;
 pub use self::composite_point_containment_test::CompositePointContainmentTest;
+#[cfg(feature = "std")]
 pub use self::point_intersections_visitor::PointIntersectionsVisitor;
+#[cfg(feature = "std")]
 pub use self::ray_intersections_visitor::RayIntersectionsVisitor;
 
+#[cfg(feature = "std")]
 mod aabb_sets_interferences_collector;
+#[cfg(feature = "std")]
 mod bounding_volume_intersections_simultaneous_visitor;
+#[cfg(feature = "std")]
 mod bounding_volume_intersections_visitor;
+#[cfg(feature = "std")]
 mod composite_closest_point_visitor;
 mod composite_point_containment_test;
+#[cfg(feature = "std")]
 mod point_intersections_visitor;
+#[cfg(feature = "std")]
 mod ray_intersections_visitor;

--- a/src/query/visitors/mod.rs
+++ b/src/query/visitors/mod.rs
@@ -1,7 +1,7 @@
 //! Visitors for performing geometric queries exploiting spatial partitioning data structures.
 
 #[cfg(feature = "std")]
-pub use self::aabb_sets_interferences_collector::AABBSetsInterferencesCollector;
+pub use self::aabb_sets_interferences_collector::AabbSetsInterferencesCollector;
 #[cfg(feature = "std")]
 pub use self::bounding_volume_intersections_simultaneous_visitor::BoundingVolumeIntersectionsSimultaneousVisitor;
 #[cfg(feature = "std")]

--- a/src/query/visitors/point_intersections_visitor.rs
+++ b/src/query/visitors/point_intersections_visitor.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::SimdAABB;
+use crate::bounding_volume::SimdAabb;
 use crate::math::{Point, Real, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdVisitStatus, SimdVisitor};
 use simba::simd::{SimdBool as _, SimdValue};
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 /// Spatial partitioning structure visitor collecting nodes that may contain a given point.
 pub struct PointIntersectionsVisitor<'a, T, F> {
     simd_point: Point<SimdReal>,
-    /// Callback executed for each leaf which AABB contains `self.point`.
+    /// Callback executed for each leaf which Aabb contains `self.point`.
     callback: &'a mut F,
     _phantom: PhantomData<T>,
 }
@@ -29,12 +29,12 @@ where
     }
 }
 
-impl<'a, T, F> SimdVisitor<T, SimdAABB> for PointIntersectionsVisitor<'a, T, F>
+impl<'a, T, F> SimdVisitor<T, SimdAabb> for PointIntersectionsVisitor<'a, T, F>
 where
     F: FnMut(&T) -> bool,
 {
     #[inline]
-    fn visit(&mut self, bv: &SimdAABB, b: Option<[Option<&T>; SIMD_WIDTH]>) -> SimdVisitStatus {
+    fn visit(&mut self, bv: &SimdAabb, b: Option<[Option<&T>; SIMD_WIDTH]>) -> SimdVisitStatus {
         let mask = bv.contains_local_point(&self.simd_point);
 
         if let Some(data) = b {

--- a/src/query/visitors/ray_intersections_visitor.rs
+++ b/src/query/visitors/ray_intersections_visitor.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::SimdAABB;
+use crate::bounding_volume::SimdAabb;
 use crate::math::{Real, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdVisitStatus, SimdVisitor};
 use crate::query::{Ray, SimdRay};
@@ -29,12 +29,12 @@ where
     }
 }
 
-impl<'a, T, F> SimdVisitor<T, SimdAABB> for RayIntersectionsVisitor<'a, T, F>
+impl<'a, T, F> SimdVisitor<T, SimdAabb> for RayIntersectionsVisitor<'a, T, F>
 where
     F: FnMut(&T) -> bool,
 {
     #[inline]
-    fn visit(&mut self, bv: &SimdAABB, b: Option<[Option<&T>; SIMD_WIDTH]>) -> SimdVisitStatus {
+    fn visit(&mut self, bv: &SimdAabb, b: Option<[Option<&T>; SIMD_WIDTH]>) -> SimdVisitStatus {
         let mask = bv.cast_local_ray(&self.simd_ray, self.max_toi).0;
 
         if let Some(data) = b {

--- a/src/shape/composite_shape.rs
+++ b/src/shape/composite_shape.rs
@@ -1,5 +1,5 @@
 use crate::math::{Isometry, Real};
-use crate::partitioning::{GenericQBVH, IndexedData, QBVHStorage, QBVH};
+use crate::partitioning::{GenericQbvh, IndexedData, Qbvh, QbvhStorage};
 use crate::shape::Shape;
 use crate::utils::DefaultStorage;
 
@@ -13,13 +13,13 @@ pub trait SimdCompositeShape {
     fn map_part_at(&self, shape_id: u32, f: &mut dyn FnMut(Option<&Isometry<Real>>, &dyn Shape));
 
     /// Gets the acceleration structure of the composite shape.
-    fn qbvh(&self) -> &QBVH<u32>;
+    fn qbvh(&self) -> &Qbvh<u32>;
 }
 
 pub trait TypedSimdCompositeShape {
     type PartShape: ?Sized + Shape;
     type PartId: IndexedData;
-    type QBVHStorage: QBVHStorage<Self::PartId>;
+    type QbvhStorage: QbvhStorage<Self::PartId>;
 
     fn map_typed_part_at(
         &self,
@@ -36,14 +36,14 @@ pub trait TypedSimdCompositeShape {
         f: impl FnMut(Option<&Isometry<Real>>, &dyn Shape),
     );
 
-    fn typed_qbvh(&self) -> &GenericQBVH<Self::PartId, Self::QBVHStorage>;
+    fn typed_qbvh(&self) -> &GenericQbvh<Self::PartId, Self::QbvhStorage>;
 }
 
 #[cfg(feature = "std")]
 impl<'a> TypedSimdCompositeShape for dyn SimdCompositeShape + 'a {
     type PartShape = dyn Shape;
     type PartId = u32;
-    type QBVHStorage = DefaultStorage;
+    type QbvhStorage = DefaultStorage;
 
     fn map_typed_part_at(
         &self,
@@ -61,7 +61,7 @@ impl<'a> TypedSimdCompositeShape for dyn SimdCompositeShape + 'a {
         self.map_part_at(shape_id, &mut f)
     }
 
-    fn typed_qbvh(&self) -> &GenericQBVH<Self::PartId, Self::QBVHStorage> {
+    fn typed_qbvh(&self) -> &GenericQbvh<Self::PartId, Self::QbvhStorage> {
         self.qbvh()
     }
 }

--- a/src/shape/composite_shape.rs
+++ b/src/shape/composite_shape.rs
@@ -1,11 +1,13 @@
 use crate::math::{Isometry, Real};
-use crate::partitioning::{IndexedData, QBVH};
+use crate::partitioning::{GenericQBVH, IndexedData, QBVHStorage, QBVH};
 use crate::shape::Shape;
+use crate::utils::DefaultStorage;
 
 /// Trait implemented by shapes composed of multiple simpler shapes.
 ///
 /// A composite shape is composed of several shapes. For example, this can
 /// be a convex decomposition of a concave shape; or a triangle-mesh.
+#[cfg(feature = "std")]
 pub trait SimdCompositeShape {
     /// Applies a function to one sub-shape of this composite shape.
     fn map_part_at(&self, shape_id: u32, f: &mut dyn FnMut(Option<&Isometry<Real>>, &dyn Shape));
@@ -17,6 +19,7 @@ pub trait SimdCompositeShape {
 pub trait TypedSimdCompositeShape {
     type PartShape: ?Sized + Shape;
     type PartId: IndexedData;
+    type QBVHStorage: QBVHStorage<Self::PartId>;
 
     fn map_typed_part_at(
         &self,
@@ -33,12 +36,14 @@ pub trait TypedSimdCompositeShape {
         f: impl FnMut(Option<&Isometry<Real>>, &dyn Shape),
     );
 
-    fn typed_qbvh(&self) -> &QBVH<Self::PartId>;
+    fn typed_qbvh(&self) -> &GenericQBVH<Self::PartId, Self::QBVHStorage>;
 }
 
+#[cfg(feature = "std")]
 impl<'a> TypedSimdCompositeShape for dyn SimdCompositeShape + 'a {
     type PartShape = dyn Shape;
     type PartId = u32;
+    type QBVHStorage = DefaultStorage;
 
     fn map_typed_part_at(
         &self,
@@ -56,7 +61,7 @@ impl<'a> TypedSimdCompositeShape for dyn SimdCompositeShape + 'a {
         self.map_part_at(shape_id, &mut f)
     }
 
-    fn typed_qbvh(&self) -> &QBVH<Self::PartId> {
+    fn typed_qbvh(&self) -> &GenericQBVH<Self::PartId, Self::QBVHStorage> {
         self.qbvh()
     }
 }

--- a/src/shape/compound.rs
+++ b/src/shape/compound.rs
@@ -10,6 +10,7 @@ use crate::shape::{ConvexPolygon, TriMesh, Triangle};
 use crate::shape::{Shape, SharedShape, SimdCompositeShape, TypedSimdCompositeShape};
 #[cfg(feature = "dim2")]
 use crate::transformation::hertel_mehlhorn;
+use crate::utils::DefaultStorage;
 
 /// A compound shape with an aabb bounding volume.
 ///
@@ -137,6 +138,7 @@ impl SimdCompositeShape for Compound {
 impl TypedSimdCompositeShape for Compound {
     type PartShape = dyn Shape;
     type PartId = u32;
+    type QBVHStorage = DefaultStorage;
 
     #[inline(always)]
     fn map_typed_part_at(

--- a/src/shape/compound.rs
+++ b/src/shape/compound.rs
@@ -2,9 +2,9 @@
 //! Shape composed from the union of primitives.
 //!
 
-use crate::bounding_volume::{BoundingSphere, BoundingVolume, AABB};
+use crate::bounding_volume::{Aabb, BoundingSphere, BoundingVolume};
 use crate::math::{Isometry, Real};
-use crate::partitioning::QBVH;
+use crate::partitioning::Qbvh;
 #[cfg(feature = "dim2")]
 use crate::shape::{ConvexPolygon, TriMesh, Triangle};
 use crate::shape::{Shape, SharedShape, SimdCompositeShape, TypedSimdCompositeShape};
@@ -21,9 +21,9 @@ use crate::utils::DefaultStorage;
 #[derive(Clone)]
 pub struct Compound {
     shapes: Vec<(Isometry<Real>, SharedShape)>,
-    qbvh: QBVH<u32>,
-    aabbs: Vec<AABB>,
-    aabb: AABB,
+    qbvh: Qbvh<u32>,
+    aabbs: Vec<Aabb>,
+    aabb: Aabb,
 }
 
 impl Compound {
@@ -38,7 +38,7 @@ impl Compound {
         );
         let mut aabbs = Vec::new();
         let mut leaves = Vec::new();
-        let mut aabb = AABB::new_invalid();
+        let mut aabb = Aabb::new_invalid();
 
         for (i, &(ref delta, ref shape)) in shapes.iter().enumerate() {
             let bv = shape.compute_aabb(delta);
@@ -52,7 +52,7 @@ impl Compound {
             }
         }
 
-        let mut qbvh = QBVH::new();
+        let mut qbvh = Qbvh::new();
         // NOTE: we apply no dilation factor because we won't
         // update this tree dynamically.
         qbvh.clear_and_rebuild(leaves.into_iter(), 0.0);
@@ -96,9 +96,9 @@ impl Compound {
         &self.shapes[..]
     }
 
-    /// The AABB of this compound in its local-space.
+    /// The Aabb of this compound in its local-space.
     #[inline]
-    pub fn local_aabb(&self) -> &AABB {
+    pub fn local_aabb(&self) -> &Aabb {
         &self.aabb
     }
 
@@ -108,15 +108,15 @@ impl Compound {
         self.aabb.bounding_sphere()
     }
 
-    /// The shapes AABBs.
+    /// The shapes Aabbs.
     #[inline]
-    pub fn aabbs(&self) -> &[AABB] {
+    pub fn aabbs(&self) -> &[Aabb] {
         &self.aabbs[..]
     }
 
     /// The acceleration structure used by this compound shape.
     #[inline]
-    pub fn qbvh(&self) -> &QBVH<u32> {
+    pub fn qbvh(&self) -> &Qbvh<u32> {
         &self.qbvh
     }
 }
@@ -130,7 +130,7 @@ impl SimdCompositeShape for Compound {
     }
 
     #[inline]
-    fn qbvh(&self) -> &QBVH<u32> {
+    fn qbvh(&self) -> &Qbvh<u32> {
         &self.qbvh
     }
 }
@@ -138,7 +138,7 @@ impl SimdCompositeShape for Compound {
 impl TypedSimdCompositeShape for Compound {
     type PartShape = dyn Shape;
     type PartId = u32;
-    type QBVHStorage = DefaultStorage;
+    type QbvhStorage = DefaultStorage;
 
     #[inline(always)]
     fn map_typed_part_at(
@@ -163,7 +163,7 @@ impl TypedSimdCompositeShape for Compound {
     }
 
     #[inline]
-    fn typed_qbvh(&self) -> &QBVH<u32> {
+    fn typed_qbvh(&self) -> &Qbvh<u32> {
         &self.qbvh
     }
 }

--- a/src/shape/heightfield2.rs
+++ b/src/shape/heightfield2.rs
@@ -14,7 +14,7 @@ use {crate::utils::CudaArray1, cust::error::CudaResult};
 
 use na::Point2;
 
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Real, Vector};
 
 use crate::shape::Segment;
@@ -26,7 +26,7 @@ pub type HeightFieldCellStatus = bool;
 
 /// Trait describing all the types needed for storing an heightfield’s data.
 pub trait HeightFieldStorage {
-    /// Type of the array containing the heightfield’s heigths.
+    /// Type of the array containing the heightfield’s heights.
     type Heights: Array1<Real>;
     /// Type of the array containing the heightfield’s cells status.
     type Status: Array1<HeightFieldCellStatus>;
@@ -63,7 +63,7 @@ pub struct GenericHeightField<Storage: HeightFieldStorage> {
     status: Storage::Status,
 
     scale: Vector<Real>,
-    aabb: AABB,
+    aabb: Aabb,
 }
 
 impl<Storage> Clone for GenericHeightField<Storage>
@@ -123,7 +123,7 @@ impl HeightField {
         let max = heights.max();
         let min = heights.min();
         let hscale = scale * 0.5;
-        let aabb = AABB::new(
+        let aabb = Aabb::new(
             Point2::new(-hscale.x, min * scale.y),
             Point2::new(hscale.x, max * scale.y),
         );
@@ -192,8 +192,8 @@ impl<Storage: HeightFieldStorage> GenericHeightField<Storage> {
         self
     }
 
-    /// The AABB of this heightfield.
-    pub fn root_aabb(&self) -> &AABB {
+    /// The Aabb of this heightfield.
+    pub fn root_aabb(&self) -> &Aabb {
         &self.aabb
     }
 
@@ -303,8 +303,8 @@ impl<Storage: HeightFieldStorage> GenericHeightField<Storage> {
         !self.status[i]
     }
 
-    /// The range of segment ids that may intersect the given local AABB.
-    pub fn unclamped_elements_range_in_local_aabb(&self, aabb: &AABB) -> Range<isize> {
+    /// The range of segment ids that may intersect the given local Aabb.
+    pub fn unclamped_elements_range_in_local_aabb(&self, aabb: &Aabb) -> Range<isize> {
         let ref_mins = aabb.mins.coords.component_div(&self.scale);
         let ref_maxs = aabb.maxs.coords.component_div(&self.scale);
         let seg_length = 1.0 / (self.heights.len() as Real - 1.0);
@@ -315,7 +315,7 @@ impl<Storage: HeightFieldStorage> GenericHeightField<Storage> {
     }
 
     /// Applies `f` to each segment of this heightfield that intersects the given `aabb`.
-    pub fn map_elements_in_local_aabb(&self, aabb: &AABB, f: &mut impl FnMut(u32, &Segment)) {
+    pub fn map_elements_in_local_aabb(&self, aabb: &Aabb, f: &mut impl FnMut(u32, &Segment)) {
         let ref_mins = aabb.mins.coords.component_div(&self.scale);
         let ref_maxs = aabb.maxs.coords.component_div(&self.scale);
         let seg_length = 1.0 / (self.heights.len() as Real - 1.0);

--- a/src/shape/heightfield2.rs
+++ b/src/shape/heightfield2.rs
@@ -24,8 +24,11 @@ use crate::utils::Array1;
 /// a removed cell.
 pub type HeightFieldCellStatus = bool;
 
+/// Trait describing all the types needed for storing an heightfield’s data.
 pub trait HeightFieldStorage {
+    /// Type of the array containing the heightfield’s heigths.
     type Heights: Array1<Real>;
+    /// Type of the array containing the heightfield’s cells status.
     type Status: Array1<HeightFieldCellStatus>;
 }
 

--- a/src/shape/heightfield3.rs
+++ b/src/shape/heightfield3.rs
@@ -8,7 +8,7 @@ use crate::utils::{CudaArrayPointer2, CudaStorage, CudaStoragePtr};
 #[cfg(all(feature = "std", feature = "cuda"))]
 use {crate::utils::CudaArray2, cust::error::CudaResult};
 
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Real, Vector};
 use crate::shape::{FeatureId, Triangle};
 use crate::utils::Array2;
@@ -40,7 +40,7 @@ bitflags! {
 
 /// Trait describing all the types needed for storing an heightfield’s data.
 pub trait HeightFieldStorage {
-    /// Type of the array containing the heightfield’s heigths.
+    /// Type of the array containing the heightfield’s heights.
     type Heights: Array2<Item = Real>;
     /// Type of the array containing the heightfield’s cells status.
     type Status: Array2<Item = HeightFieldCellStatus>;
@@ -77,7 +77,7 @@ pub struct GenericHeightField<Storage: HeightFieldStorage> {
     status: Storage::Status,
 
     scale: Vector<Real>,
-    aabb: AABB,
+    aabb: Aabb,
     num_triangles: usize,
 }
 
@@ -138,7 +138,7 @@ impl HeightField {
         let max = heights.max();
         let min = heights.min();
         let hscale = scale * 0.5;
-        let aabb = AABB::new(
+        let aabb = Aabb::new(
             Point3::new(-hscale.x, min * scale.y, -hscale.z),
             Point3::new(hscale.x, max * scale.y, hscale.z),
         );
@@ -546,8 +546,8 @@ impl<Storage: HeightFieldStorage> GenericHeightField<Storage> {
         1.0 / (self.heights.nrows() as Real - 1.0)
     }
 
-    /// The AABB of this heightmap.
-    pub fn root_aabb(&self) -> &AABB {
+    /// The Aabb of this heightmap.
+    pub fn root_aabb(&self) -> &Aabb {
         &self.aabb
     }
 
@@ -645,10 +645,10 @@ impl<Storage: HeightFieldStorage> GenericHeightField<Storage> {
         }
     }
 
-    /// The range of segment ids that may intersect the given local AABB.
+    /// The range of segment ids that may intersect the given local Aabb.
     pub fn unclamped_elements_range_in_local_aabb(
         &self,
-        aabb: &AABB,
+        aabb: &Aabb,
     ) -> (Range<isize>, Range<isize>) {
         let ref_mins = aabb.mins.coords.component_div(&self.scale);
         let ref_maxs = aabb.maxs.coords.component_div(&self.scale);
@@ -663,8 +663,8 @@ impl<Storage: HeightFieldStorage> GenericHeightField<Storage> {
         (min_z..max_z, min_x..max_x)
     }
 
-    /// Applies the function `f` to all the triangles of this heightfield intersecting the given AABB.
-    pub fn map_elements_in_local_aabb(&self, aabb: &AABB, f: &mut impl FnMut(u32, &Triangle)) {
+    /// Applies the function `f` to all the triangles of this heightfield intersecting the given Aabb.
+    pub fn map_elements_in_local_aabb(&self, aabb: &Aabb, f: &mut impl FnMut(u32, &Triangle)) {
         let ncells_x = self.ncols();
         let ncells_z = self.nrows();
 

--- a/src/shape/heightfield3.rs
+++ b/src/shape/heightfield3.rs
@@ -1,13 +1,18 @@
+use crate::utils::DefaultStorage;
 #[cfg(feature = "std")]
 use na::DMatrix;
 use std::ops::Range;
+
+#[cfg(feature = "cuda")]
+use crate::utils::{CudaArrayPointer2, CudaStorage, CudaStoragePtr};
 #[cfg(all(feature = "std", feature = "cuda"))]
 use {crate::utils::CudaArray2, cust::error::CudaResult};
 
 use crate::bounding_volume::AABB;
 use crate::math::{Real, Vector};
 use crate::shape::{FeatureId, Triangle};
-use na::{Point3, Scalar};
+use crate::utils::Array2;
+use na::Point3;
 
 #[cfg(not(feature = "std"))]
 use na::ComplexField;
@@ -24,7 +29,7 @@ bitflags! {
     pub struct HeightFieldCellStatus: u8 {
         /// If this bit is set, the concerned heightfield cell is subdivided using a Z pattern.
         const ZIGZAG_SUBDIVISION = 0b00000001;
-        /// If this bit is set, the leftmost triangle of the concerned heightfield cell is remove d.
+        /// If this bit is set, the leftmost triangle of the concerned heightfield cell is removed.
         const LEFT_TRIANGLE_REMOVED = 0b00000010;
         /// If this bit is set, the rightmost triangle of the concerned heightfield cell is removed.
         const RIGHT_TRIANGLE_REMOVED = 0b00000100;
@@ -33,43 +38,27 @@ bitflags! {
     }
 }
 
-/// Abstraction over the storage type of an heightfield’s heights grid.
 pub trait HeightFieldStorage {
-    /// The type of heights.
-    type Item;
-    /// The number of rows of the heights grid.
-    fn nrows(&self) -> usize;
-    /// The number of columns of the heights grid.
-    fn ncols(&self) -> usize;
-    /// Gets the height on the `(i, j)`-th cell of the height grid.
-    fn get(&self, i: usize, j: usize) -> Self::Item;
-    /// Sets the height on the `(i, j)`-th cell of the height grid.
-    fn set(&mut self, i: usize, j: usize, val: Self::Item);
+    type Heights: Array2<Item = Real>;
+    type Status: Array2<Item = HeightFieldCellStatus>;
 }
 
 #[cfg(feature = "std")]
-impl<T: Scalar> HeightFieldStorage for DMatrix<T> {
-    type Item = T;
+impl HeightFieldStorage for DefaultStorage {
+    type Heights = DMatrix<Real>;
+    type Status = DMatrix<HeightFieldCellStatus>;
+}
 
-    #[inline]
-    fn nrows(&self) -> usize {
-        self.nrows()
-    }
+#[cfg(all(feature = "std", feature = "cuda"))]
+impl HeightFieldStorage for CudaStorage {
+    type Heights = CudaArray2<Real>;
+    type Status = CudaArray2<HeightFieldCellStatus>;
+}
 
-    #[inline]
-    fn ncols(&self) -> usize {
-        self.ncols()
-    }
-
-    #[inline]
-    fn get(&self, i: usize, j: usize) -> Self::Item {
-        self[(i, j)].clone()
-    }
-
-    #[inline]
-    fn set(&mut self, i: usize, j: usize, val: Self::Item) {
-        self[(i, j)] = val
-    }
+#[cfg(feature = "cuda")]
+impl HeightFieldStorage for CudaStoragePtr {
+    type Heights = CudaArrayPointer2<Real>;
+    type Status = CudaArrayPointer2<HeightFieldCellStatus>;
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -77,33 +66,63 @@ impl<T: Scalar> HeightFieldStorage for DMatrix<T> {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
-#[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug)]
 #[repr(C)] // Needed for Cuda.
 /// A 3D heightfield with a generic storage buffer for its height grid.
-pub struct GenericHeightField<Heights, Status> {
-    heights: Heights,
-    status: Status,
+pub struct GenericHeightField<Storage: HeightFieldStorage> {
+    heights: Storage::Heights,
+    status: Storage::Status,
 
     scale: Vector<Real>,
     aabb: AABB,
     num_triangles: usize,
 }
 
+impl<Storage> Clone for GenericHeightField<Storage>
+where
+    Storage: HeightFieldStorage,
+    Storage::Heights: Clone,
+    Storage::Status: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            heights: self.heights.clone(),
+            status: self.status.clone(),
+            scale: self.scale,
+            aabb: self.aabb,
+            num_triangles: self.num_triangles,
+        }
+    }
+}
+
+impl<Storage> Copy for GenericHeightField<Storage>
+where
+    Storage: HeightFieldStorage,
+    Storage::Heights: Copy,
+    Storage::Status: Copy,
+{
+}
+
+#[cfg(feature = "cuda")]
+unsafe impl<Storage> cust_core::DeviceCopy for GenericHeightField<Storage>
+where
+    Storage: HeightFieldStorage,
+    Storage::Heights: cust_core::DeviceCopy + Copy,
+    Storage::Status: cust_core::DeviceCopy + Copy,
+{
+}
+
 /// A 3D heightfield.
 #[cfg(feature = "std")]
-pub type HeightField = GenericHeightField<DMatrix<Real>, DMatrix<HeightFieldCellStatus>>;
+pub type HeightField = GenericHeightField<DefaultStorage>;
 
 /// A 3D heightfield stored in the CUDA memory, initializable from the host.
 #[cfg(all(feature = "std", feature = "cuda"))]
-pub type CudaHeightField = GenericHeightField<CudaArray2<Real>, CudaArray2<HeightFieldCellStatus>>;
+pub type CudaHeightField = GenericHeightField<CudaStorage>;
 
 /// A 3D heightfield stored in the CUDA memory, accessible from within a Cuda kernel.
 #[cfg(feature = "cuda")]
-pub type CudaHeightFieldPointer = GenericHeightField<
-    crate::utils::CudaArrayPointer2<Real>,
-    crate::utils::CudaArrayPointer2<HeightFieldCellStatus>,
->;
+pub type CudaHeightFieldPtr = GenericHeightField<CudaStoragePtr>;
 
 #[cfg(feature = "std")]
 impl HeightField {
@@ -152,8 +171,8 @@ impl HeightField {
 #[cfg(all(feature = "std", feature = "cuda"))]
 impl CudaHeightField {
     /// Returns the heightfield usable from within a CUDA kernel.
-    pub fn as_device_ptr(&self) -> CudaHeightFieldPointer {
-        CudaHeightFieldPointer {
+    pub fn as_device_ptr(&self) -> CudaHeightFieldPtr {
+        CudaHeightFieldPtr {
             heights: self.heights.as_device_ptr(),
             status: self.status.as_device_ptr(),
             aabb: self.aabb,
@@ -163,11 +182,7 @@ impl CudaHeightField {
     }
 }
 
-impl<Heights, Status> GenericHeightField<Heights, Status>
-where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
-{
+impl<Storage: HeightFieldStorage> GenericHeightField<Storage> {
     /// The number of rows of this heightfield.
     pub fn nrows(&self) -> usize {
         self.heights.nrows() - 1
@@ -303,7 +318,7 @@ where
     pub fn triangles_around_point<'a>(
         &'a self,
         point: &Point3<Real>,
-    ) -> HeightFieldRadialTriangles<Heights, Status> {
+    ) -> HeightFieldRadialTriangles<Storage> {
         let center = self.closest_cell_at_point(point);
         HeightFieldRadialTriangles {
             heightfield: self,
@@ -475,17 +490,17 @@ where
     }
 
     /// The statuses of all the cells of this heightfield.
-    pub fn cells_statuses(&self) -> &Status {
+    pub fn cells_statuses(&self) -> &Storage::Status {
         &self.status
     }
 
     /// The mutable statuses of all the cells of this heightfield.
-    pub fn cells_statuses_mut(&mut self) -> &mut Status {
+    pub fn cells_statuses_mut(&mut self) -> &mut Storage::Status {
         &mut self.status
     }
 
     /// The heights of this heightfield.
-    pub fn heights(&self) -> &Heights {
+    pub fn heights(&self) -> &Storage::Heights {
         &self.heights
     }
 
@@ -733,17 +748,13 @@ where
     }
 }
 
-struct HeightFieldTriangles<'a, Heights, Status> {
-    heightfield: &'a GenericHeightField<Heights, Status>,
+struct HeightFieldTriangles<'a, Storage: HeightFieldStorage> {
+    heightfield: &'a GenericHeightField<Storage>,
     curr: (usize, usize),
     tris: (Option<Triangle>, Option<Triangle>),
 }
 
-impl<'a, Heights, Status> Iterator for HeightFieldTriangles<'a, Heights, Status>
-where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
-{
+impl<'a, Storage: HeightFieldStorage> Iterator for HeightFieldTriangles<'a, Storage> {
     type Item = Triangle;
 
     fn next(&mut self) -> Option<Triangle> {
@@ -772,19 +783,15 @@ where
 }
 
 /// An iterator through all the triangles around the given point, after vertical projection on the heightfield.
-pub struct HeightFieldRadialTriangles<'a, Heights, Status> {
-    heightfield: &'a GenericHeightField<Heights, Status>,
+pub struct HeightFieldRadialTriangles<'a, Storage: HeightFieldStorage> {
+    heightfield: &'a GenericHeightField<Storage>,
     center: (usize, usize),
     curr_radius: usize,
     curr_element: usize,
     tris: (Option<Triangle>, Option<Triangle>),
 }
 
-impl<'a, Heights, Status> HeightFieldRadialTriangles<'a, Heights, Status>
-where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
-{
+impl<'a, Storage: HeightFieldStorage> HeightFieldRadialTriangles<'a, Storage> {
     /// Returns the next triangle in this iterator.
     ///
     /// Returns `None` no triangle closest than `max_dist` remain

--- a/src/shape/heightfield3.rs
+++ b/src/shape/heightfield3.rs
@@ -38,8 +38,11 @@ bitflags! {
     }
 }
 
+/// Trait describing all the types needed for storing an heightfield’s data.
 pub trait HeightFieldStorage {
+    /// Type of the array containing the heightfield’s heigths.
     type Heights: Array2<Item = Real>;
+    /// Type of the array containing the heightfield’s cells status.
     type Status: Array2<Item = HeightFieldCellStatus>;
 }
 

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -3,27 +3,26 @@
 pub use self::ball::Ball;
 pub use self::capsule::Capsule;
 #[doc(inline)]
-#[cfg(feature = "std")]
-pub use self::composite_shape::{SimdCompositeShape, TypedSimdCompositeShape};
-#[cfg(feature = "std")]
-pub use self::compound::Compound;
+pub use self::composite_shape::TypedSimdCompositeShape;
 pub use self::cuboid::Cuboid;
 pub use self::feature_id::{FeatureId, PackedFeatureId};
 pub use self::half_space::HalfSpace;
 pub use self::polygonal_feature_map::PolygonalFeatureMap;
-#[cfg(feature = "std")]
-pub use self::polyline::Polyline;
 pub use self::round_shape::RoundShape;
 pub use self::segment::{Segment, SegmentPointLocation};
 #[cfg(feature = "serde-serialize")]
 pub(crate) use self::shape::DeserializableTypedShape;
 #[doc(inline)]
 pub use self::shape::{Shape, ShapeType, TypedShape};
-#[cfg(feature = "std")]
-pub use self::shared_shape::SharedShape;
 #[doc(inline)]
 pub use self::support_map::SupportMap;
 pub use self::triangle::{Triangle, TriangleOrientation, TrianglePointLocation};
+
+#[cfg(feature = "std")]
+pub use self::{
+    composite_shape::SimdCompositeShape, compound::Compound, polyline::Polyline,
+    shared_shape::SharedShape,
+};
 
 #[cfg(feature = "dim2")]
 #[cfg(feature = "std")]
@@ -46,8 +45,8 @@ pub use self::heightfield3::*;
 pub use self::polygonal_feature3d::PolygonalFeature;
 #[cfg(feature = "dim3")]
 pub use self::tetrahedron::{Tetrahedron, TetrahedronPointLocation};
-#[cfg(feature = "std")]
 pub use self::trimesh::*;
+pub use self::trimesh_storage::TriMeshStorage;
 
 /// A cylinder dilated by a sphere (so it has round corners).
 #[cfg(feature = "dim3")]
@@ -71,7 +70,6 @@ pub type RoundConvexPolygon = RoundShape<ConvexPolygon>;
 mod ball;
 mod capsule;
 #[doc(hidden)]
-#[cfg(feature = "std")]
 pub mod composite_shape;
 #[cfg(feature = "std")]
 mod compound;
@@ -107,7 +105,6 @@ mod polygonal_feature3d;
 mod polygonal_feature_map;
 #[cfg(feature = "dim3")]
 mod tetrahedron;
-#[cfg(feature = "std")]
 pub(crate) mod trimesh;
 // TODO: move this elsewhere?
 mod feature_id;
@@ -115,3 +112,4 @@ mod feature_id;
 mod polygonal_feature2d;
 #[cfg(feature = "std")]
 mod shared_shape;
+mod trimesh_storage;

--- a/src/shape/polygon.rs
+++ b/src/shape/polygon.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)] // TODO: remove this once we support polygons.
 
 use crate::math::{Isometry, Point, Real, Vector};
-use parry::bounding_volume::AABB;
+use parry::bounding_volume::Aabb;
 
 #[derive(Clone)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -31,7 +31,7 @@ impl Polygon {
     }
 
     /// Compute the axis-aligned bounding box of the polygon.
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
         let p0 = pos * self.vertices[0];
         let mut mins = p0;
         let mut maxs = p0;
@@ -42,7 +42,7 @@ impl Polygon {
             maxs = maxs.sup(&pt);
         }
 
-        AABB::new(mins.into(), maxs.into())
+        Aabb::new(mins.into(), maxs.into())
     }
 
     /// The vertices of this polygon.

--- a/src/shape/polyline.rs
+++ b/src/shape/polyline.rs
@@ -5,6 +5,7 @@ use crate::query::{PointProjection, PointQueryWithLocation};
 use crate::shape::composite_shape::SimdCompositeShape;
 use crate::shape::{FeatureId, Segment, SegmentPointLocation, Shape, TypedSimdCompositeShape};
 
+use crate::utils::DefaultStorage;
 #[cfg(not(feature = "std"))]
 use na::ComplexField; // for .abs()
 
@@ -225,6 +226,7 @@ impl SimdCompositeShape for Polyline {
 impl TypedSimdCompositeShape for Polyline {
     type PartShape = Segment;
     type PartId = u32;
+    type QBVHStorage = DefaultStorage;
 
     #[inline(always)]
     fn map_typed_part_at(

--- a/src/shape/polyline.rs
+++ b/src/shape/polyline.rs
@@ -1,6 +1,6 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Point, Real, Vector};
-use crate::partitioning::QBVH;
+use crate::partitioning::Qbvh;
 use crate::query::{PointProjection, PointQueryWithLocation};
 use crate::shape::composite_shape::SimdCompositeShape;
 use crate::shape::{FeatureId, Segment, SegmentPointLocation, Shape, TypedSimdCompositeShape};
@@ -17,7 +17,7 @@ use na::ComplexField; // for .abs()
 )]
 /// A polyline.
 pub struct Polyline {
-    qbvh: QBVH<u32>,
+    qbvh: Qbvh<u32>,
     vertices: Vec<Point<Real>>,
     indices: Vec<[u32; 2]>,
 }
@@ -33,7 +33,7 @@ impl Polyline {
             (i as u32, aabb)
         });
 
-        let mut qbvh = QBVH::new();
+        let mut qbvh = Qbvh::new();
         // NOTE: we apply no dilation factor because we won't
         // update this tree dynamically.
         qbvh.clear_and_rebuild(data, 0.0);
@@ -46,16 +46,16 @@ impl Polyline {
     }
 
     /// Compute the axis-aligned bounding box of this polyline.
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
         self.qbvh.root_aabb().transform_by(pos)
     }
 
     /// Gets the local axis-aligned bounding box of this polyline.
-    pub fn local_aabb(&self) -> &AABB {
+    pub fn local_aabb(&self) -> &Aabb {
         &self.qbvh.root_aabb()
     }
 
-    pub(crate) fn qbvh(&self) -> &QBVH<u32> {
+    pub(crate) fn qbvh(&self) -> &Qbvh<u32> {
         &self.qbvh
     }
 
@@ -137,7 +137,7 @@ impl Polyline {
         self.indices.reverse();
 
         // Because we reversed the indices, we need to
-        // adjust the segment indices stored in the QBVH.
+        // adjust the segment indices stored in the Qbvh.
         for (_, seg_id) in self.qbvh.iter_data_mut() {
             *seg_id = self.indices.len() as u32 - *seg_id - 1;
         }
@@ -218,7 +218,7 @@ impl SimdCompositeShape for Polyline {
         f(None, &tri)
     }
 
-    fn qbvh(&self) -> &QBVH<u32> {
+    fn qbvh(&self) -> &Qbvh<u32> {
         &self.qbvh
     }
 }
@@ -226,7 +226,7 @@ impl SimdCompositeShape for Polyline {
 impl TypedSimdCompositeShape for Polyline {
     type PartShape = Segment;
     type PartId = u32;
-    type QBVHStorage = DefaultStorage;
+    type QbvhStorage = DefaultStorage;
 
     #[inline(always)]
     fn map_typed_part_at(
@@ -244,7 +244,7 @@ impl TypedSimdCompositeShape for Polyline {
         f(None, &seg)
     }
 
-    fn typed_qbvh(&self) -> &QBVH<u32> {
+    fn typed_qbvh(&self) -> &Qbvh<u32> {
         &self.qbvh
     }
 }

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::{BoundingSphere, BoundingVolume, AABB};
+use crate::bounding_volume::{Aabb, BoundingSphere, BoundingVolume};
 use crate::mass_properties::MassProperties;
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::query::{PointQuery, RayCast};
@@ -272,8 +272,8 @@ impl DeserializableTypedShape {
 
 /// Trait implemented by shapes usable by Rapier.
 pub trait Shape: RayCast + PointQuery + DowncastSync {
-    /// Computes the AABB of this shape.
-    fn compute_local_aabb(&self) -> AABB;
+    /// Computes the Aabb of this shape.
+    fn compute_local_aabb(&self) -> Aabb;
     /// Computes the bounding-sphere of this shape.
     fn compute_local_bounding_sphere(&self) -> BoundingSphere;
 
@@ -281,8 +281,8 @@ pub trait Shape: RayCast + PointQuery + DowncastSync {
     #[cfg(feature = "std")]
     fn clone_box(&self) -> Box<dyn Shape>;
 
-    /// Computes the AABB of this shape with the given position.
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    /// Computes the Aabb of this shape with the given position.
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.compute_local_aabb().transform_by(position)
     }
     /// Computes the bounding-sphere of this shape with the given position.
@@ -346,9 +346,9 @@ pub trait Shape: RayCast + PointQuery + DowncastSync {
         None
     }
 
-    /// Computes the swept AABB of this shape, i.e., the space it would occupy by moving from
+    /// Computes the swept Aabb of this shape, i.e., the space it would occupy by moving from
     /// the given start position to the given end position.
-    fn compute_swept_aabb(&self, start_pos: &Isometry<Real>, end_pos: &Isometry<Real>) -> AABB {
+    fn compute_swept_aabb(&self, start_pos: &Isometry<Real>, end_pos: &Isometry<Real>) -> Aabb {
         let aabb1 = self.compute_aabb(start_pos);
         let aabb2 = self.compute_aabb(end_pos);
         aabb1.merged(&aabb2)
@@ -584,7 +584,7 @@ impl Shape for Ball {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         self.local_aabb()
     }
 
@@ -592,7 +592,7 @@ impl Shape for Ball {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -641,7 +641,7 @@ impl Shape for Cuboid {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         self.local_aabb()
     }
 
@@ -649,7 +649,7 @@ impl Shape for Cuboid {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -700,7 +700,7 @@ impl Shape for Capsule {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         self.local_aabb()
     }
 
@@ -708,7 +708,7 @@ impl Shape for Capsule {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -751,7 +751,7 @@ impl Shape for Triangle {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         self.local_aabb()
     }
 
@@ -759,7 +759,7 @@ impl Shape for Triangle {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -814,7 +814,7 @@ impl Shape for Segment {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         self.local_aabb()
     }
 
@@ -822,7 +822,7 @@ impl Shape for Segment {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -873,7 +873,7 @@ impl Shape for Compound {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         *self.local_aabb()
     }
 
@@ -881,7 +881,7 @@ impl Shape for Compound {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.local_aabb().transform_by(position)
     }
 
@@ -921,7 +921,7 @@ impl Shape for Polyline {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         *self.local_aabb()
     }
 
@@ -929,7 +929,7 @@ impl Shape for Polyline {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -967,7 +967,7 @@ impl Shape for TriMesh {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         *self.local_aabb()
     }
 
@@ -975,7 +975,7 @@ impl Shape for TriMesh {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -1014,7 +1014,7 @@ impl Shape for HeightField {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         self.local_aabb()
     }
 
@@ -1022,7 +1022,7 @@ impl Shape for HeightField {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -1056,7 +1056,7 @@ impl Shape for ConvexPolygon {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         self.local_aabb()
     }
 
@@ -1064,7 +1064,7 @@ impl Shape for ConvexPolygon {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -1119,7 +1119,7 @@ impl Shape for ConvexPolyhedron {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         self.local_aabb()
     }
 
@@ -1127,7 +1127,7 @@ impl Shape for ConvexPolyhedron {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -1183,7 +1183,7 @@ impl Shape for Cylinder {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         self.local_aabb()
     }
 
@@ -1191,7 +1191,7 @@ impl Shape for Cylinder {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -1235,7 +1235,7 @@ impl Shape for Cone {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         self.local_aabb()
     }
 
@@ -1243,7 +1243,7 @@ impl Shape for Cone {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -1289,7 +1289,7 @@ impl Shape for HalfSpace {
         Box::new(self.clone())
     }
 
-    fn compute_local_aabb(&self) -> AABB {
+    fn compute_local_aabb(&self) -> Aabb {
         self.local_aabb()
     }
 
@@ -1297,7 +1297,7 @@ impl Shape for HalfSpace {
         self.local_bounding_sphere()
     }
 
-    fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+    fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
         self.aabb(position)
     }
 
@@ -1334,7 +1334,7 @@ macro_rules! impl_shape_for_round_shape(
                 Box::new(self.clone())
             }
 
-            fn compute_local_aabb(&self) -> AABB {
+            fn compute_local_aabb(&self) -> Aabb {
                 self.inner_shape.local_aabb().loosened(self.border_radius)
             }
 
@@ -1342,7 +1342,7 @@ macro_rules! impl_shape_for_round_shape(
                 self.inner_shape.local_bounding_sphere().loosened(self.border_radius)
             }
 
-            fn compute_aabb(&self, position: &Isometry<Real>) -> AABB {
+            fn compute_aabb(&self, position: &Isometry<Real>) -> Aabb {
                 self.inner_shape.aabb(position).loosened(self.border_radius)
             }
 

--- a/src/shape/triangle.rs
+++ b/src/shape/triangle.rs
@@ -515,6 +515,11 @@ impl Triangle {
             TriangleOrientation::Degenerate
         }
     }
+
+    /// Reverse the orientation of this triangle by swapping b and c.
+    pub fn reverse(&mut self) {
+        std::mem::swap(&mut self.b, &mut self.c);
+    }
 }
 
 impl SupportMap for Triangle {

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -347,10 +347,13 @@ pub struct GenericTriMesh<Storage: TriMeshStorage> {
     flags: TriMeshFlags,
 }
 
+/// A triangle-mesh.
 pub type TriMesh = GenericTriMesh<DefaultStorage>;
 #[cfg(feature = "cuda")]
+/// A triangle-mesh stored on CUDA memory.
 pub type CudaTriMesh = GenericTriMesh<CudaStorage>;
 #[cfg(feature = "cuda")]
+/// A triangle-mesh accessible from CUDA kernels.
 pub type CudaTriMeshPtr = GenericTriMesh<CudaStoragePtr>;
 
 #[cfg(all(feature = "std", feature = "cuda"))]

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -1,16 +1,28 @@
-use std::collections::HashSet;
-
 use crate::bounding_volume::AABB;
 use crate::math::{Isometry, Point, Real, Vector};
-use crate::partitioning::QBVH;
-use crate::shape::composite_shape::SimdCompositeShape;
+use crate::partitioning::QBVHStorage;
+use crate::partitioning::{GenericQBVH, QBVH};
+use crate::shape::trimesh_storage::TriMeshStorage;
 use crate::shape::{FeatureId, Shape, Triangle, TypedSimdCompositeShape};
-#[cfg(feature = "dim2")]
-use crate::transformation::ear_clipping::triangulate_ear_clipping;
-use crate::utils::hashmap::{Entry, HashMap};
-use crate::utils::HashablePartialEq;
+
+use crate::utils::{Array1, DefaultStorage, HashablePartialEq};
 #[cfg(feature = "dim3")]
-use {crate::shape::Cuboid, crate::utils::SortedPair};
+use {crate::shape::Cuboid, crate::shape::HeightFieldStorage, crate::utils::SortedPair};
+
+#[cfg(feature = "std")]
+use {
+    crate::shape::composite_shape::SimdCompositeShape,
+    crate::utils::hashmap::{Entry, HashMap},
+    std::collections::HashSet,
+};
+
+#[cfg(all(feature = "dim2", feature = "std"))]
+use crate::transformation::ear_clipping::triangulate_ear_clipping;
+
+#[cfg(feature = "cuda")]
+use crate::utils::{CudaStorage, CudaStoragePtr};
+#[cfg(all(feature = "std", feature = "cuda"))]
+use {crate::utils::CudaArray1, cust::error::CudaResult};
 
 /// Indicated an inconsistency in the topology of a triangle mesh.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -28,6 +40,7 @@ pub enum TopologyError {
     },
 }
 
+#[cfg(feature = "std")]
 impl std::fmt::Display for TopologyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -52,52 +65,88 @@ impl std::error::Error for TopologyError {}
 /// point on the triangle, as described in the paper:
 /// "Signed distance computation using the angle weighted pseudonormal", Baerentzen, et al.
 /// DOI: 10.1109/TVCG.2005.49
-#[derive(Clone)]
+#[derive(Default)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
+#[repr(C)] // Needed for Cuda.
 #[cfg(feature = "dim3")]
-pub struct TriMeshPseudoNormals {
+pub struct TriMeshPseudoNormals<Storage: TriMeshStorage> {
     /// The pseudo-normals of the vertices.
-    pub vertices_pseudo_normal: Vec<Vector<Real>>,
+    pub vertices_pseudo_normal: Storage::ArrayVector,
     /// The pseudo-normals of the edges.
-    pub edges_pseudo_normal: HashMap<SortedPair<u32>, Vector<Real>>,
+    pub edges_pseudo_normal: Storage::ArrayVectorTriple,
 }
 
-#[cfg(feature = "dim3")]
-impl Default for TriMeshPseudoNormals {
-    fn default() -> Self {
-        Self {
-            vertices_pseudo_normal: vec![],
-            edges_pseudo_normal: Default::default(),
+#[cfg(all(feature = "dim3", feature = "std", feature = "cuda"))]
+impl TriMeshPseudoNormals<CudaStorage> {
+    /// Returns the heightfield usable from within a CUDA kernel.
+    fn as_device_ptr(&self) -> TriMeshPseudoNormals<CudaStoragePtr> {
+        TriMeshPseudoNormals {
+            vertices_pseudo_normal: self.vertices_pseudo_normal.as_device_ptr(),
+            edges_pseudo_normal: self.edges_pseudo_normal.as_device_ptr(),
         }
     }
 }
 
+#[cfg(all(feature = "dim3", feature = "std", feature = "cuda"))]
+impl TriMeshPseudoNormals<DefaultStorage> {
+    fn to_cuda(&self) -> CudaResult<TriMeshPseudoNormals<CudaStorage>> {
+        Ok(TriMeshPseudoNormals {
+            vertices_pseudo_normal: CudaArray1::new(&self.vertices_pseudo_normal)?,
+            edges_pseudo_normal: CudaArray1::new(&self.edges_pseudo_normal)?,
+        })
+    }
+}
+
 /// The connected-components of a triangle mesh.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
-pub struct TriMeshConnectedComponents {
+#[repr(C)] // Needed for Cuda.
+pub struct TriMeshConnectedComponents<Storage: TriMeshStorage> {
     /// The `face_colors[i]` gives the connected-component index
     /// of the i-th face.
-    pub face_colors: Vec<u32>,
+    pub face_colors: Storage::ArrayU32,
     /// The set of faces grouped by connected components.
-    pub grouped_faces: Vec<u32>,
+    pub grouped_faces: Storage::ArrayU32,
     /// The range of connected components. `self.grouped_faces[self.ranges[i]..self.ranges[i + 1]]`
     /// contains the indices of all the faces part of the i-th connected component.
-    pub ranges: Vec<usize>,
+    pub ranges: Storage::ArrayUsize,
 }
 
-impl TriMeshConnectedComponents {
+impl<Storage: TriMeshStorage> TriMeshConnectedComponents<Storage> {
     /// The total number of connected components.
     pub fn num_connected_components(&self) -> usize {
         self.ranges.len() - 1
+    }
+}
+
+#[cfg(all(feature = "std", feature = "cuda"))]
+impl TriMeshConnectedComponents<CudaStorage> {
+    /// Returns the heightfield usable from within a CUDA kernel.
+    fn as_device_ptr(&self) -> TriMeshConnectedComponents<CudaStoragePtr> {
+        TriMeshConnectedComponents {
+            face_colors: self.face_colors.as_device_ptr(),
+            grouped_faces: self.grouped_faces.as_device_ptr(),
+            ranges: self.ranges.as_device_ptr(),
+        }
+    }
+}
+
+#[cfg(all(feature = "std", feature = "cuda"))]
+impl TriMeshConnectedComponents<DefaultStorage> {
+    fn to_cuda(&self) -> CudaResult<TriMeshConnectedComponents<CudaStorage>> {
+        Ok(TriMeshConnectedComponents {
+            face_colors: CudaArray1::new(&self.face_colors)?,
+            grouped_faces: CudaArray1::new(&self.grouped_faces)?,
+            ranges: CudaArray1::new(&self.ranges)?,
+        })
     }
 }
 
@@ -108,6 +157,8 @@ impl TriMeshConnectedComponents {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
+#[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
+#[repr(C)] // Needed for Cuda.
 pub struct TopoVertex {
     /// One of the half-edge with this vertex as endpoint.
     pub half_edge: u32,
@@ -120,6 +171,8 @@ pub struct TopoVertex {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
+#[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
+#[repr(C)] // Needed for Cuda.
 pub struct TopoFace {
     /// The half-edge adjascent to this face, whith a starting point equal
     /// to the first point of this face.
@@ -133,6 +186,8 @@ pub struct TopoFace {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
+#[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
+#[repr(C)] // Needed for Cuda.
 pub struct TopoHalfEdge {
     /// The next half-edge.
     pub next: u32,
@@ -147,22 +202,34 @@ pub struct TopoHalfEdge {
 }
 
 /// The half-edge topology information of a triangle mesh.
-#[derive(Clone, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
-pub struct TriMeshTopology {
+#[repr(C)] // Needed for Cuda.
+pub struct TriMeshTopology<Storage: TriMeshStorage> {
     /// The vertices of this half-edge representation.
-    pub vertices: Vec<TopoVertex>,
+    pub vertices: Storage::ArrayTopoVertex,
     /// The faces of this half-edge representation.
-    pub faces: Vec<TopoFace>,
+    pub faces: Storage::ArrayTopoFace,
     /// The half-edges of this half-edge representation.
-    pub half_edges: Vec<TopoHalfEdge>,
+    pub half_edges: Storage::ArrayTopoHalfEdge,
 }
 
-impl TriMeshTopology {
+#[cfg(all(feature = "std", feature = "cuda"))]
+impl TriMeshTopology<CudaStorage> {
+    fn as_device_ptr(&self) -> TriMeshTopology<CudaStoragePtr> {
+        TriMeshTopology {
+            vertices: self.vertices.as_device_ptr(),
+            faces: self.faces.as_device_ptr(),
+            half_edges: self.half_edges.as_device_ptr(),
+        }
+    }
+}
+
+impl<Storage: TriMeshStorage> TriMeshTopology<Storage> {
     #[cfg(feature = "dim3")]
     pub(crate) fn face_half_edges_ids(&self, fid: u32) -> [u32; 3] {
         let first_half_edge = self.faces[fid as usize].half_edge;
@@ -177,6 +244,17 @@ impl TriMeshTopology {
     }
 }
 
+#[cfg(all(feature = "std", feature = "cuda"))]
+impl TriMeshTopology<DefaultStorage> {
+    fn to_cuda(&self) -> CudaResult<TriMeshTopology<CudaStorage>> {
+        Ok(TriMeshTopology {
+            vertices: CudaArray1::new(&self.vertices)?,
+            faces: CudaArray1::new(&self.faces)?,
+            half_edges: CudaArray1::new(&self.half_edges)?,
+        })
+    }
+}
+
 bitflags::bitflags! {
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[cfg_attr(
@@ -184,6 +262,7 @@ bitflags::bitflags! {
         derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
     )]
     #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
+    #[repr(C)] // Needed for Cuda.
     #[derive(Default)]
     /// The status of the cell of an heightfield.
     pub struct TriMeshFlags: u8 {
@@ -221,28 +300,111 @@ bitflags::bitflags! {
     }
 }
 
-#[derive(Clone)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde-serialize",
+    serde(bound(
+        serialize = "<Storage::QBVHStorage as QBVHStorage<u32>>::Nodes: serde::Serialize, \
+                     <Storage::QBVHStorage as QBVHStorage<u32>>::ArrayU32: serde::Serialize, \
+                     <Storage::QBVHStorage as QBVHStorage<u32>>::ArrayProxies: serde::Serialize,\
+                     Storage::ArrayTopoVertex: serde::Serialize,\
+                     Storage::ArrayTopoFace: serde::Serialize,\
+                     Storage::ArrayTopoHalfEdge: serde::Serialize,\
+                     Storage::ArrayU32: serde::Serialize,\
+                     Storage::ArrayUsize: serde::Serialize,\
+                     Storage::ArrayVector: serde::Serialize,\
+                     Storage::ArrayPoint: serde::Serialize,\
+                     Storage::ArrayIdx: serde::Serialize,\
+                     Storage::ArrayVectorTriple: serde::Serialize",
+        deserialize = "<Storage::QBVHStorage as QBVHStorage<u32>>::Nodes: serde::Deserialize<'de>, \
+                     <Storage::QBVHStorage as QBVHStorage<u32>>::ArrayU32: serde::Deserialize<'de>, \
+                     <Storage::QBVHStorage as QBVHStorage<u32>>::ArrayProxies: serde::Deserialize<'de>,\
+                     Storage::ArrayTopoVertex: serde::Deserialize<'de>,\
+                     Storage::ArrayTopoFace: serde::Deserialize<'de>,\
+                     Storage::ArrayTopoHalfEdge: serde::Deserialize<'de>,\
+                     Storage::ArrayU32: serde::Deserialize<'de>,\
+                     Storage::ArrayUsize: serde::Deserialize<'de>,\
+                     Storage::ArrayVector: serde::Deserialize<'de>,\
+                     Storage::ArrayPoint: serde::Deserialize<'de>,\
+                     Storage::ArrayIdx: serde::Deserialize<'de>,\
+                     Storage::ArrayVectorTriple: serde::Deserialize<'de>",
+    ))
+)]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
+#[repr(C)] // Needed for Cuda.
 /// A triangle mesh.
-pub struct TriMesh {
-    qbvh: QBVH<u32>,
-    vertices: Vec<Point<Real>>,
-    indices: Vec<[u32; 3]>,
+pub struct GenericTriMesh<Storage: TriMeshStorage> {
+    qbvh: GenericQBVH<u32, Storage::QBVHStorage>,
+    vertices: Storage::ArrayPoint,
+    indices: Storage::ArrayIdx,
     #[cfg(feature = "dim3")]
-    pub(crate) pseudo_normals: Option<TriMeshPseudoNormals>,
-    topology: Option<TriMeshTopology>,
-    connected_components: Option<TriMeshConnectedComponents>,
+    pub(crate) pseudo_normals: Option<TriMeshPseudoNormals<Storage>>,
+    topology: Option<TriMeshTopology<Storage>>,
+    connected_components: Option<TriMeshConnectedComponents<Storage>>,
     flags: TriMeshFlags,
 }
 
+pub type TriMesh = GenericTriMesh<DefaultStorage>;
+#[cfg(feature = "cuda")]
+pub type CudaTriMesh = GenericTriMesh<CudaStorage>;
+#[cfg(feature = "cuda")]
+pub type CudaTriMeshPtr = GenericTriMesh<CudaStoragePtr>;
+
+#[cfg(all(feature = "std", feature = "cuda"))]
+impl CudaTriMesh {
+    /// Returns the heightfield usable from within a CUDA kernel.
+    pub fn as_device_ptr(&self) -> CudaTriMeshPtr {
+        GenericTriMesh {
+            qbvh: self.qbvh.as_device_ptr(),
+            vertices: self.vertices.as_device_ptr(),
+            indices: self.indices.as_device_ptr(),
+            #[cfg(feature = "dim3")]
+            pseudo_normals: self.pseudo_normals.as_ref().map(|pn| pn.as_device_ptr()),
+            topology: self.topology.as_ref().map(|topo| topo.as_device_ptr()),
+            connected_components: self
+                .connected_components
+                .as_ref()
+                .map(|cc| cc.as_device_ptr()),
+            flags: self.flags,
+        }
+    }
+}
+
+#[cfg(feature = "std")]
 impl TriMesh {
     /// Creates a new triangle mesh from a vertex buffer and an index buffer.
     pub fn new(vertices: Vec<Point<Real>>, indices: Vec<[u32; 3]>) -> Self {
         Self::with_flags(vertices, indices, TriMeshFlags::empty())
+    }
+
+    /// Converts this RAM-based heigthfield to an heigthfield based on CUDA memory.
+    #[cfg(feature = "cuda")]
+    pub fn to_cuda(&self) -> CudaResult<CudaTriMesh> {
+        Ok(CudaTriMesh {
+            qbvh: self.qbvh.to_cuda()?,
+            vertices: CudaArray1::new(&self.vertices)?,
+            indices: CudaArray1::new(&self.indices)?,
+            #[cfg(feature = "dim3")]
+            pseudo_normals: self
+                .pseudo_normals
+                .as_ref()
+                .map(|pn| pn.to_cuda())
+                .transpose()?,
+            topology: self
+                .topology
+                .as_ref()
+                .map(|topo| topo.to_cuda())
+                .transpose()?,
+            connected_components: self
+                .connected_components
+                .as_ref()
+                .map(|cc| cc.to_cuda())
+                .transpose()?,
+            flags: self.flags,
+        })
     }
 
     /// Creates a new triangle mesh from a vertex buffer and an index buffer, and flags controlling optional properties.
@@ -275,11 +437,6 @@ impl TriMesh {
         }
 
         result
-    }
-
-    /// The flags of this triangle mesh.
-    pub fn flags(&self) -> TriMeshFlags {
-        self.flags
     }
 
     /// Sets the flags of this triangle mesh, controlling its optional associated data.
@@ -351,10 +508,11 @@ impl TriMesh {
                 .vertices_pseudo_normal
                 .iter_mut()
                 .for_each(|n| *n = transform * *n);
-            pseudo_normals
-                .edges_pseudo_normal
-                .values_mut()
-                .for_each(|n| *n = transform * *n);
+            pseudo_normals.edges_pseudo_normal.iter_mut().for_each(|n| {
+                n[0] = transform * n[0];
+                n[1] = transform * n[1];
+                n[2] = transform * n[2];
+            });
         }
     }
 
@@ -370,9 +528,14 @@ impl TriMesh {
                 n.component_mul_assign(scale);
                 let _ = n.try_normalize_mut(0.0);
             });
-            pn.edges_pseudo_normal.values_mut().for_each(|n| {
-                n.component_mul_assign(scale);
-                let _ = n.try_normalize_mut(0.0);
+            pn.edges_pseudo_normal.iter_mut().for_each(|n| {
+                n[0].component_mul_assign(scale);
+                n[1].component_mul_assign(scale);
+                n[2].component_mul_assign(scale);
+
+                let _ = n[0].try_normalize_mut(0.0);
+                let _ = n[1].try_normalize_mut(0.0);
+                let _ = n[2].try_normalize_mut(0.0);
             });
         }
 
@@ -411,66 +574,6 @@ impl TriMesh {
         triangulate_ear_clipping(&vertices).map(|indices| Self::new(vertices, indices))
     }
 
-    /// Compute the axis-aligned bounding box of this triangle mesh.
-    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
-        self.qbvh.root_aabb().transform_by(pos)
-    }
-
-    /// Gets the local axis-aligned bounding box of this triangle mesh.
-    pub fn local_aabb(&self) -> &AABB {
-        self.qbvh.root_aabb()
-    }
-
-    /// The acceleration structure used by this triangle-mesh.
-    pub fn qbvh(&self) -> &QBVH<u32> {
-        &self.qbvh
-    }
-
-    /// The number of triangles forming this mesh.
-    pub fn num_triangles(&self) -> usize {
-        self.indices.len()
-    }
-
-    /// Does the given feature ID identify a backface of this trimesh?
-    pub fn is_backface(&self, feature: FeatureId) -> bool {
-        if let FeatureId::Face(i) = feature {
-            i >= self.indices.len() as u32
-        } else {
-            false
-        }
-    }
-
-    /// An iterator through all the triangles of this mesh.
-    pub fn triangles(&self) -> impl ExactSizeIterator<Item = Triangle> + '_ {
-        self.indices.iter().map(move |ids| {
-            Triangle::new(
-                self.vertices[ids[0] as usize],
-                self.vertices[ids[1] as usize],
-                self.vertices[ids[2] as usize],
-            )
-        })
-    }
-
-    /// Get the `i`-th triangle of this mesh.
-    pub fn triangle(&self, i: u32) -> Triangle {
-        let idx = self.indices[i as usize];
-        Triangle::new(
-            self.vertices[idx[0] as usize],
-            self.vertices[idx[1] as usize],
-            self.vertices[idx[2] as usize],
-        )
-    }
-
-    /// The vertex buffer of this mesh.
-    pub fn vertices(&self) -> &[Point<Real>] {
-        &self.vertices[..]
-    }
-
-    /// The index buffer of this mesh.
-    pub fn indices(&self) -> &[[u32; 3]] {
-        &self.indices
-    }
-
     /// A flat view of the index buffer of this mesh.
     pub fn flat_indices(&self) -> &[u32] {
         unsafe {
@@ -478,22 +581,6 @@ impl TriMesh {
             let data = self.indices.as_ptr() as *const u32;
             std::slice::from_raw_parts(data, len)
         }
-    }
-
-    /// Returns the topology information of this trimesh, if it has been computed.
-    pub fn topology(&self) -> Option<&TriMeshTopology> {
-        self.topology.as_ref()
-    }
-
-    /// Returns the connected-component information of this trimesh, if it has been computed.
-    pub fn connected_components(&self) -> Option<&TriMeshConnectedComponents> {
-        self.connected_components.as_ref()
-    }
-
-    /// The pseudo-normals of this triangle mesh, if they have been computed.
-    #[cfg(feature = "dim3")]
-    pub fn pseudo_normals(&self) -> Option<&TriMeshPseudoNormals> {
-        self.pseudo_normals.as_ref()
     }
 
     fn rebuild_qbvh(&mut self) {
@@ -526,13 +613,15 @@ impl TriMesh {
                 *n = -*n;
             }
 
-            for n in pseudo_normals.edges_pseudo_normal.values_mut() {
-                *n = -*n;
+            for n in pseudo_normals.edges_pseudo_normal.iter_mut() {
+                n[0] = -n[0];
+                n[1] = -n[1];
+                n[2] = -n[2];
             }
         }
 
         if self.flags.contains(TriMeshFlags::HALF_EDGE_TOPOLOGY) {
-            // TODO: this could be done more efficiently.
+            // TODO: this could be done more efficiently.
             let _ = self.compute_topology(false, false);
         }
     }
@@ -681,6 +770,22 @@ impl TriMesh {
             }
         }
 
+        let edges_pseudo_normal = self
+            .indices()
+            .iter()
+            .map(|idx| {
+                let e0 = SortedPair::new(idx[0], idx[1]);
+                let e1 = SortedPair::new(idx[1], idx[2]);
+                let e2 = SortedPair::new(idx[2], idx[0]);
+                let default = Vector::zeros();
+                [
+                    edges_pseudo_normal.get(&e0).copied().unwrap_or(default),
+                    edges_pseudo_normal.get(&e1).copied().unwrap_or(default),
+                    edges_pseudo_normal.get(&e2).copied().unwrap_or(default),
+                ]
+            })
+            .collect();
+
         self.pseudo_normals = Some(TriMeshPseudoNormals {
             vertices_pseudo_normal,
             edges_pseudo_normal,
@@ -735,7 +840,7 @@ impl TriMesh {
             self.delete_bad_topology_triangles();
         }
 
-        let mut topology = TriMeshTopology::default();
+        let mut topology = TriMeshTopology::<DefaultStorage>::default();
         let mut half_edge_map = HashMap::default();
 
         topology.vertices.resize(
@@ -878,6 +983,89 @@ impl TriMesh {
             assert!(he.vertex == idx[0] || he.vertex == idx[1] || he.vertex == idx[2]);
         }
     }
+
+    /// An iterator through all the triangles of this mesh.
+    pub fn triangles(&self) -> impl ExactSizeIterator<Item = Triangle> + '_ {
+        self.indices.iter().map(move |ids| {
+            Triangle::new(
+                self.vertices[ids[0] as usize],
+                self.vertices[ids[1] as usize],
+                self.vertices[ids[2] as usize],
+            )
+        })
+    }
+}
+
+impl<Storage: TriMeshStorage> GenericTriMesh<Storage> {
+    /// The flags of this triangle mesh.
+    pub fn flags(&self) -> TriMeshFlags {
+        self.flags
+    }
+
+    /// Compute the axis-aligned bounding box of this triangle mesh.
+    pub fn aabb(&self, pos: &Isometry<Real>) -> AABB {
+        self.qbvh.root_aabb().transform_by(pos)
+    }
+
+    /// Gets the local axis-aligned bounding box of this triangle mesh.
+    pub fn local_aabb(&self) -> &AABB {
+        self.qbvh.root_aabb()
+    }
+
+    /// The acceleration structure used by this triangle-mesh.
+    pub fn qbvh(&self) -> &GenericQBVH<u32, Storage::QBVHStorage> {
+        &self.qbvh
+    }
+
+    /// The number of triangles forming this mesh.
+    pub fn num_triangles(&self) -> usize {
+        self.indices.len()
+    }
+
+    /// Does the given feature ID identify a backface of this trimesh?
+    pub fn is_backface(&self, feature: FeatureId) -> bool {
+        if let FeatureId::Face(i) = feature {
+            i >= self.indices.len() as u32
+        } else {
+            false
+        }
+    }
+
+    /// Get the `i`-th triangle of this mesh.
+    pub fn triangle(&self, i: u32) -> Triangle {
+        let idx = self.indices[i as usize];
+        Triangle::new(
+            self.vertices[idx[0] as usize],
+            self.vertices[idx[1] as usize],
+            self.vertices[idx[2] as usize],
+        )
+    }
+
+    /// The vertex buffer of this mesh.
+    pub fn vertices(&self) -> &Storage::ArrayPoint {
+        &self.vertices
+    }
+
+    /// The index buffer of this mesh.
+    pub fn indices(&self) -> &Storage::ArrayIdx {
+        &self.indices
+    }
+
+    /// Returns the topology information of this trimesh, if it has been computed.
+    pub fn topology(&self) -> Option<&TriMeshTopology<Storage>> {
+        self.topology.as_ref()
+    }
+
+    /// Returns the connected-component information of this trimesh, if it has been computed.
+    pub fn connected_components(&self) -> Option<&TriMeshConnectedComponents<Storage>> {
+        self.connected_components.as_ref()
+    }
+
+    /// The pseudo-normals of this triangle mesh, if they have been computed.
+    #[cfg(feature = "dim3")]
+    pub fn pseudo_normals(&self) -> Option<&TriMeshPseudoNormals<Storage>> {
+        self.pseudo_normals.as_ref()
+    }
 }
 
 /*
@@ -928,18 +1116,16 @@ impl RayCast for TriMesh {
 */
 
 #[cfg(feature = "dim3")]
-impl<Heights, Status> From<crate::shape::GenericHeightField<Heights, Status>> for TriMesh
-where
-    Heights: crate::shape::HeightFieldStorage<Item = Real>,
-    Status: crate::shape::HeightFieldStorage<Item = crate::shape::HeightFieldCellStatus>,
-{
-    fn from(heightfield: crate::shape::GenericHeightField<Heights, Status>) -> Self {
+#[cfg(feature = "std")]
+impl<Storage: HeightFieldStorage> From<crate::shape::GenericHeightField<Storage>> for TriMesh {
+    fn from(heightfield: crate::shape::GenericHeightField<Storage>) -> Self {
         let (vtx, idx) = heightfield.to_trimesh();
         TriMesh::new(vtx, idx)
     }
 }
 
 #[cfg(feature = "dim3")]
+#[cfg(feature = "std")]
 impl From<Cuboid> for TriMesh {
     fn from(cuboid: Cuboid) -> Self {
         let (vtx, idx) = cuboid.to_trimesh();
@@ -947,6 +1133,7 @@ impl From<Cuboid> for TriMesh {
     }
 }
 
+#[cfg(feature = "std")]
 impl SimdCompositeShape for TriMesh {
     fn map_part_at(&self, i: u32, f: &mut dyn FnMut(Option<&Isometry<Real>>, &dyn Shape)) {
         let tri = self.triangle(i);
@@ -958,9 +1145,10 @@ impl SimdCompositeShape for TriMesh {
     }
 }
 
-impl TypedSimdCompositeShape for TriMesh {
+impl<Storage: TriMeshStorage> TypedSimdCompositeShape for GenericTriMesh<Storage> {
     type PartShape = Triangle;
     type PartId = u32;
+    type QBVHStorage = Storage::QBVHStorage;
 
     #[inline(always)]
     fn map_typed_part_at(
@@ -978,7 +1166,181 @@ impl TypedSimdCompositeShape for TriMesh {
         f(None, &tri)
     }
 
-    fn typed_qbvh(&self) -> &QBVH<u32> {
+    fn typed_qbvh(&self) -> &GenericQBVH<u32, Self::QBVHStorage> {
         &self.qbvh
     }
+}
+
+/*******************************************
+ *
+ * BOILERPLACE Copy/Clone implementations
+ *
+ *
+ ******************************************/
+#[cfg(feature = "dim3")]
+impl<Storage> Clone for TriMeshPseudoNormals<Storage>
+where
+    Storage: TriMeshStorage,
+    Storage::ArrayVector: Clone,
+    Storage::ArrayVectorTriple: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            vertices_pseudo_normal: self.vertices_pseudo_normal.clone(),
+            edges_pseudo_normal: self.edges_pseudo_normal.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "dim3")]
+impl<Storage> Copy for TriMeshPseudoNormals<Storage>
+where
+    Storage: TriMeshStorage,
+    Storage::ArrayVector: Copy,
+    Storage::ArrayVectorTriple: Copy,
+{
+}
+
+#[cfg(feature = "dim3")]
+#[cfg(feature = "cuda")]
+unsafe impl<Storage> cust_core::DeviceCopy for TriMeshPseudoNormals<Storage>
+where
+    Storage: TriMeshStorage,
+    Storage::ArrayVector: cust_core::DeviceCopy + Copy,
+    Storage::ArrayVectorTriple: cust_core::DeviceCopy + Copy,
+{
+}
+
+impl<Storage> Clone for TriMeshConnectedComponents<Storage>
+where
+    Storage: TriMeshStorage,
+    Storage::ArrayU32: Clone,
+    Storage::ArrayUsize: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            face_colors: self.face_colors.clone(),
+            grouped_faces: self.grouped_faces.clone(),
+            ranges: self.ranges.clone(),
+        }
+    }
+}
+
+impl<Storage> Copy for TriMeshConnectedComponents<Storage>
+where
+    Storage: TriMeshStorage,
+    Storage::ArrayU32: Copy,
+    Storage::ArrayUsize: Copy,
+{
+}
+
+#[cfg(feature = "cuda")]
+unsafe impl<Storage> cust_core::DeviceCopy for TriMeshConnectedComponents<Storage>
+where
+    Storage: TriMeshStorage,
+    Storage::ArrayU32: cust_core::DeviceCopy + Copy,
+    Storage::ArrayUsize: cust_core::DeviceCopy + Copy,
+{
+}
+
+impl<Storage> Clone for TriMeshTopology<Storage>
+where
+    Storage: TriMeshStorage,
+    Storage::ArrayTopoVertex: Clone,
+    Storage::ArrayTopoFace: Clone,
+    Storage::ArrayTopoHalfEdge: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            vertices: self.vertices.clone(),
+            faces: self.faces.clone(),
+            half_edges: self.half_edges.clone(),
+        }
+    }
+}
+
+impl<Storage> Copy for TriMeshTopology<Storage>
+where
+    Storage: TriMeshStorage,
+    Storage::ArrayTopoVertex: Copy,
+    Storage::ArrayTopoFace: Copy,
+    Storage::ArrayTopoHalfEdge: Copy,
+{
+}
+
+#[cfg(feature = "cuda")]
+unsafe impl<Storage> cust_core::DeviceCopy for TriMeshTopology<Storage>
+where
+    Storage: TriMeshStorage,
+    Storage::ArrayTopoVertex: cust_core::DeviceCopy + Copy,
+    Storage::ArrayTopoFace: cust_core::DeviceCopy + Copy,
+    Storage::ArrayTopoHalfEdge: cust_core::DeviceCopy + Copy,
+{
+}
+
+impl<Storage> Clone for GenericTriMesh<Storage>
+where
+    Storage: TriMeshStorage,
+    <Storage::QBVHStorage as QBVHStorage<u32>>::Nodes: Clone,
+    <Storage::QBVHStorage as QBVHStorage<u32>>::ArrayU32: Clone,
+    <Storage::QBVHStorage as QBVHStorage<u32>>::ArrayProxies: Clone,
+    Storage::ArrayTopoVertex: Clone,
+    Storage::ArrayTopoFace: Clone,
+    Storage::ArrayTopoHalfEdge: Clone,
+    Storage::ArrayU32: Clone,
+    Storage::ArrayUsize: Clone,
+    Storage::ArrayVector: Clone,
+    Storage::ArrayPoint: Clone,
+    Storage::ArrayIdx: Clone,
+    Storage::ArrayVectorTriple: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            qbvh: self.qbvh.clone(),
+            vertices: self.vertices.clone(),
+            indices: self.indices.clone(),
+            #[cfg(feature = "dim3")]
+            pseudo_normals: self.pseudo_normals.clone(),
+            topology: self.topology.clone(),
+            connected_components: self.connected_components.clone(),
+            flags: self.flags.clone(),
+        }
+    }
+}
+
+impl<Storage> Copy for GenericTriMesh<Storage>
+where
+    Storage: TriMeshStorage,
+    <Storage::QBVHStorage as QBVHStorage<u32>>::Nodes: Copy,
+    <Storage::QBVHStorage as QBVHStorage<u32>>::ArrayU32: Copy,
+    <Storage::QBVHStorage as QBVHStorage<u32>>::ArrayProxies: Copy,
+    Storage::ArrayTopoVertex: Copy,
+    Storage::ArrayTopoFace: Copy,
+    Storage::ArrayTopoHalfEdge: Copy,
+    Storage::ArrayU32: Copy,
+    Storage::ArrayUsize: Copy,
+    Storage::ArrayVector: Copy,
+    Storage::ArrayPoint: Copy,
+    Storage::ArrayIdx: Copy,
+    Storage::ArrayVectorTriple: Copy,
+{
+}
+
+#[cfg(feature = "cuda")]
+unsafe impl<Storage> cust_core::DeviceCopy for GenericTriMesh<Storage>
+where
+    Storage: TriMeshStorage,
+    <Storage::QBVHStorage as QBVHStorage<u32>>::Nodes: cust_core::DeviceCopy + Copy,
+    <Storage::QBVHStorage as QBVHStorage<u32>>::ArrayU32: cust_core::DeviceCopy + Copy,
+    <Storage::QBVHStorage as QBVHStorage<u32>>::ArrayProxies: cust_core::DeviceCopy + Copy,
+    Storage::ArrayTopoVertex: cust_core::DeviceCopy + Copy,
+    Storage::ArrayTopoFace: cust_core::DeviceCopy + Copy,
+    Storage::ArrayTopoHalfEdge: cust_core::DeviceCopy + Copy,
+    Storage::ArrayU32: cust_core::DeviceCopy + Copy,
+    Storage::ArrayUsize: cust_core::DeviceCopy + Copy,
+    Storage::ArrayVector: cust_core::DeviceCopy + Copy,
+    Storage::ArrayPoint: cust_core::DeviceCopy + Copy,
+    Storage::ArrayIdx: cust_core::DeviceCopy + Copy,
+    Storage::ArrayVectorTriple: cust_core::DeviceCopy + Copy,
+{
 }

--- a/src/shape/trimesh_storage.rs
+++ b/src/shape/trimesh_storage.rs
@@ -1,0 +1,64 @@
+use crate::math::{Point, Real, Vector};
+use crate::partitioning::QBVHStorage;
+use crate::shape::{TopoFace, TopoHalfEdge, TopoVertex};
+use crate::utils::{Array1, DefaultStorage};
+
+#[cfg(all(feature = "std", feature = "cuda"))]
+use crate::utils::CudaArray1;
+#[cfg(feature = "cuda")]
+use crate::utils::{CudaArrayPointer1, CudaStorage, CudaStoragePtr};
+
+pub trait TriMeshStorage {
+    type QBVHStorage: QBVHStorage<u32>;
+    type ArrayTopoVertex: Array1<TopoVertex>;
+    type ArrayTopoFace: Array1<TopoFace>;
+    type ArrayTopoHalfEdge: Array1<TopoHalfEdge>;
+    type ArrayU32: Array1<u32>;
+    type ArrayUsize: Array1<usize>;
+    type ArrayVector: Array1<Vector<Real>>;
+    type ArrayPoint: Array1<Point<Real>>;
+    type ArrayIdx: Array1<[u32; 3]>;
+    type ArrayVectorTriple: Array1<[Vector<Real>; 3]>;
+}
+
+#[cfg(feature = "std")]
+impl TriMeshStorage for DefaultStorage {
+    type QBVHStorage = Self;
+    type ArrayTopoVertex = Vec<TopoVertex>;
+    type ArrayTopoFace = Vec<TopoFace>;
+    type ArrayTopoHalfEdge = Vec<TopoHalfEdge>;
+    type ArrayU32 = Vec<u32>;
+    type ArrayUsize = Vec<usize>;
+    type ArrayVector = Vec<Vector<Real>>;
+    type ArrayPoint = Vec<Point<Real>>;
+    type ArrayIdx = Vec<[u32; 3]>;
+    type ArrayVectorTriple = Vec<[Vector<Real>; 3]>;
+}
+
+#[cfg(all(feature = "std", feature = "cuda"))]
+impl TriMeshStorage for CudaStorage {
+    type QBVHStorage = Self;
+    type ArrayTopoVertex = CudaArray1<TopoVertex>;
+    type ArrayTopoFace = CudaArray1<TopoFace>;
+    type ArrayTopoHalfEdge = CudaArray1<TopoHalfEdge>;
+    type ArrayU32 = CudaArray1<u32>;
+    type ArrayUsize = CudaArray1<usize>;
+    type ArrayVector = CudaArray1<Vector<Real>>;
+    type ArrayPoint = CudaArray1<Point<Real>>;
+    type ArrayIdx = CudaArray1<[u32; 3]>;
+    type ArrayVectorTriple = CudaArray1<[Vector<Real>; 3]>;
+}
+
+#[cfg(feature = "cuda")]
+impl TriMeshStorage for CudaStoragePtr {
+    type QBVHStorage = Self;
+    type ArrayTopoVertex = CudaArrayPointer1<TopoVertex>;
+    type ArrayTopoFace = CudaArrayPointer1<TopoFace>;
+    type ArrayTopoHalfEdge = CudaArrayPointer1<TopoHalfEdge>;
+    type ArrayU32 = CudaArrayPointer1<u32>;
+    type ArrayUsize = CudaArrayPointer1<usize>;
+    type ArrayVector = CudaArrayPointer1<Vector<Real>>;
+    type ArrayPoint = CudaArrayPointer1<Point<Real>>;
+    type ArrayIdx = CudaArrayPointer1<[u32; 3]>;
+    type ArrayVectorTriple = CudaArrayPointer1<[Vector<Real>; 3]>;
+}

--- a/src/shape/trimesh_storage.rs
+++ b/src/shape/trimesh_storage.rs
@@ -1,5 +1,5 @@
 use crate::math::{Point, Real, Vector};
-use crate::partitioning::QBVHStorage;
+use crate::partitioning::QbvhStorage;
 use crate::shape::{TopoFace, TopoHalfEdge, TopoVertex};
 use crate::utils::{Array1, DefaultStorage};
 
@@ -10,8 +10,8 @@ use crate::utils::{CudaArrayPointer1, CudaStorage, CudaStoragePtr};
 
 /// Trait describing all the types needed for storing a triangle mesh’s data.
 pub trait TriMeshStorage {
-    /// Storage needed to store a QBVH.
-    type QBVHStorage: QBVHStorage<u32>;
+    /// Storage needed to store a Qbvh.
+    type QbvhStorage: QbvhStorage<u32>;
     /// Storage needed to store topology vertices.
     type ArrayTopoVertex: Array1<TopoVertex>;
     /// Storage needed to store topology faces.
@@ -34,7 +34,7 @@ pub trait TriMeshStorage {
 
 #[cfg(feature = "std")]
 impl TriMeshStorage for DefaultStorage {
-    type QBVHStorage = Self;
+    type QbvhStorage = Self;
     type ArrayTopoVertex = Vec<TopoVertex>;
     type ArrayTopoFace = Vec<TopoFace>;
     type ArrayTopoHalfEdge = Vec<TopoHalfEdge>;
@@ -48,7 +48,7 @@ impl TriMeshStorage for DefaultStorage {
 
 #[cfg(all(feature = "std", feature = "cuda"))]
 impl TriMeshStorage for CudaStorage {
-    type QBVHStorage = Self;
+    type QbvhStorage = Self;
     type ArrayTopoVertex = CudaArray1<TopoVertex>;
     type ArrayTopoFace = CudaArray1<TopoFace>;
     type ArrayTopoHalfEdge = CudaArray1<TopoHalfEdge>;
@@ -62,7 +62,7 @@ impl TriMeshStorage for CudaStorage {
 
 #[cfg(feature = "cuda")]
 impl TriMeshStorage for CudaStoragePtr {
-    type QBVHStorage = Self;
+    type QbvhStorage = Self;
     type ArrayTopoVertex = CudaArrayPointer1<TopoVertex>;
     type ArrayTopoFace = CudaArrayPointer1<TopoFace>;
     type ArrayTopoHalfEdge = CudaArrayPointer1<TopoHalfEdge>;

--- a/src/shape/trimesh_storage.rs
+++ b/src/shape/trimesh_storage.rs
@@ -8,16 +8,27 @@ use crate::utils::CudaArray1;
 #[cfg(feature = "cuda")]
 use crate::utils::{CudaArrayPointer1, CudaStorage, CudaStoragePtr};
 
+/// Trait describing all the types needed for storing a triangle mesh’s data.
 pub trait TriMeshStorage {
+    /// Storage needed to store a QBVH.
     type QBVHStorage: QBVHStorage<u32>;
+    /// Storage needed to store topology vertices.
     type ArrayTopoVertex: Array1<TopoVertex>;
+    /// Storage needed to store topology faces.
     type ArrayTopoFace: Array1<TopoFace>;
+    /// Storage needed to store topology half-edges.
     type ArrayTopoHalfEdge: Array1<TopoHalfEdge>;
+    /// Storage needed to store u32
     type ArrayU32: Array1<u32>;
+    /// Storage needed to store usize.
     type ArrayUsize: Array1<usize>;
+    /// Storage needed to store vectors.
     type ArrayVector: Array1<Vector<Real>>;
+    /// Storage needed to store points.
     type ArrayPoint: Array1<Point<Real>>;
+    /// Storage needed to store triangle indices.
     type ArrayIdx: Array1<[u32; 3]>;
+    /// Storage needed to store triples of vectors.
     type ArrayVectorTriple: Array1<[Vector<Real>; 3]>;
 }
 

--- a/src/transformation/convex_hull_utils.rs
+++ b/src/transformation/convex_hull_utils.rs
@@ -74,7 +74,7 @@ where
     argmax
 }
 
-/// Scale and center the given set of point depending on their AABB.
+/// Scale and center the given set of point depending on their Aabb.
 #[cfg(feature = "dim3")]
 pub fn normalize(coords: &mut [Point<Real>]) -> (Point<Real>, Real) {
     let aabb = bounding_volume::details::local_point_cloud_aabb(&coords[..]);

--- a/src/transformation/to_outline/cuboid_to_outline.rs
+++ b/src/transformation/to_outline/cuboid_to_outline.rs
@@ -1,10 +1,10 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 use crate::shape::Cuboid;
 use crate::transformation::utils;
 
-impl AABB {
-    /// Outlines this AABB’s shape using polylines.
+impl Aabb {
+    /// Outlines this Aabb’s shape using polylines.
     pub fn to_outline(&self) -> (Vec<Point<Real>>, Vec<[u32; 2]>) {
         let center = self.center();
         let half_extents = self.half_extents();
@@ -28,7 +28,7 @@ impl Cuboid {
  * The cuboid is centered at the origin, and has its half extents set to 0.5.
  */
 fn unit_cuboid_outline() -> (Vec<Point<Real>>, Vec<[u32; 2]>) {
-    let aabb = AABB::from_half_extents(Point::origin(), Vector::repeat(0.5));
+    let aabb = Aabb::from_half_extents(Point::origin(), Vector::repeat(0.5));
     (
         aabb.vertices().to_vec(),
         vec![

--- a/src/transformation/to_outline/heightfield_to_outline.rs
+++ b/src/transformation/to_outline/heightfield_to_outline.rs
@@ -2,11 +2,7 @@ use crate::math::Real;
 use crate::shape::{GenericHeightField, HeightFieldCellStatus, HeightFieldStorage};
 use na::Point3;
 
-impl<Heights, Status> GenericHeightField<Heights, Status>
-where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
-{
+impl<Storage: HeightFieldStorage> GenericHeightField<Storage> {
     /// Outlines this heightfield’s shape using polylines.
     pub fn to_outline(&self) -> (Vec<Point3<Real>>, Vec<[u32; 2]>) {
         todo!()

--- a/src/transformation/to_outline/round_cuboid_to_outline.rs
+++ b/src/transformation/to_outline/round_cuboid_to_outline.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 use crate::shape::RoundCuboid;
 use crate::transformation::utils;
@@ -6,9 +6,9 @@ use crate::transformation::utils;
 impl RoundCuboid {
     /// Outlines this round cuboid’s surface with polylines.
     pub fn to_outline(&self, nsubdivs: u32) -> (Vec<Point<Real>>, Vec<[u32; 2]>) {
-        let aabb = AABB::from_half_extents(Point::origin(), self.inner_shape.half_extents);
+        let aabb = Aabb::from_half_extents(Point::origin(), self.inner_shape.half_extents);
         let aabb_vtx = aabb.vertices();
-        let fidx = AABB::FACES_VERTEX_IDS;
+        let fidx = Aabb::FACES_VERTEX_IDS;
         let x = Vector::x() * self.border_radius;
         let y = Vector::y() * self.border_radius;
         let z = Vector::z() * self.border_radius;

--- a/src/transformation/to_outline/round_triangle_to_outline.rs
+++ b/src/transformation/to_outline/round_triangle_to_outline.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 use crate::shape::RoundTriangle;
 use crate::transformation::utils;

--- a/src/transformation/to_trimesh/cuboid_to_trimesh.rs
+++ b/src/transformation/to_trimesh/cuboid_to_trimesh.rs
@@ -1,11 +1,11 @@
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::Real;
 use crate::shape::Cuboid;
 use crate::transformation::utils;
 use na::{self, Point3};
 
-impl AABB {
-    /// Discretize the boundary of this AABB as a triangle-mesh.
+impl Aabb {
+    /// Discretize the boundary of this Aabb as a triangle-mesh.
     pub fn to_trimesh(&self) -> (Vec<Point3<Real>>, Vec<[u32; 3]>) {
         let center = self.center();
         let half_extents = self.half_extents();

--- a/src/transformation/to_trimesh/heightfield_to_trimesh.rs
+++ b/src/transformation/to_trimesh/heightfield_to_trimesh.rs
@@ -1,13 +1,9 @@
 use crate::math::Real;
-use crate::shape::{GenericHeightField, HeightFieldCellStatus, HeightFieldStorage};
+use crate::shape::{GenericHeightField, HeightFieldStorage};
 use na::Point3;
 
-impl<Heights, Status> GenericHeightField<Heights, Status>
-where
-    Heights: HeightFieldStorage<Item = Real>,
-    Status: HeightFieldStorage<Item = HeightFieldCellStatus>,
-{
-    /// Discretize the boundary of this ball as a triangle-mesh.
+impl<Storage: HeightFieldStorage> GenericHeightField<Storage> {
+    /// Discretize the boundary of this heightfield as a triangle-mesh.
     pub fn to_trimesh(&self) -> (Vec<Point3<Real>>, Vec<[u32; 3]>) {
         let mut vertices = Vec::new();
         let mut indices = Vec::new();

--- a/src/transformation/voxelization/voxel_set.rs
+++ b/src/transformation/voxelization/voxel_set.rs
@@ -17,7 +17,7 @@
 // > THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::{FillMode, VoxelizedVolume};
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Matrix, Point, Real, Vector, DIM};
 use crate::transformation::vhacd::CutPlane;
 use std::sync::Arc;
@@ -238,7 +238,7 @@ impl VoxelSet {
                     let aabb_center =
                         self.origin + voxel.coords.coords.map(|k| k as Real) * self.scale;
                     let aabb =
-                        AABB::from_half_extents(aabb_center, Vector::repeat(self.scale / 2.0));
+                        Aabb::from_half_extents(aabb_center, Vector::repeat(self.scale / 2.0));
 
                     #[cfg(feature = "dim2")]
                     if let Some(seg) = aabb.clip_segment(&points[ia], &points[ib]) {
@@ -309,7 +309,7 @@ impl VoxelSet {
                 &self.intersections[voxel.intersections_range.0..voxel.intersections_range.1];
             for prim_id in intersections {
                 let aabb_center = self.origin + voxel.coords.coords.map(|k| k as Real) * self.scale;
-                let aabb = AABB::from_half_extents(aabb_center, Vector::repeat(self.scale / 2.0));
+                let aabb = Aabb::from_half_extents(aabb_center, Vector::repeat(self.scale / 2.0));
 
                 let pa = points[indices[*prim_id as usize][0] as usize];
                 let pb = points[indices[*prim_id as usize][1] as usize];

--- a/src/transformation/voxelization/voxelized_volume.rs
+++ b/src/transformation/voxelization/voxelized_volume.rs
@@ -16,7 +16,7 @@
 // >
 // > THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::bounding_volume::AABB;
+use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector, DIM};
 use crate::query;
 use crate::transformation::voxelization::{Voxel, VoxelSet};
@@ -254,7 +254,7 @@ impl VoxelizedVolume {
                             || keep_voxel_to_primitives_map
                             || *value == VoxelValue::PrimitiveUndefined
                         {
-                            let aabb = AABB::from_half_extents(pt, box_half_size);
+                            let aabb = Aabb::from_half_extents(pt, box_half_size);
 
                             #[cfg(feature = "dim2")]
                             {

--- a/src/utils/array.rs
+++ b/src/utils/array.rs
@@ -7,12 +7,14 @@ pub trait Array1<T>: IndexMut<usize, Output = T> {
     /// The number of heights on this storage.
     fn len(&self) -> usize;
 
+    /// Is this array empty?
     #[inline]
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     // NOTE: we don’t name it just `get` to avoid clashes with pre-existing `get` methods.
+    /// Gets the i-th element of this array, if it exists.
     #[inline]
     fn get_at(&self, i: usize) -> Option<&T> {
         if i < self.len() {
@@ -84,10 +86,13 @@ impl<T: Scalar> Array2 for DMatrix<T> {
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+/// Default data storage based on `Vec`, `DVector`, and `DMatrix`.
 pub struct DefaultStorage;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 #[cfg(feature = "cuda")]
+/// Data storage residing in CUDA memory.
 pub struct CudaStorage;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 #[cfg(feature = "cuda")]
+/// Data storage for accessing data from CUDA kernels.
 pub struct CudaStoragePtr;

--- a/src/utils/array.rs
+++ b/src/utils/array.rs
@@ -1,0 +1,93 @@
+use core::ops::IndexMut;
+#[cfg(feature = "std")]
+use na::{DMatrix, DVector, Scalar};
+
+/// Abstraction over a 1D array.
+pub trait Array1<T>: IndexMut<usize, Output = T> {
+    /// The number of heights on this storage.
+    fn len(&self) -> usize;
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    // NOTE: we don’t name it just `get` to avoid clashes with pre-existing `get` methods.
+    #[inline]
+    fn get_at(&self, i: usize) -> Option<&T> {
+        if i < self.len() {
+            Some(&self[i])
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> Array1<T> for Vec<T> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> Array1<T> for DVector<T> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+/// Abstraction over a 2D array.
+pub trait Array2 {
+    /// The type of heights.
+    type Item;
+    /// The number of rows of the heights grid.
+    fn nrows(&self) -> usize;
+    /// The number of columns of the heights grid.
+    fn ncols(&self) -> usize;
+    /// Gets the height on the `(i, j)`-th cell of the height grid.
+    fn get(&self, i: usize, j: usize) -> Self::Item;
+    /// Sets the height on the `(i, j)`-th cell of the height grid.
+    fn set(&mut self, i: usize, j: usize, val: Self::Item);
+}
+
+#[cfg(feature = "std")]
+impl<T: Scalar> Array2 for DMatrix<T> {
+    type Item = T;
+
+    #[inline]
+    fn nrows(&self) -> usize {
+        self.nrows()
+    }
+
+    #[inline]
+    fn ncols(&self) -> usize {
+        self.ncols()
+    }
+
+    #[inline]
+    fn get(&self, i: usize, j: usize) -> Self::Item {
+        self[(i, j)].clone()
+    }
+
+    #[inline]
+    fn set(&mut self, i: usize, j: usize, val: Self::Item) {
+        self[(i, j)] = val
+    }
+}
+
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub struct DefaultStorage;
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[cfg(feature = "cuda")]
+pub struct CudaStorage;
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[cfg(feature = "cuda")]
+pub struct CudaStoragePtr;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -17,6 +17,7 @@ pub use self::point_cloud_support_point::{
 pub use self::point_in_poly2d::point_in_poly2d;
 pub use self::sdp_matrix::{SdpMatrix2, SdpMatrix3};
 
+pub use self::array::{Array1, Array2, DefaultStorage};
 pub use self::as_bytes::AsBytes;
 pub(crate) use self::consts::*;
 pub use self::cov::{center_cov, cov};
@@ -35,10 +36,13 @@ pub(crate) use self::wops::{simd_swap, WBasis, WCross, WSign};
 #[cfg(all(feature = "cuda", feature = "std"))]
 pub use self::cuda_array::{CudaArray1, CudaArray2};
 #[cfg(feature = "cuda")]
-pub use self::cuda_array::{CudaArrayPointer1, CudaArrayPointer2};
-#[cfg(feature = "cuda")]
-pub use self::cuda_device_pointer::DevicePointer;
+pub use {
+    self::array::{CudaStorage, CudaStoragePtr},
+    self::cuda_array::{CudaArrayPointer1, CudaArrayPointer2},
+    self::cuda_device_pointer::DevicePointer,
+};
 
+mod array;
 mod as_bytes;
 mod ccw_face_normal;
 mod center;

--- a/src/utils/weighted_value.rs
+++ b/src/utils/weighted_value.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 
+#[derive(Copy, Clone)]
 pub struct WeightedValue<T> {
     pub value: T,
     pub cost: Real,


### PR DESCRIPTION
This makes it possible to send a triangle mesh to CUDA memory, and use these from CUDA kernels for point-projection.

This also renames: `AABB` to `Aabb` and `QBVH` to `Qbvh`.