### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,21 @@
 # Change Log
 
-## Unreleased
+## v0.11.0 (30 Oct. 2022)
 
 ### Modified
 - Rename `AABB` to `Aabb` to comply with Rust’s style guide.
 - Rename `QBVH` to `Qbvh` to comply with Rust’s style guide.
 
 ### Added
+- Add `ConvexPolygon::offsetted` to dilate a polygon.
 - Add `CudaTriMesh` and `CudaTriMeshPtr` for triangle-meshes usable with CUDA.
 - Add a no-std implementation of point-projection on a triangle mesh.
 
 ### Fixed
 - Fix ghost collisions on internal edges on flat 3D meshed and flat 3D heightfields.
-- Fix pseudo-normals calculation that could generated invalid normals for triangles with
+- Fix pseudo-normals calculation that could generate invalid normals for triangles with
   some small vertex angles.
+- Fix `Aabb::bounding_sphere` which returned a bounding sphere that was too big.
 
 
 ## v0.10.0 (02 Oct. 2022)

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry2d-f64"
-version = "0.10.0"
+version = "0.11.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry2d"
-version = "0.10.0"
+version = "0.11.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry3d-f64"
-version = "0.10.0"
+version = "0.11.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry3d"
-version = "0.10.0"
+version = "0.11.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "3 dimensional collision detection library in Rust."

--- a/src/shape/convex_polygon.rs
+++ b/src/shape/convex_polygon.rs
@@ -296,15 +296,15 @@ mod tests {
         ])
         .unwrap();
 
-        let offseted = polygon.offseted(0.5);
+        let offsetted = polygon.offsetted(0.5);
         let expected = vec![
             Point::new(2.207, 0.5),
             Point::new(-2.207, 0.5),
             Point::new(0., -1.707),
         ];
 
-        assert_eq!(offseted.points().len(), 3);
-        assert!(offseted
+        assert_eq!(offsetted.points().len(), 3);
+        assert!(offsetted
             .points()
             .iter()
             .zip(expected.iter())


### PR DESCRIPTION
### Modified
- Rename `AABB` to `Aabb` to comply with Rust’s style guide.
- Rename `QBVH` to `Qbvh` to comply with Rust’s style guide.

### Added
- Add `ConvexPolygon::offseted` to dilate a polygon.
- Add `CudaTriMesh` and `CudaTriMeshPtr` for triangle-meshes usable with CUDA.
- Add a no-std implementation of point-projection on a triangle mesh.

### Fixed
- Fix ghost collisions on internal edges on flat 3D meshed and flat 3D heightfields.
- Fix pseudo-normals calculation that could generate invalid normals for triangles with
  some small vertex angles.
- Fix `Aabb::bounding_sphere` which returned a bounding sphere that was too big.
