### PR TITLE
Add the ability to modify a Qbvh after its creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+### Added
+- Add `Qbvh::remove`, `Qbvh::pre_update_or_insert`, `Qbvh::refit`, `Qbvh::rebalance` to allow modifying a `Qbvh`
+  without having to rebuild it completely.
+- Add `SharedShape::trimesh_with_flags` for building a trimesh with specific pre-processing flags.
+
 ## v0.11.1 (30 Oct. 2022)
 
 ### Added

--- a/src/bounding_volume/simd_aabb.rs
+++ b/src/bounding_volume/simd_aabb.rs
@@ -134,6 +134,12 @@ impl SimdAabb {
         }
     }
 
+    /// Enlarges this bounding volume by the given margin.
+    pub fn loosen(&mut self, margin: SimdReal) {
+        self.mins -= Vector::repeat(margin);
+        self.maxs += Vector::repeat(margin);
+    }
+
     /// Dilate all the Aabbs represented by `self`` by their extents multiplied
     /// by the given scale `factor`.
     pub fn dilate_by_factor(&mut self, factor: SimdReal) {

--- a/src/partitioning/mod.rs
+++ b/src/partitioning/mod.rs
@@ -1,10 +1,11 @@
 //! Spatial partitioning tools.
 
 #[cfg(feature = "std")]
-pub use self::qbvh::{CenterDataSplitter, QbvhDataGenerator, QbvhNonOverlappingDataSplitter};
 pub use self::qbvh::{
-    GenericQbvh, IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhProxy, QbvhStorage,
-    QbvhUpdateWorkspace, SimdNodeIndex,
+    CenterDataSplitter, QbvhDataGenerator, QbvhNonOverlappingDataSplitter, QbvhUpdateWorkspace,
+};
+pub use self::qbvh::{
+    GenericQbvh, IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhProxy, QbvhStorage, SimdNodeIndex,
 };
 #[cfg(feature = "parallel")]
 pub use self::visitor::{ParallelSimdSimultaneousVisitor, ParallelSimdVisitor};

--- a/src/partitioning/mod.rs
+++ b/src/partitioning/mod.rs
@@ -3,7 +3,8 @@
 #[cfg(feature = "std")]
 pub use self::qbvh::{CenterDataSplitter, QbvhDataGenerator, QbvhNonOverlappingDataSplitter};
 pub use self::qbvh::{
-    GenericQbvh, IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhProxy, QbvhStorage, SimdNodeIndex,
+    GenericQbvh, IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhProxy, QbvhStorage,
+    QbvhUpdateWorkspace, SimdNodeIndex,
 };
 #[cfg(feature = "parallel")]
 pub use self::visitor::{ParallelSimdSimultaneousVisitor, ParallelSimdVisitor};

--- a/src/partitioning/qbvh/build.rs
+++ b/src/partitioning/qbvh/build.rs
@@ -281,6 +281,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
         mut splitter: impl QbvhDataSplitter<LeafData>,
         dilation_factor: Real,
     ) {
+        self.free_list.clear();
         self.nodes.clear();
         self.proxies.clear();
 

--- a/src/partitioning/qbvh/build.rs
+++ b/src/partitioning/qbvh/build.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::{Aabb, BoundingVolume, SimdAabb};
+use crate::bounding_volume::{Aabb, SimdAabb};
 use crate::math::Vector;
 use crate::math::{Point, Real};
 use crate::query::SplitResult;
@@ -6,7 +6,7 @@ use crate::simd::SimdReal;
 use simba::simd::SimdValue;
 
 use super::utils::split_indices_wrt_dim;
-use super::{IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhProxy};
+use super::{IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhNodeFlags, QbvhProxy};
 
 pub struct BuilderProxies<'a, LeafData> {
     proxies: &'a mut Vec<QbvhProxy<LeafData>>,
@@ -67,24 +67,24 @@ impl<LeafData> QbvhDataSplitter<LeafData> for CenterDataSplitter {
         _: &'idx mut Vec<usize>,
         proxies: BuilderProxies<LeafData>,
     ) -> [&'idx mut [usize]; 4] {
-        self.split_dataset_wo_workspace(subdiv_dims, center, indices, proxies)
+        self.split_dataset_wo_workspace(subdiv_dims, center, indices, &*proxies.aabbs)
     }
 }
 
 impl CenterDataSplitter {
-    fn split_dataset_wo_workspace<'idx, LeafData>(
-        &mut self,
+    pub(crate) fn split_dataset_wo_workspace<'idx>(
+        &self,
         subdiv_dims: [usize; 2],
         center: Point<Real>,
         indices: &'idx mut [usize],
-        proxies: BuilderProxies<LeafData>,
+        aabbs: &[Aabb],
     ) -> [&'idx mut [usize]; 4] {
         // TODO: should we split wrt. the median instead of the average?
         // TODO: we should ensure each subslice contains at least 4 elements each (or less if
         // indices has less than 16 elements in the first place).
         let (left, right) = split_indices_wrt_dim(
             indices,
-            &proxies.aabbs,
+            aabbs,
             &center,
             subdiv_dims[0],
             self.enable_fallback_split,
@@ -92,14 +92,14 @@ impl CenterDataSplitter {
 
         let (left_bottom, left_top) = split_indices_wrt_dim(
             left,
-            &proxies.aabbs,
+            aabbs,
             &center,
             subdiv_dims[1],
             self.enable_fallback_split,
         );
         let (right_bottom, right_top) = split_indices_wrt_dim(
             right,
-            &proxies.aabbs,
+            aabbs,
             &center,
             subdiv_dims[1],
             self.enable_fallback_split,
@@ -219,7 +219,7 @@ where
         }
 
         // 3: Partition the indices.
-        let mut center_splitter = CenterDataSplitter {
+        let center_splitter = CenterDataSplitter {
             enable_fallback_split: false,
         };
 
@@ -227,7 +227,7 @@ where
             subdiv_dims,
             split_pt,
             indices_workspace,
-            proxies,
+            &*proxies.aabbs,
         )
     }
 }
@@ -306,8 +306,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
             simd_aabb: SimdAabb::new_invalid(),
             children: [1, u32::MAX, u32::MAX, u32::MAX],
             parent: NodeIndex::invalid(),
-            leaf: false,
-            dirty: false,
+            flags: QbvhNodeFlags::default(),
         };
 
         self.nodes.push(root_node);
