### PR TITLE
Clarify doc comments of SegmentsIntersection::Point

### DIFF
--- a/src/utils/segments_intersection.rs
+++ b/src/utils/segments_intersection.rs
@@ -10,9 +10,9 @@ use na::ComplexField;
 pub enum SegmentsIntersection {
     /// Single point of intersection.
     Point {
-        /// Location of the first intersection point on the first segment.
+        /// Location of the intersection point on the first segment.
         loc1: SegmentPointLocation,
-        /// Location of the second intersection point on the second segment.
+        /// Location of the intersection point on the second segment.
         loc2: SegmentPointLocation,
     },
     /// Intersection along a segment (when both segments are collinear).


### PR DESCRIPTION
Point-intersection only has only one intersection point, so the original doc comments "Location of the first intersection point on the first segment." and Location of the second intersection point on the second segment" are confusing. It seems like they were copied from the Segment-intersection where those descriptions make sense.