### PR TITLE
Speed up rkyv serialization

### DIFF
--- a/src/bounding_volume/simd_aabb.rs
+++ b/src/bounding_volume/simd_aabb.rs
@@ -9,7 +9,7 @@ use simba::simd::{SimdPartialOrd, SimdValue};
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
 pub struct SimdAabb {

--- a/src/partitioning/mod.rs
+++ b/src/partitioning/mod.rs
@@ -6,6 +6,7 @@ pub use self::qbvh::{
 };
 pub use self::qbvh::{
     GenericQbvh, IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhProxy, QbvhStorage, SimdNodeIndex,
+    QbvhNodeFlags,
 };
 #[cfg(feature = "parallel")]
 pub use self::visitor::{ParallelSimdSimultaneousVisitor, ParallelSimdVisitor};

--- a/src/partitioning/qbvh/qbvh.rs
+++ b/src/partitioning/qbvh/qbvh.rs
@@ -98,7 +98,7 @@ bitflags! {
     #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
     #[derive(Default)]
     /// The status of a QBVH node.
-    pub struct QbvhNodeFlags: u8 {
+    pub struct QbvhNodeFlags: u64 {
         /// If this bit is set, the node is a leaf.
         const LEAF = 0b0001;
         /// If this bit is set, this node was recently changed.
@@ -115,9 +115,10 @@ bitflags! {
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
 )]
 #[cfg_attr(feature = "cuda", derive(cust_core::DeviceCopy))]
+#[repr(C)]
 pub struct QbvhNode {
     /// The Aabbs of the qbvh nodes represented by this node.
     pub simd_aabb: SimdAabb,
@@ -234,9 +235,13 @@ impl<LeafData> QbvhProxy<LeafData> {
 #[derive(Debug)]
 pub struct GenericQbvh<LeafData, Storage: QbvhStorage<LeafData>> {
     pub(super) root_aabb: Aabb,
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub(super) nodes: Storage::Nodes,
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub(super) dirty_nodes: Storage::ArrayU32,
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub(super) free_list: Storage::ArrayU32,
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub(super) proxies: Storage::ArrayProxies,
 }
 

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -342,7 +342,9 @@ bitflags::bitflags! {
 /// A triangle mesh.
 pub struct GenericTriMesh<Storage: TriMeshStorage> {
     qbvh: GenericQbvh<u32, Storage::QbvhStorage>,
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     vertices: Storage::ArrayPoint,
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     indices: Storage::ArrayIdx,
     #[cfg(feature = "dim3")]
     pub(crate) pseudo_normals: Option<TriMeshPseudoNormals<Storage>>,


### PR DESCRIPTION
This tries to make use of the rkyv `CopyOptimize` attribute that can guarantee memcpy-able structs are indeed just that, rather then iterating over each element in the vector.

This ran into one oddity however, the archived layout of `QbvhNode` is smaller then the regular layout (128 vs 124 bytes), this is because `QbvhNode` contains quite a few padding bytes.

 - `QbvhNodeFlags` is `u8`
 - `NodeIndex` has a `u8` member

Both of those cause a (normally) 121-bytes struct to get blown up to 128 bytes.

In this PR I've hackfixed/worked around this issue by making QbvhNodeFlags u64 which obviously isn't what anybody would want, however since I'm not familiar with this project I'd like to open the discussion about what to do with this.

It seems likely that `QbvhNode` needs to be somehow cache-line aligned (which it is at the moment), but it might be nice to mark the padding bytes in `NodeIndex` and `QbvhNode` explicitly so it's clear where in the node one can stuff some additional info.

Removing the `CopyOptimize` is not the end of the world; but in this case having it speeds up rkyv serialization by about 2x.