### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## v0.13.0 (15 Jan. 2023)
+
+### Modified
+- About `rkyv` support: most POD structs (`Aabb`, `Ball`, `Cuboid`, etc.) are now archived as themselves instead of
+  being archived as different types (for example `Aabb` is archived as `Aabb` itself istead of `ArchivedAabb`).
+
+### Added
+- In 3D, add `transformation::try_convex_hull` for a convex hull calculation that will return an error instead of
+  panicking on unsupported inputs.
+
+### Fixed
+- Fixed duplicate faces in the connected components returned by `TriMesh::connected_components`.
+
 ## v0.12.1 (09 Jan. 2023)
 
 ### Added

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry2d-f64"
-version = "0.12.1"
+version = "0.13.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry2d"
-version = "0.12.1"
+version = "0.13.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry3d-f64"
-version = "0.12.1"
+version = "0.13.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "parry3d"
-version = "0.12.1"
+version = "0.13.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "3 dimensional collision detection library in Rust."


### PR DESCRIPTION
## v0.13.0 (15 Jan. 2023)

### Modified
- About `rkyv` support: most POD structs (`Aabb`, `Ball`, `Cuboid`, etc.) are now archived as themselves instead of
  being archived as different types (for example `Aabb` is archived as `Aabb` itself istead of `ArchivedAabb`).

### Added
- In 3D, add `transformation::try_convex_hull` for a convex hull calculation that will return an error instead of
  panicking on unsupported inputs.

### Fixed
- Fixed duplicate faces in the connected components returned by `TriMesh::connected_components`.