@@ -340,12 +339,10 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
         if indices.len() <= 4 {
             // Leaf case.
             let my_id = self.nodes.len();
-            let mut my_aabb = Aabb::new_invalid();
             let mut leaf_aabbs = [Aabb::new_invalid(); 4];
             let mut proxy_ids = [u32::MAX; 4];
 
             for (k, id) in indices.iter().enumerate() {
-                my_aabb.merge(&aabbs[*id]);
                 leaf_aabbs[k] = aabbs[*id];
                 proxy_ids[k] = *id as u32;
                 self.proxies[*id].node = NodeIndex::new(my_id as u32, k as u8);
@@ -355,12 +352,13 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
                 simd_aabb: SimdAabb::from(leaf_aabbs),
                 children: proxy_ids,
                 parent,
-                leaf: true,
-                dirty: false,
+                flags: QbvhNodeFlags::LEAF,
             };
 
             node.simd_aabb.dilate_by_factor(SimdReal::splat(dilation));
+            let my_aabb = node.simd_aabb.to_merged_aabb();
             self.nodes.push(node);
+
             return (my_id as u32, my_aabb);
         }
 
@@ -403,8 +401,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
             simd_aabb: SimdAabb::new_invalid(),
             children: [0; 4], // Will be set after the recursive call
             parent,
-            leaf: false,
-            dirty: false,
+            flags: QbvhNodeFlags::default(),
         };
 
         let id = self.nodes.len() as u32;
@@ -442,12 +439,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
             .simd_aabb
             .dilate_by_factor(SimdReal::splat(dilation));
 
-        // TODO: will this chain of .merged be properly optimized?
-        let my_aabb = children[0]
-            .1
-            .merged(&children[1].1)
-            .merged(&children[2].1)
-            .merged(&children[3].1);
+        let my_aabb = self.nodes[id as usize].simd_aabb.to_merged_aabb();
         (id, my_aabb)
     }
 }

--- a/src/partitioning/qbvh/mod.rs
+++ b/src/partitioning/qbvh/mod.rs
@@ -1,13 +1,15 @@
 #[cfg(feature = "std")]
