### PR TITLE
Release v0.12

### DIFF
--- a/.github/workflows/parry-ci-build.yml
+++ b/.github/workflows/parry-ci-build.yml
@@ -63,7 +63,7 @@ jobs:
   build-cuda:
     runs-on: ubuntu-latest
     steps:
-      - uses: Jimver/cuda-toolkit@v0.2.4
+      - uses: Jimver/cuda-toolkit@v0.2.8
         with:
           cuda: '11.2.2'
       - name: Install nightly-2021-12-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # Change Log
 
-## Unreleased
+## v0.12.0 (11 Nov. 2022)
+
+### Modified
+- `Qbvh::leaf_data` now requires `&self` instead of `&mut self`.
+- Replace the `Qbvh::leaf` boolean by a bitflags.
 
 ### Added
 - Add `Qbvh::remove`, `Qbvh::pre_update_or_insert`, `Qbvh::refit`, `Qbvh::rebalance` to allow modifying a `Qbvh`
   without having to rebuild it completely.
+- Add `QbvhNode::is_leaf` to get if a node is a leaf or not.
 - Add `SharedShape::trimesh_with_flags` for building a trimesh with specific pre-processing flags.
+
+### Fixed
+- Fix `Triangle::contains_point`.
 
 ## v0.11.1 (30 Oct. 2022)
 

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry2d-f64"
-version = "0.11.1"
+version = "0.12.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry2d"
-version = "0.11.1"
+version = "0.12.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry3d-f64"
-version = "0.11.1"
+version = "0.12.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry3d"
-version = "0.11.1"
+version = "0.12.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "3 dimensional collision detection library in Rust."


### PR DESCRIPTION
## v0.12.0 (11 Nov. 2022)

### Modified
- `Qbvh::leaf_data` now requires `&self` instead of `&mut self`.
- Replace the `Qbvh::leaf` boolean by a bitflags.

### Added
- Add `Qbvh::remove`, `Qbvh::pre_update_or_insert`, `Qbvh::refit`, `Qbvh::rebalance` to allow modifying a `Qbvh`
  without having to rebuild it completely.
- Add `QbvhNode::is_leaf` to get if a node is a leaf or not.
- Add `SharedShape::trimesh_with_flags` for building a trimesh with specific pre-processing flags.

### Fixed
- Fix `Triangle::contains_point`.