### PR TITLE
Add functionality to intersect a `TriMesh` with a plane

### DIFF
--- a/crates/parry3d/tests/geometry/mod.rs
+++ b/crates/parry3d/tests/geometry/mod.rs
@@ -6,4 +6,5 @@ mod cylinder_cuboid_contact;
 mod epa3;
 mod still_objects_toi;
 mod time_of_impact3;
+mod trimesh_intersection;
 mod trimesh_trimesh_toi;

--- a/crates/parry3d/tests/geometry/trimesh_intersection.rs
+++ b/crates/parry3d/tests/geometry/trimesh_intersection.rs
@@ -2,7 +2,8 @@ use na::{Point3, Vector3};
 use parry3d::query::IntersectResult;
 use parry3d::shape::TriMesh;
 
-fn build_octohedron() -> TriMesh {
+fn build_diamond() -> TriMesh {
+    // Two tetrahedrons sharing a face
     let points = vec![
         Point3::new(0.0, 2.0, 0.0),
         Point3::new(-2.0, -1.0, 0.0),
@@ -25,7 +26,7 @@ fn build_octohedron() -> TriMesh {
 
 #[test]
 fn trimesh_plane_edge_intersection() {
-    let mesh = build_octohedron();
+    let mesh = build_diamond();
 
     let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 0.5, std::f32::EPSILON);
 
@@ -45,7 +46,7 @@ fn trimesh_plane_edge_intersection() {
 
 #[test]
 fn trimesh_plane_vertex_intersection() {
-    let mesh = build_octohedron();
+    let mesh = build_diamond();
 
     let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 0.0, std::f32::EPSILON);
 
@@ -64,8 +65,29 @@ fn trimesh_plane_vertex_intersection() {
 }
 
 #[test]
+fn trimesh_plane_mixed_intersection() {
+    let mesh = build_diamond();
+
+    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(0), 0.0, std::f32::EPSILON);
+
+    assert!(matches!(result, IntersectResult::Intersect(_)));
+
+    if let IntersectResult::Intersect(lines) = result {
+        assert_eq!(lines.len(), 1);
+
+        // Need to check points individually since order is not garunteed
+        let vertices = lines[0].vertices();
+        assert_eq!(vertices.len(), 4);
+        assert!(vertices.contains(&Point3::new(0.0, 2.0, 0.0)));
+        assert!(vertices.contains(&Point3::new(0.0, 0.0, 2.0)));
+        assert!(vertices.contains(&Point3::new(0.0, -1.0, 0.0)));
+        assert!(vertices.contains(&Point3::new(0.0, 0.0, -2.0)));
+    }
+}
+
+#[test]
 fn trimesh_plane_above() {
-    let mesh = build_octohedron();
+    let mesh = build_diamond();
 
     let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), -5.0, std::f32::EPSILON);
 
@@ -74,7 +96,7 @@ fn trimesh_plane_above() {
 
 #[test]
 fn trimesh_plane_below() {
-    let mesh = build_octohedron();
+    let mesh = build_diamond();
 
     let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 5.0, std::f32::EPSILON);
 

--- a/crates/parry3d/tests/geometry/trimesh_intersection.rs
+++ b/crates/parry3d/tests/geometry/trimesh_intersection.rs
@@ -1,0 +1,82 @@
+use na::{Point3, Vector3};
+use parry3d::query::IntersectResult;
+use parry3d::shape::TriMesh;
+
+fn build_octohedron() -> TriMesh {
+    let points = vec![
+        Point3::new(0.0, 2.0, 0.0),
+        Point3::new(-2.0, -1.0, 0.0),
+        Point3::new(0.0, 0.0, 2.0),
+        Point3::new(2.0, -1.0, 0.0),
+        Point3::new(0.0, 0.0, -2.0),
+    ];
+
+    let indices = vec![
+        [0u32, 1, 2],
+        [0, 2, 3],
+        [1, 2, 3],
+        [0, 1, 4],
+        [0, 4, 3],
+        [1, 4, 3],
+    ];
+
+    TriMesh::new(points, indices)
+}
+
+#[test]
+fn trimesh_plane_edge_intersection() {
+    let mesh = build_octohedron();
+
+    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 0.5, std::f32::EPSILON);
+
+    assert!(matches!(result, IntersectResult::Intersect(_)));
+
+    if let IntersectResult::Intersect(lines) = result {
+        assert_eq!(lines.len(), 1);
+
+        // Need to check points individually since order is not garunteed
+        let vertices = lines[0].vertices();
+        assert_eq!(vertices.len(), 3);
+        assert!(vertices.contains(&Point3::new(-1.5, -0.75, 0.5)));
+        assert!(vertices.contains(&Point3::new(1.5, -0.75, 0.5)));
+        assert!(vertices.contains(&Point3::new(0.0, 1.5, 0.5)));
+    }
+}
+
+#[test]
+fn trimesh_plane_vertex_intersection() {
+    let mesh = build_octohedron();
+
+    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 0.0, std::f32::EPSILON);
+
+    assert!(matches!(result, IntersectResult::Intersect(_)));
+
+    if let IntersectResult::Intersect(lines) = result {
+        assert_eq!(lines.len(), 1);
+
+        // Need to check points individually since order is not garunteed
+        let vertices = lines[0].vertices();
+        assert_eq!(vertices.len(), 3);
+        assert!(vertices.contains(&Point3::new(-2.0, -1.0, 0.0)));
+        assert!(vertices.contains(&Point3::new(2.0, -1.0, 0.0)));
+        assert!(vertices.contains(&Point3::new(0.0, 2.0, 0.0)));
+    }
+}
+
+#[test]
+fn trimesh_plane_above() {
+    let mesh = build_octohedron();
+
+    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), -5.0, std::f32::EPSILON);
+
+    assert!(matches!(result, IntersectResult::Positive));
+}
+
+#[test]
+fn trimesh_plane_below() {
+    let mesh = build_octohedron();
+
+    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 5.0, std::f32::EPSILON);
+
+    assert!(matches!(result, IntersectResult::Negative));
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -41,7 +41,7 @@ pub use self::point::{PointProjection, PointQuery, PointQueryWithLocation};
 pub use self::query_dispatcher::PersistentQueryDispatcher;
 pub use self::query_dispatcher::{QueryDispatcher, QueryDispatcherChain};
 pub use self::ray::{Ray, RayCast, RayIntersection, SimdRay};