-pub use self::build::{
-    BuilderProxies, CenterDataSplitter, QbvhDataGenerator, QbvhNonOverlappingDataSplitter,
+pub use self::{
+    build::{
+        BuilderProxies, CenterDataSplitter, QbvhDataGenerator, QbvhNonOverlappingDataSplitter,
+    },
+    update::QbvhUpdateWorkspace,
 };
 
 pub use self::qbvh::{
     GenericQbvh, IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhNodeFlags, QbvhProxy, SimdNodeIndex,
 };
 pub use self::storage::QbvhStorage;
-pub use self::update::QbvhUpdateWorkspace;
 
 mod qbvh;
 mod storage;

--- a/src/partitioning/qbvh/mod.rs
+++ b/src/partitioning/qbvh/mod.rs
@@ -4,9 +4,10 @@ pub use self::build::{
 };
 
 pub use self::qbvh::{
-    GenericQbvh, IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhProxy, SimdNodeIndex,
+    GenericQbvh, IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhNodeFlags, QbvhProxy, SimdNodeIndex,
 };
 pub use self::storage::QbvhStorage;
+pub use self::update::QbvhUpdateWorkspace;
 
 mod qbvh;
 mod storage;

--- a/src/partitioning/qbvh/traversal.rs
+++ b/src/partitioning/qbvh/traversal.rs
@@ -75,7 +75,7 @@ impl<LeafData: IndexedData, Storage: QbvhStorage<LeafData>> GenericQbvh<LeafData
         }
         while let Some(entry) = stack.pop() {
             let node = &self.nodes[entry as usize];
-            let leaf_data = if node.leaf {
+            let leaf_data = if node.is_leaf() {
                 Some(
                     array![|ii| Some(&self.proxies.get_at(node.children[ii] as usize)?.data); SIMD_WIDTH],
                 )
@@ -92,7 +92,7 @@ impl<LeafData: IndexedData, Storage: QbvhStorage<LeafData>> GenericQbvh<LeafData
 
                     for ii in 0..SIMD_WIDTH {
                         if (bitmask & (1 << ii)) != 0 {
-                            if !node.leaf {
+                            if !node.is_leaf() {
                                 // Internal node, visit the child.
                                 // Un fortunately, we have this check because invalid Aabbs
                                 // return a hit as well.
@@ -152,7 +152,7 @@ impl<LeafData: IndexedData, Storage: QbvhStorage<LeafData>> GenericQbvh<LeafData
             }
 
             let node = &self.nodes[entry.value as usize];
-            let leaf_data = if node.leaf {
+            let leaf_data = if node.is_leaf() {
                 Some(
                     array![|ii| Some(&self.proxies.get_at(node.children[ii] as usize)?.data); SIMD_WIDTH],
                 )
@@ -174,7 +174,7 @@ impl<LeafData: IndexedData, Storage: QbvhStorage<LeafData>> GenericQbvh<LeafData
 
                     for ii in 0..SIMD_WIDTH {
                         if (bitmask & (1 << ii)) != 0 {
-                            if node.leaf {
+                            if node.is_leaf() {
                                 if weights[ii] < best_cost && results[ii].is_some() {
                                     // We found a leaf!
                                     if let Some(proxy) =
@@ -221,7 +221,7 @@ impl<LeafData: IndexedData, Storage: QbvhStorage<LeafData>> GenericQbvh<LeafData
 
             for ii in 0..SIMD_WIDTH {
                 if (bitmask & (1 << ii)) != 0 {
-                    if node.leaf {
+                    if node.is_leaf() {
                         // We found a leaf!
                         // Unfortunately, invalid Aabbs return a intersection as well.
                         if let Some(proxy) = self.proxies.get_at(node.children[ii] as usize) {
@@ -267,7 +267,7 @@ impl<LeafData: IndexedData, Storage: QbvhStorage<LeafData>> GenericQbvh<LeafData
             let node1 = &qbvh1.nodes[entry.0 as usize];
             let node2 = &qbvh2.nodes[entry.1 as usize];
 
-            let leaf_data1 = if node1.leaf {
+            let leaf_data1 = if node1.is_leaf() {
                 Some(
                     array![|ii| Some(&qbvh1.proxies.get_at(node1.children[ii] as usize)?.data); SIMD_WIDTH],
                 )
@@ -275,7 +275,7 @@ impl<LeafData: IndexedData, Storage: QbvhStorage<LeafData>> GenericQbvh<LeafData
                 None
             };
 
-            let leaf_data2 = if node2.leaf {
+            let leaf_data2 = if node2.is_leaf() {
                 Some(
                     array![|ii| Some(&qbvh2.proxies.get_at(node2.children[ii] as usize)?.data); SIMD_WIDTH],
                 )
@@ -288,7 +288,107 @@ impl<LeafData: IndexedData, Storage: QbvhStorage<LeafData>> GenericQbvh<LeafData
                     return;
                 }
                 SimdSimultaneousVisitStatus::MaybeContinue(mask) => {
-                    match (node1.leaf, node2.leaf) {
+                    match (node1.is_leaf(), node2.is_leaf()) {
+                        (true, true) => { /* Can’t go deeper. */ }
+                        (true, false) => {
+                            let mut bitmask = 0;
+                            for ii in 0..SIMD_WIDTH {
+                                bitmask |= mask[ii].bitmask();
+                            }
+
+                            for jj in 0..SIMD_WIDTH {
+                                if (bitmask & (1 << jj)) != 0 {
+                                    if node2.children[jj] as usize <= qbvh2.nodes.len() {
+                                        stack.push((entry.0, node2.children[jj]));
+                                    }
+                                }
+                            }
+                        }
+                        (false, true) => {
+                            for ii in 0..SIMD_WIDTH {
+                                let bitmask = mask[ii].bitmask();
+
+                                if bitmask != 0 {
+                                    if node1.children[ii] as usize <= qbvh1.nodes.len() {
+                                        stack.push((node1.children[ii], entry.1));
+                                    }
+                                }
+                            }
+                        }
+                        (false, false) => {
+                            for ii in 0..SIMD_WIDTH {
+                                let bitmask = mask[ii].bitmask();
+
+                                for jj in 0..SIMD_WIDTH {
+                                    if (bitmask & (1 << jj)) != 0 {
+                                        if node1.children[ii] as usize <= qbvh1.nodes.len()
+                                            && node2.children[jj] as usize <= qbvh2.nodes.len()
+                                        {
+                                            stack.push((node1.children[ii], node2.children[jj]));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Performs a simultaneous traversal of two Qbvh.
+    pub fn traverse_modified_bvtt<LeafData2: IndexedData>(
+        &self,
+        qbvh2: &Qbvh<LeafData2>,
+        visitor: &mut impl SimdSimultaneousVisitor<LeafData, LeafData2, SimdAabb>,
+    ) {
+        self.traverse_modified_bvtt_with_stack(qbvh2, visitor, &mut Vec::new())
+    }
+
+    /// Performs a simultaneous traversal of two Qbvh.
+    pub fn traverse_modified_bvtt_with_stack<LeafData2: IndexedData>(
+        &self,
+        qbvh2: &Qbvh<LeafData2>,
+        visitor: &mut impl SimdSimultaneousVisitor<LeafData, LeafData2, SimdAabb>,
+        stack: &mut Vec<(u32, u32)>,
+    ) {
+        let qbvh1 = self;
+        stack.clear();
+
+        if !qbvh1.nodes.is_empty() && !qbvh2.nodes.is_empty() && qbvh1.nodes[0].is_changed() {
+            stack.push((0, 0));
+        }
+
+        while let Some(entry) = stack.pop() {
+            let node1 = &qbvh1.nodes[entry.0 as usize];
+            let node2 = &qbvh2.nodes[entry.1 as usize];
+
+            if !node1.is_changed() {
+                continue;
+            }
+
+            let leaf_data1 = if node1.is_leaf() {
+                Some(
+                    array![|ii| Some(&qbvh1.proxies.get_at(node1.children[ii] as usize)?.data); SIMD_WIDTH],
+                )
+            } else {
+                None
+            };
+
+            let leaf_data2 = if node2.is_leaf() {
+                Some(
+                    array![|ii| Some(&qbvh2.proxies.get_at(node2.children[ii] as usize)?.data); SIMD_WIDTH],
+                )
+            } else {
+                None
+            };
+
+            match visitor.visit(&node1.simd_aabb, leaf_data1, &node2.simd_aabb, leaf_data2) {
+                SimdSimultaneousVisitStatus::ExitEarly => {
+                    return;
+                }
+                SimdSimultaneousVisitStatus::MaybeContinue(mask) => {
+                    match (node1.is_leaf(), node2.is_leaf()) {
                         (true, true) => { /* Can’t go deeper. */ }
                         (true, false) => {
                             let mut bitmask = 0;
@@ -361,7 +461,7 @@ impl<LeafData: IndexedData + Sync> Qbvh<LeafData> {
 
         let mut stack: ArrayVec<u32, SIMD_WIDTH> = ArrayVec::new();
         let node = &self.nodes[entry as usize];
-        let leaf_data = if node.leaf {
+        let leaf_data = if node.is_leaf() {
             Some(
                 array![|ii| Some(&self.proxies.get_at(node.children[ii] as usize)?.data); SIMD_WIDTH],
             )
@@ -379,7 +479,7 @@ impl<LeafData: IndexedData + Sync> Qbvh<LeafData> {
 
                 for ii in 0..SIMD_WIDTH {
                     if (bitmask & (1 << ii)) != 0 {
-                        if !node.leaf {
+                        if !node.is_leaf() {
                             // Internal node, visit the child.
                             // Un fortunately, we have this check because invalid Aabbs
                             // return a hit as well.
@@ -444,7 +544,7 @@ impl<LeafData: IndexedData + Sync> Qbvh<LeafData> {
         const SQUARE_SIMD_WIDTH: usize = SIMD_WIDTH * SIMD_WIDTH;
         let mut stack: ArrayVec<(u32, u32), SQUARE_SIMD_WIDTH> = ArrayVec::new();
 
-        let leaf_data1 = if node1.leaf {
+        let leaf_data1 = if node1.is_leaf() {
             Some(
                 array![|ii| Some(&qbvh1.proxies.get_at(node1.children[ii] as usize)?.data); SIMD_WIDTH],
             )
@@ -452,7 +552,7 @@ impl<LeafData: IndexedData + Sync> Qbvh<LeafData> {
             None
         };
 
-        let leaf_data2 = if node2.leaf {
+        let leaf_data2 = if node2.is_leaf() {
             Some(
                 array![|ii| Some(&qbvh2.proxies.get_at(node2.children[ii] as usize)?.data); SIMD_WIDTH],
             )
@@ -470,7 +570,7 @@ impl<LeafData: IndexedData + Sync> Qbvh<LeafData> {
                 return;
             }
             SimdSimultaneousVisitStatus::MaybeContinue(mask) => {
-                match (node1.leaf, node2.leaf) {
+                match (node1.is_leaf(), node2.is_leaf()) {
                     (true, true) => { /* Can’t go deeper. */ }
                     (true, false) => {
                         let mut bitmask = 0;

--- a/src/partitioning/qbvh/traversal_no_std.rs
+++ b/src/partitioning/qbvh/traversal_no_std.rs
@@ -34,7 +34,7 @@ impl<LeafData: IndexedData, Storage: QbvhStorage<LeafData>> GenericQbvh<LeafData
         curr_node: u32,
     ) -> bool {
         let node = &self.nodes[curr_node as usize];
-        let leaf_data = if node.leaf {
+        let leaf_data = if node.is_leaf() {
             Some(
                 array![|ii| Some(&self.proxies.get_at(node.children[ii] as usize)?.data); SIMD_WIDTH],
             )
@@ -51,7 +51,7 @@ impl<LeafData: IndexedData, Storage: QbvhStorage<LeafData>> GenericQbvh<LeafData
 
                 for ii in 0..SIMD_WIDTH {
                     if (bitmask & (1 << ii)) != 0 {
-                        if !node.leaf {
+                        if !node.is_leaf() {
                             // Internal node, visit the child.
                             // Unfortunately, we have this check because invalid Aabbs
                             // return a hit as well.
@@ -132,7 +132,7 @@ impl<LeafData: IndexedData, Storage: QbvhStorage<LeafData>> GenericQbvh<LeafData
             }
 
             let node = &self.nodes[entry.value as usize];
-            let leaf_data = if node.leaf {
+            let leaf_data = if node.is_leaf() {
                 Some(
                     array![|ii| Some(&self.proxies.get_at(node.children[ii] as usize)?.data); SIMD_WIDTH],
                 )
@@ -157,7 +157,7 @@ impl<LeafData: IndexedData, Storage: QbvhStorage<LeafData>> GenericQbvh<LeafData
 
                     for ii in 0..SIMD_WIDTH {
                         if (bitmask & (1 << ii)) != 0 {
-                            if node.leaf {
+                            if node.is_leaf() {
                                 if weights[ii] < *best_cost && results[ii].is_some() {
                                     // We found a leaf!
                                     if let Some(proxy) =

--- a/src/partitioning/qbvh/update.rs
+++ b/src/partitioning/qbvh/update.rs
@@ -2,211 +2,568 @@ use crate::bounding_volume::{Aabb, BoundingVolume, SimdAabb};
 #[cfg(feature = "dim3")]
 use crate::math::Vector;
 use crate::math::{Point, Real};
+use crate::partitioning::{CenterDataSplitter, QbvhProxy};
 use crate::simd::{SimdReal, SIMD_WIDTH};
 use simba::simd::{SimdBool, SimdValue};
-use std::ops::Range;
 
-use super::{utils::split_indices_wrt_dim, IndexedData, NodeIndex, Qbvh, QbvhNode};
+use super::{IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhNodeFlags};
 
-#[allow(dead_code)]
-struct QbvhIncrementalBuilderStep {
-    range: Range<usize>,
-    parent: NodeIndex,
-}
-
-#[allow(dead_code)]
-struct QbvhIncrementalBuilder<LeafData> {
-    qbvh: Qbvh<LeafData>,
-    to_insert: Vec<QbvhIncrementalBuilderStep>,
+#[derive(Clone, Default)]
+/// Workspace for QBVH update.
+///
+/// Re-using the same workspace for multiple QBVH modification isn’t mandatory, but it improves
+/// performances by avoiding useless allocation.
+pub struct QbvhUpdateWorkspace {
+    stack: Vec<(u32, u8)>,
+    dirty_parent_nodes: Vec<u32>,
+    // For rebalancing.
+    to_sort: Vec<usize>,
+    orig_ids: Vec<u32>,
+    is_leaf: Vec<bool>,
     aabbs: Vec<Aabb>,
-    indices: Vec<usize>,
 }
 
-#[allow(dead_code)]
-impl<LeafData: IndexedData> QbvhIncrementalBuilder<LeafData> {
-    pub fn new() -> Self {
-        Self {
-            qbvh: Qbvh::new(),
-            to_insert: Vec::new(),
-            aabbs: Vec::new(),
-            indices: Vec::new(),
-        }
-    }
-
-    pub fn update_single_depth(&mut self) {
-        if let Some(to_insert) = self.to_insert.pop() {
-            let indices = &mut self.indices[to_insert.range];
-
-            // Leaf case.
-            if indices.len() <= 4 {
-                let id = self.qbvh.nodes.len();
-                let mut aabb = Aabb::new_invalid();
-                let mut leaf_aabbs = [Aabb::new_invalid(); 4];
-                let mut proxy_ids = [u32::MAX; 4];
-
-                for (k, id) in indices.iter().enumerate() {
-                    aabb.merge(&self.aabbs[*id]);
-                    leaf_aabbs[k] = self.aabbs[*id];
-                    proxy_ids[k] = *id as u32;
-                }
-
-                let node = QbvhNode {
-                    simd_aabb: SimdAabb::from(leaf_aabbs),
-                    children: proxy_ids,
-                    parent: to_insert.parent,
-                    leaf: true,
-                    dirty: false,
-                };
-
-                self.qbvh.nodes[to_insert.parent.index as usize].children
-                    [to_insert.parent.lane as usize] = id as u32;
-                self.qbvh.nodes[to_insert.parent.index as usize]
-                    .simd_aabb
-                    .replace(to_insert.parent.lane as usize, aabb);
-                self.qbvh.nodes.push(node);
-                return;
-            }
-
-            // Compute the center and variance along each dimension.
-            // In 3D we compute the variance to not-subdivide the dimension with lowest variance.
-            // Therefore variance computation is not needed in 2D because we only have 2 dimension
-            // to split in the first place.
-            let mut center = Point::origin();
-            #[cfg(feature = "dim3")]
-            let mut variance = Vector::zeros();
-
-            let denom = 1.0 / (indices.len() as Real);
-            let mut aabb = Aabb::new_invalid();
-
-            for i in &*indices {
-                let coords = self.aabbs[*i].center().coords;
-                aabb.merge(&self.aabbs[*i]);
-                center += coords * denom;
-                #[cfg(feature = "dim3")]
-                {
-                    variance += coords.component_mul(&coords) * denom;
-                }
-            }
-
-            #[cfg(feature = "dim3")]
-            {
-                variance = variance - center.coords.component_mul(&center.coords);
-            }
-
-            // Find the axis with minimum variance. This is the axis along
-            // which we are **not** subdividing our set.
-            #[allow(unused_mut)] // Does not need to be mutable in 2D.
-            let mut subdiv_dims = [0, 1];
-            #[cfg(feature = "dim3")]
-            {
-                let min = variance.imin();
-                subdiv_dims[0] = (min + 1) % 3;
-                subdiv_dims[1] = (min + 2) % 3;
-            }
-
-            // Split the set along the two subdiv_dims dimensions.
-            // TODO: should we split wrt. the median instead of the average?
-            // TODO: we should ensure each subslice contains at least 4 elements each (or less if
-            // indices has less than 16 elements in the first place.
-            let (left, right) =
-                split_indices_wrt_dim(indices, &self.aabbs, &center, subdiv_dims[0], true);
-
-            let (left_bottom, left_top) =
-                split_indices_wrt_dim(left, &self.aabbs, &center, subdiv_dims[1], true);
-            let (right_bottom, right_top) =
-                split_indices_wrt_dim(right, &self.aabbs, &center, subdiv_dims[1], true);
-
-            let node = QbvhNode {
-                simd_aabb: SimdAabb::new_invalid(),
-                children: [0; 4], // Will be set after the recursive call
-                parent: to_insert.parent,
-                leaf: false,
-                dirty: false,
-            };
-
-            let id = self.qbvh.nodes.len() as u32;
-            self.qbvh.nodes.push(node);
-
-            // Recurse!
-            let a = left_bottom.len();
-            let b = a + left_top.len();
-            let c = b + right_bottom.len();
-            let d = c + right_top.len();
-            self.to_insert.push(QbvhIncrementalBuilderStep {
-                range: 0..a,
-                parent: NodeIndex::new(id, 0),
-            });
-            self.to_insert.push(QbvhIncrementalBuilderStep {
-                range: a..b,
-                parent: NodeIndex::new(id, 1),
-            });
-            self.to_insert.push(QbvhIncrementalBuilderStep {
-                range: b..c,
-                parent: NodeIndex::new(id, 2),
-            });
-            self.to_insert.push(QbvhIncrementalBuilderStep {
-                range: c..d,
-                parent: NodeIndex::new(id, 3),
-            });
-
-            self.qbvh.nodes[to_insert.parent.index as usize].children
-                [to_insert.parent.lane as usize] = id as u32;
-            self.qbvh.nodes[to_insert.parent.index as usize]
-                .simd_aabb
-                .replace(to_insert.parent.lane as usize, aabb);
-        }
+impl QbvhUpdateWorkspace {
+    fn clear(&mut self) {
+        self.stack.clear();
+        self.dirty_parent_nodes.clear();
+        self.to_sort.clear();
+        self.orig_ids.clear();
+        self.is_leaf.clear();
+        self.aabbs.clear();
     }
 }
 
 impl<LeafData: IndexedData> Qbvh<LeafData> {
-    /// Marks a piece of data as dirty so it can be updated during the next
-    /// call to `self.update`.
-    pub fn pre_update(&mut self, data: LeafData) {
+    /// Immediately remove a leaf from this QBVH.
+    pub fn remove(&mut self, data: LeafData) -> Option<LeafData> {
         let id = data.index();
-        let node_id = self.proxies[id].node.index;
-        let node = &mut self.nodes[node_id as usize];
-        if !node.dirty {
-            node.dirty = true;
-            self.dirty_nodes.push(node_id);
+        let proxy = self.proxies.get_mut(id)?;
+        let node = self.nodes.get_mut(proxy.node.index as usize)?;
+
+        if !node.is_dirty() {
+            node.set_dirty(true);
+            node.children[proxy.node.lane as usize] = u32::MAX;
+            self.dirty_nodes.push(proxy.node.index);
+        }
+
+        *proxy = QbvhProxy::invalid();
+
+        Some(data)
+    }
+
+    /// Prepare a new leaf for insertion into this QBVH (or for update if it already exists).
+    ///
+    /// The insertion or update will be completely valid only after the next call to [`Qbvh::refit`].
+    pub fn pre_update_or_insert(&mut self, data: LeafData) {
+        if self.nodes.is_empty() {
+            let mut root = QbvhNode::empty();
+            root.children = [1, u32::MAX, u32::MAX, u32::MAX];
+            self.nodes
+                .extend_from_slice(&[root, QbvhNode::empty_leaf_with_parent(NodeIndex::new(0, 0))]);
+        }
+
+        let id = data.index();
+
+        if self.proxies.len() <= id {
+            self.proxies.resize(id + 1, QbvhProxy::invalid());
+        }
+
+        let proxy = &mut self.proxies[id];
+        proxy.data = data;
+
+        if proxy.is_detached() {
+            // Attach the proxy into one of the leaf attached to the root, if there is room.
+            for ii in 0..SIMD_WIDTH {
+                let mut child = self.nodes[0].children[ii];
+
+                if child == u32::MAX {
+                    // Missing node, add it.
+                    child = self.nodes.len() as u32;
+                    self.nodes
+                        .push(QbvhNode::empty_leaf_with_parent(NodeIndex::new(
+                            0, ii as u8,
+                        )));
+                    self.nodes[0].children[ii] = child;
+                }
+
+                let child_node = &mut self.nodes[child as usize];
+                if child_node.children[SIMD_WIDTH - 1] == u32::MAX {
+                    // Insert into this node.
+                    for kk in 0..SIMD_WIDTH {
+                        if child_node.children[kk] == u32::MAX {
+                            child_node.children[kk] = id as u32;
+                            proxy.node = NodeIndex::new(child, kk as u8);
+
+                            if !child_node.is_dirty() {
+                                self.dirty_nodes.push(child);
+                                child_node.set_dirty(true);
+                            }
+
+                            return;
+                        }
+                    }
+                }
+            }
+
+            // If we reached this point, we didn’t find room for our
+            // new proxy. Create a new root to make more room.
+            let mut old_root = self.nodes[0].clone();
+            old_root.parent = NodeIndex::new(0, 0);
+
+            for child_id in old_root.children {
+                let parent_index = self.nodes.len() as u32;
+
+                if let Some(child_node) = self.nodes.get_mut(child_id as usize) {
+                    child_node.parent.index = parent_index;
+                }
+            }
+
+            // The first new node contains the (unmodified) old root, the second
+            // new node contains the newly added proxy.
+            self.dirty_nodes.push(self.nodes.len() as u32 + 1);
+
+            let mut new_leaf_node = QbvhNode::empty_leaf_with_parent(NodeIndex::new(0, 1));
+            new_leaf_node.children[0] = id as u32;
+            new_leaf_node.set_dirty(true);
+
+            let new_root_children = [
+                self.nodes.len() as u32,
+                self.nodes.len() as u32 + 1,
+                self.nodes.len() as u32 + 2,
+                self.nodes.len() as u32 + 3,
+            ];
+
+            self.nodes.extend_from_slice(&[
+                old_root,
+                new_leaf_node,
+                QbvhNode::empty_leaf_with_parent(NodeIndex::new(0, 2)),
+                QbvhNode::empty_leaf_with_parent(NodeIndex::new(0, 3)),
+            ]);
+
+            self.nodes[0].children = new_root_children;
+        } else {
+            let node = &mut self.nodes[proxy.node.index as usize];
+            if !node.is_dirty() {
+                node.set_dirty(true);
+                self.dirty_nodes.push(proxy.node.index);
+            }
         }
     }
 
-    /// Update all the nodes that have been marked as dirty by `self.pre_update`.
-    pub fn update<F>(&mut self, aabb_builder: F, dilation_factor: Real)
+    #[allow(dead_code)] // Not sure yet if we want to keep this.
+    pub(crate) fn clear_changed_flag(&mut self, workspace: &mut QbvhUpdateWorkspace) {
+        if self.nodes.is_empty() {
+            return;
+        }
+
+        workspace.clear();
+        workspace.stack.push((0, 0));
+
+        while let Some((id, _)) = workspace.stack.pop() {
+            let node = &mut self.nodes[id as usize];
+
+            if node.is_changed() {
+                node.set_changed(false);
+
+                for child in node.children {
+                    if child < self.nodes.len() as u32 {
+                        workspace.stack.push((child, 0));
+                    }
+                }
+            }
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn check_topology(&self, aabb_builder: impl Fn(&LeafData) -> Aabb) {
+        if self.nodes.is_empty() {
+            return;
+        }
+
+        let mut stack = vec![];
+        stack.push(0);
+
+        let mut node_id_found = vec![false; self.nodes.len()];
+        let mut proxy_id_found = vec![false; self.proxies.len()];
+
+        while let Some(id) = stack.pop() {
+            let node = &self.nodes[id as usize];
+
+            // No duplicate references to internal nodes.
+            assert!(!node_id_found[id as usize]);
+            node_id_found[id as usize] = true;
+
+            if id != 0 {
+                let parent = &self.nodes[node.parent.index as usize];
+
+                // Check parent <-> children indices.
+                assert!(!parent.is_leaf());
+                assert_eq!(parent.children[node.parent.lane as usize], id);
+                // Make sure the parent AABB contains its child AABB.
+                assert!(
+                    parent
+                        .simd_aabb
+                        .extract(node.parent.lane as usize)
+                        .contains(&node.simd_aabb.to_merged_aabb()),
+                    "failed for {id}"
+                );
+                // If this node is changed, its parent is changed too.
+                if node.is_changed() {
+                    assert!(parent.is_changed());
+                }
+            }
+
+            if node.is_leaf() {
+                for ii in 0..SIMD_WIDTH {
+                    let proxy_id = node.children[ii];
+                    if proxy_id != u32::MAX {
+                        // No duplicate references to proxies.
+                        assert!(!proxy_id_found[proxy_id as usize]);
+                        proxy_id_found[proxy_id as usize] = true;
+
+                        // Proxy AABB is correct.
+                        let aabb = node.simd_aabb.extract(ii);
+                        assert!(aabb.contains(&aabb_builder(&self.proxies[proxy_id as usize].data)));
+                        // assert_eq!(aabb, aabb_builder(&self.proxies[proxy_id as usize].data));
+
+                        // Proxy node reference is correct.
+                        assert_eq!(
+                            self.proxies[proxy_id as usize].node,
+                            NodeIndex::new(id, ii as u8)
+                        );
+                    }
+                }
+            } else {
+                for child in node.children {
+                    if child != u32::MAX {
+                        stack.push(child);
+                    }
+                }
+            }
+        }
+
+        // Each proxy was visited once.
+        assert!(proxy_id_found.iter().all(|found| *found));
+    }
+
+    /// Update all the nodes that have been marked as dirty by [`Qbvh::pre_update_or_insert`],
+    /// and [`Qbvh::remove`].
+    ///
+    /// This will not alter the topology of this `Qbvh`.
+    pub fn refit<F>(
+        &mut self,
+        margin: Real,
+        workspace: &mut QbvhUpdateWorkspace,
+        aabb_builder: F,
+    ) -> usize
     where
         F: Fn(&LeafData) -> Aabb,
     {
         // Loop on the dirty leaves.
-        let dilation_factor = SimdReal::splat(dilation_factor);
+        workspace.clear();
+        let margin = SimdReal::splat(margin);
+        let mut first_iter = true;
+        let mut num_changed = 0;
 
-        while let Some(id) = self.dirty_nodes.pop() {
-            // NOTE: this will data the case where we reach the root of the tree.
-            if let Some(node) = self.nodes.get(id as usize) {
-                // Compute the new aabb.
-                let mut new_aabbs = [Aabb::new_invalid(); SIMD_WIDTH];
-                for (child_id, new_aabb) in node.children.iter().zip(new_aabbs.iter_mut()) {
-                    if node.leaf {
-                        // We are in a leaf: compute the Aabbs.
-                        if let Some(proxy) = self.proxies.get(*child_id as usize) {
-                            *new_aabb = aabb_builder(&proxy.data);
+        while !self.dirty_nodes.is_empty() {
+            while let Some(id) = self.dirty_nodes.pop() {
+                // NOTE: this will cover the case where we reach the root of the tree.
+                if let Some(node) = self.nodes.get(id as usize) {
+                    // Compute the new aabb.
+                    let mut new_aabbs = [Aabb::new_invalid(); SIMD_WIDTH];
+                    for (child_id, new_aabb) in node.children.iter().zip(new_aabbs.iter_mut()) {
+                        if node.is_leaf() {
+                            // We are in a leaf: compute the Aabbs.
+                            if let Some(proxy) = self.proxies.get(*child_id as usize) {
+                                *new_aabb = aabb_builder(&proxy.data);
+                            }
+                        } else {
+                            // We are in an internal node: compute the children's Aabbs.
+                            if let Some(node) = self.nodes.get(*child_id as usize) {
+                                *new_aabb = node.simd_aabb.to_merged_aabb();
+                            }
                         }
-                    } else {
-                        // We are in an internal node: compute the children's Aabbs.
-                        if let Some(node) = self.nodes.get(*child_id as usize) {
-                            *new_aabb = node.simd_aabb.to_merged_aabb();
+                    }
+
+                    let node = &mut self.nodes[id as usize];
+                    let new_simd_aabb = SimdAabb::from(new_aabbs);
+                    node.set_dirty(false);
+
+                    if !first_iter || !node.simd_aabb.contains(&new_simd_aabb).all() {
+                        node.set_changed(true);
+                        node.simd_aabb = new_simd_aabb;
+                        node.simd_aabb.loosen(margin);
+                        let parent_id = node.parent.index;
+                        num_changed += 1;
+
+                        if let Some(parent) = self.nodes.get_mut(parent_id as usize) {
+                            if !parent.is_dirty() {
+                                workspace.dirty_parent_nodes.push(parent_id);
+                                parent.set_dirty(true);
+                            }
                         }
                     }
                 }
+            }
 
-                let node = &mut self.nodes[id as usize];
-                let new_simd_aabb = SimdAabb::from(new_aabbs);
-                if !node.simd_aabb.contains(&new_simd_aabb).all() {
-                    node.simd_aabb = new_simd_aabb;
-                    node.simd_aabb.dilate_by_factor(dilation_factor);
-                    self.dirty_nodes.push(node.parent.index);
-                }
-                node.dirty = false;
+            first_iter = false;
+            std::mem::swap(&mut self.dirty_nodes, &mut workspace.dirty_parent_nodes);
+        }
+
+        num_changed
+    }
+
+    /// Rebalances the `Qbvh` tree.
+    ///
+    /// This will modify the topology of this tree. This assumes that the leaf AABBs have
+    /// already been updated with [`Qbvh::refit`] or [`Qbvh::clear_and_rebuild`].
+    pub fn rebalance(&mut self, margin: Real, workspace: &mut QbvhUpdateWorkspace) {
+        if self.nodes.is_empty() {
+            return;
+        }
+
+        workspace.clear();
+
+        const MIN_CHANGED_DEPTH: u8 = 5; // TODO: find a good value
+
+        for root_child in self.nodes[0].children {
+            if root_child < self.nodes.len() as u32 {
+                workspace.stack.push((root_child, 1));
             }
         }
+
+        // Collect empty slots and pseudo-leaves to sort.
+        while let Some((id, depth)) = workspace.stack.pop() {
+            let node = &mut self.nodes[id as usize];
+
+            if node.is_leaf() {
+                self.free_list.push(id);
+                for ii in 0..SIMD_WIDTH {
+                    let proxy_id = node.children[ii];
+                    if proxy_id < self.proxies.len() as u32 {
+                        workspace.orig_ids.push(proxy_id);
+                        workspace.aabbs.push(node.simd_aabb.extract(ii));
+                        workspace.is_leaf.push(true);
+                    }
+                }
+            } else if node.is_changed() || depth < MIN_CHANGED_DEPTH {
+                self.free_list.push(id);
+
+                for child in node.children {
+                    if child < self.nodes.len() as u32 {
+                        workspace.stack.push((child, depth + 1));
+                    }
+                }
+            } else {
+                workspace.orig_ids.push(id);
+                workspace.aabbs.push(node.simd_aabb.to_merged_aabb());
+                workspace.is_leaf.push(false);
+            }
+        }
+
+        workspace.to_sort.extend(0..workspace.orig_ids.len());
+        let root_id = NodeIndex::new(0, 0);
+
+        let mut indices = std::mem::replace(&mut workspace.to_sort, vec![]);
+        let (id, aabb) = self.do_recurse_rebalance(&mut indices, workspace, root_id, margin);
+        workspace.to_sort = indices;
+
+        self.root_aabb = aabb;
+
+        self.nodes[0] = QbvhNode {
+            simd_aabb: SimdAabb::from([
+                aabb,
+                Aabb::new_invalid(),
+                Aabb::new_invalid(),
+                Aabb::new_invalid(),
+            ]),
+            children: [id, u32::MAX, u32::MAX, u32::MAX],
+            parent: NodeIndex::invalid(),
+            flags: QbvhNodeFlags::default(),
+        };
+    }
+
+    fn do_recurse_rebalance(
+        &mut self,
+        indices: &mut [usize],
+        workspace: &QbvhUpdateWorkspace,
+        parent: NodeIndex,
+        margin: Real,
+    ) -> (u32, Aabb) {
+        if indices.len() <= 4 {
+            // Leaf case.
+            let mut has_leaf = false;
+            let mut has_internal = false;
+
+            for id in &*indices {
+                has_leaf |= workspace.is_leaf[*id];
+                has_internal |= !workspace.is_leaf[*id];
+            }
+
+            let my_internal_id = if has_internal {
+                self.free_list.pop().unwrap_or_else(|| {
+                    self.nodes.push(QbvhNode::empty());
+                    self.nodes.len() as u32 - 1
+                })
+            } else {
+                u32::MAX
+            };
+
+            let my_leaf_id = if has_leaf {
+                self.free_list.pop().unwrap_or_else(|| {
+                    self.nodes.push(QbvhNode::empty());
+                    self.nodes.len() as u32 - 1
+                })
+            } else {
+                u32::MAX
+            };
+
+            let mut my_leaf_aabb = Aabb::new_invalid();
+            let mut my_internal_aabb = Aabb::new_invalid();
+
+            let mut leaf_aabbs = [Aabb::new_invalid(); 4];
+            let mut internal_aabbs = [Aabb::new_invalid(); 4];
+
+            let mut proxy_ids = [u32::MAX; 4];
+            let mut internal_ids = [u32::MAX; 4];
+            let mut new_internal_lane_containing_leaf = usize::MAX;
+
+            for (k, id) in indices.iter().enumerate() {
+                let orig_id = workspace.orig_ids[*id];
+                if workspace.is_leaf[*id] {
+                    new_internal_lane_containing_leaf = k;
+                    my_leaf_aabb.merge(&workspace.aabbs[*id]);
+                    leaf_aabbs[k] = workspace.aabbs[*id];
+                    proxy_ids[k] = orig_id;
+                    self.proxies[orig_id as usize].node = NodeIndex::new(my_leaf_id, k as u8);
+                } else {
+                    my_internal_aabb.merge(&workspace.aabbs[*id]);
+                    internal_aabbs[k] = workspace.aabbs[*id];
+                    internal_ids[k] = orig_id;
+                    self.nodes[orig_id as usize].parent = NodeIndex::new(my_internal_id, k as u8);
+                }
+            }
+
+            if has_internal {
+                if has_leaf {
+                    internal_ids[new_internal_lane_containing_leaf] = my_leaf_id;
+                    internal_aabbs[new_internal_lane_containing_leaf] = my_leaf_aabb;
+                }
+
+                let internal_node = QbvhNode {
+                    simd_aabb: SimdAabb::from(internal_aabbs),
+                    children: internal_ids,
+                    parent,
+                    flags: QbvhNodeFlags::default(),
+                };
+                // NOTE: we don’t dilate because the AABBs for the rebalancing were
+                //       already dilated during the refit.
+                self.nodes[my_internal_id as usize] = internal_node;
+            }
+
+            if has_leaf {
+                let leaf_node = QbvhNode {
+                    simd_aabb: SimdAabb::from(leaf_aabbs),
+                    children: proxy_ids,
+                    parent: if has_internal {
+                        NodeIndex::new(my_internal_id, new_internal_lane_containing_leaf as u8)
+                    } else {
+                        parent
+                    },
+                    flags: QbvhNodeFlags::LEAF,
+                };
+                // NOTE: we don’t dilate because the AABBs for the rebalancing were
+                //       already dilated during the refit.
+                self.nodes[my_leaf_id as usize] = leaf_node;
+            }
+
+            if has_internal {
+                return (my_internal_id, my_internal_aabb);
+            } else {
+                return (my_leaf_id, my_leaf_aabb);
+            }
+        }
+
+        // Compute the center and variance along each dimension.
+        // In 3D we compute the variance to not-subdivide the dimension with lowest variance.
+        // Therefore variance computation is not needed in 2D because we only have 2 dimension
+        // to split in the first place.
+        let mut center = Point::origin();
+        #[cfg(feature = "dim3")]
+        let mut variance = Vector::zeros();
+
+        let center_denom = 1.0 / (indices.len() as Real);
+
+        for i in &*indices {
+            let coords = workspace.aabbs[*i].center().coords;
+            center += coords * center_denom;
+        }
+
+        #[cfg(feature = "dim3")]
+        {
+            let variance_denom = 1.0 / ((indices.len() - 1) as Real);
+            for i in &*indices {
+                let dir_to_center = workspace.aabbs[*i].center() - center;
+                variance += dir_to_center.component_mul(&dir_to_center) * variance_denom;
+            }
+        }
+
+        // Find the axis with minimum variance. This is the axis along
+        // which we are **not** subdividing our set.
+        #[allow(unused_mut)] // Does not need to be mutable in 2D.
+        let mut subdiv_dims = [0, 1];
+        #[cfg(feature = "dim3")]
+        {
+            let min = variance.imin();
+            subdiv_dims[0] = (min + 1) % 3;
+            subdiv_dims[1] = (min + 2) % 3;
+        }
+
+        let node = QbvhNode {
+            simd_aabb: SimdAabb::new_invalid(),
+            children: [0; 4], // Will be set after the recursive call
+            parent,
+            flags: QbvhNodeFlags::default(),
+        };
+
+        let nid = if let Some(nid) = self.free_list.pop() {
+            self.nodes[nid as usize] = node;
+            nid as u32
+        } else {
+            let nid = self.nodes.len();
+            self.nodes.push(node);
+            nid as u32
+        };
+
+        // Split the set along the two subdiv_dims dimensions.
+        let splitter = CenterDataSplitter::default();
+        let splits =
+            splitter.split_dataset_wo_workspace(subdiv_dims, center, indices, &workspace.aabbs);
+        let n = [
+            NodeIndex::new(nid, 0),
+            NodeIndex::new(nid, 1),
+            NodeIndex::new(nid, 2),
+            NodeIndex::new(nid, 3),
+        ];
+
+        let children = [
+            self.do_recurse_rebalance(splits[0], workspace, n[0], margin),
+            self.do_recurse_rebalance(splits[1], workspace, n[1], margin),
+            self.do_recurse_rebalance(splits[2], workspace, n[2], margin),
+            self.do_recurse_rebalance(splits[3], workspace, n[3], margin),
+        ];
+
+        // Now we know the indices of the child nodes.
+        self.nodes[nid as usize].children =
+            [children[0].0, children[1].0, children[2].0, children[3].0];
+        self.nodes[nid as usize].simd_aabb =
+            SimdAabb::from([children[0].1, children[1].1, children[2].1, children[3].1]);
+        self.nodes[nid as usize]
+            .simd_aabb
+            .loosen(SimdReal::splat(margin));
+
+        let my_aabb = self.nodes[nid as usize].simd_aabb.to_merged_aabb();
+        (nid, my_aabb)
     }
 }

--- a/src/partitioning/qbvh/update.rs
+++ b/src/partitioning/qbvh/update.rs
@@ -317,7 +317,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
     /// Rebalances the `Qbvh` tree.
     ///
     /// This will modify the topology of this tree. This assumes that the leaf AABBs have
-    /// already been updated with [`Qbvh::refit`] or [`Qbvh::clear_and_rebuild`].
+    /// already been updated with [`Qbvh::refit`].
     pub fn rebalance(&mut self, margin: Real, workspace: &mut QbvhUpdateWorkspace) {
         if self.nodes.is_empty() {
             return;

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -174,7 +174,7 @@ pub struct TopoVertex {
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 #[repr(C)] // Needed for Cuda.
 pub struct TopoFace {
-    /// The half-edge adjascent to this face, whith a starting point equal
+    /// The half-edge adjacent to this face, with a starting point equal
     /// to the first point of this face.
     pub half_edge: u32,
 }


### PR DESCRIPTION
This adds `Qbvh::remove`, `Qbvh::pre_update_or_insert`, `Qbvh::refit`, `Qbvh::rebalance` to allow modifying a `Qbvh` without having to rebuild it completely.