### PR TITLE
Make `Qbvh::leaf_data` non-mut.

### DIFF
--- a/src/partitioning/qbvh/qbvh.rs
+++ b/src/partitioning/qbvh/qbvh.rs
@@ -348,7 +348,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
     /// Returns the data associated to a given leaf.
     ///
     /// Returns `None` if the provided node ID does not identify a leaf.
-    pub fn leaf_data(&mut self, node_id: NodeIndex) -> Option<LeafData> {
+    pub fn leaf_data(&self, node_id: NodeIndex) -> Option<LeafData> {
         let node = self.nodes.get(node_id.index as usize)?;
 
         if !node.is_leaf() {


### PR DESCRIPTION
There is no reason to take a mutable reference here.