-pub use self::split::SplitResult;
+pub use self::split::{IntersectResult, SplitResult};
 pub use self::time_of_impact::{time_of_impact, TOIStatus, TOI};
 
 mod clip;

--- a/src/query/split/mod.rs
+++ b/src/query/split/mod.rs
@@ -1,4 +1,4 @@
-pub use self::split::SplitResult;
+pub use self::split::{IntersectResult, SplitResult};
 
 mod split;
 mod split_aabb;

--- a/src/query/split/split.rs
+++ b/src/query/split/split.rs
@@ -8,3 +8,13 @@ pub enum SplitResult<T> {
     /// The shape being split is fully contained in the positive half-space of the plane.
     Positive,
 }
+
+/// The result of a plane-intersection operation.
+pub enum IntersectResult<T> {
+    /// The intersect operation yielded a result, lying in the plane
+    Intersect(T),
+    /// The shape being intersected is fully contained in the negative half-space of the plane.
+    Negative,
+    /// The shape being intersected is fully contained in the positive half-space of the plane.
+    Positive,
+}

--- a/src/query/split/split_trimesh.rs
+++ b/src/query/split/split_trimesh.rs
@@ -346,6 +346,21 @@ impl TriMesh {
         }
     }
 
+    /// Computes the intersection [`Polyline`]s between this mesh and the plane identified by
+    /// the given canonical axis.
+    ///
+    /// This will intersect the mesh by a plane with a normal with it’s `axis`-th component set to 1.
+    /// The splitting plane is shifted wrt. the origin by the `bias` (i.e. it passes through the point
+    /// equal to `normal * bias`).
+    pub fn canonical_intersection_with_plane(
+        &self,
+        axis: usize,
+        bias: Real,
+        epsilon: Real,
+    ) -> IntersectResult<Vec<Polyline>> {
+        self.intersection_with_local_plane(&Vector::ith_axis(axis), bias, epsilon)
+    }
+
     /// Computes the intersection [`Polyline`]s between this mesh, transformed by `position`,
     /// and a plane identified by its normal `axis` and the `bias`
     /// (i.e. the plane passes through the point equal to `normal * bias`).

--- a/src/query/split/split_trimesh.rs
+++ b/src/query/split/split_trimesh.rs
@@ -539,7 +539,14 @@ impl TriMesh {
 
                     let intersection_idx = intersect_edge(idx_a, idx_b);
 
-                    add_segment_adjacencies(idx_c, intersection_idx);
+                    let out_idx_c = *existing_vertices_found.entry(idx_c).or_insert_with(|| {
+                        let v2 = vertices[idx_c as usize];
+
+                        new_vertices.push(v2);
+                        (new_vertices.len() - 1) as u32
+                    });
+
+                    add_segment_adjacencies(out_idx_c, intersection_idx);
                 }
                 (FeatureId::Edge(mut e1), FeatureId::Edge(mut e2)) => {
                     // The plane splits the triangle into 1 + 2 triangles.


### PR DESCRIPTION
## Objective

Adds functionality to intersect a intersect a `TriMesh` with a plane, extracting any `Polyline`s that lie on the intersection. The API intentionally mimics the `TriMesh` split functions, and much of the implementation is identical.

## Changelog
- Added `TriMesh::canonical_intersection_with_plane` for intersecting with planes aligned with one of the axes
- Added `TriMesh::intersection_with_plane` for intersecting with arbitrary planes
- Added `TriMesh::intersection_with_local_plane` for intersecting with arbitrary planes in the same space as the mesh
- Added `IntersectResult` as the output type for the above functions. (Mimicing the API of the splitting functions.)
- Added `Polyline::extract_connected_components`, which splits a compound polyline into its connected components.

## Notes
- I wasn't sure if unit tests were expected, but I had already written some for my own local testing, so I figured there wasn't any reason not to include them.
- Unlike the `TriMesh` splitting functions, the triangle splitting in the new function generates an adjacency list of the final line segments. This allows us to easily construct multiple, consistently-oriented lines by traversing the list.
- The other notable difference with the impl for the splitting functions is that the `new_vertices` list starts empty, and so only contains vertices that are actually output.