### PR TITLE
Make SimdAabb deserializable in map-like formats like JSON, YAML

### DIFF
--- a/src/bounding_volume/simd_aabb.rs
+++ b/src/bounding_volume/simd_aabb.rs
@@ -77,6 +77,7 @@ impl<'de> serde::Deserialize<'de> for SimdAabb {
             {
                 let mut mins: Option<Point<[Real; SIMD_WIDTH]>> = None;
                 let mut maxs: Option<Point<[Real; SIMD_WIDTH]>> = None;
+
                 while let Some(key) = map.next_key()? {
                     match key {
                         Field::Mins => {
@@ -93,10 +94,11 @@ impl<'de> serde::Deserialize<'de> for SimdAabb {
                         }
                     }
                 }
+
                 let mins = mins.ok_or_else(|| serde::de::Error::missing_field("mins"))?;
                 let maxs = maxs.ok_or_else(|| serde::de::Error::missing_field("maxs"))?;
-                let mins = Point::from(mins.coords.map(|e| SimdReal::from(e)));
-                let maxs = Point::from(maxs.coords.map(|e| SimdReal::from(e)));
+                let mins = mins.map(SimdReal::from);
+                let maxs = maxs.map(SimdReal::from);
                 Ok(SimdAabb { mins, maxs })
             }
 
@@ -110,8 +112,8 @@ impl<'de> serde::Deserialize<'de> for SimdAabb {
                 let maxs: Point<[Real; SIMD_WIDTH]> = seq
                     .next_element()?
                     .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
-                let mins = Point::from(mins.coords.map(|e| SimdReal::from(e)));
-                let maxs = Point::from(maxs.coords.map(|e| SimdReal::from(e)));
+                let mins = mins.map(SimdReal::from);
+                let maxs = maxs.map(SimdReal::from);
                 Ok(SimdAabb { mins, maxs })
             }
         }

--- a/src/bounding_volume/simd_aabb.rs
+++ b/src/bounding_volume/simd_aabb.rs
@@ -39,7 +39,7 @@ impl serde::Serialize for SimdAabb {
                 .map(|e| array![|ii| e.extract(ii); SIMD_WIDTH]),
         );
 
-        let mut simd_aabb = serializer.serialize_struct("simd_aabb", 2)?;
+        let mut simd_aabb = serializer.serialize_struct("SimdAabb", 2)?;
         simd_aabb.serialize_field("mins", &mins)?;
         simd_aabb.serialize_field("maxs", &maxs)?;
         simd_aabb.end()
@@ -54,6 +54,13 @@ impl<'de> serde::Deserialize<'de> for SimdAabb {
     {
         struct Visitor {}
 
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Mins,
+            Maxs,
+        }
+
         impl<'de> serde::de::Visitor<'de> for Visitor {
             type Value = SimdAabb;
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -62,6 +69,35 @@ impl<'de> serde::Deserialize<'de> for SimdAabb {
                     "two arrays containing at least {} floats",
                     SIMD_WIDTH * DIM * 2
                 )
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut mins: Option<Point<[Real; SIMD_WIDTH]>> = None;
+                let mut maxs: Option<Point<[Real; SIMD_WIDTH]>> = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Mins => {
+                            if mins.is_some() {
+                                return Err(serde::de::Error::duplicate_field("mins"));
+                            }
+                            mins = Some(map.next_value()?);
+                        }
+                        Field::Maxs => {
+                            if maxs.is_some() {
+                                return Err(serde::de::Error::duplicate_field("maxs"));
+                            }
+                            maxs = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let mins = mins.ok_or_else(|| serde::de::Error::missing_field("mins"))?;
+                let maxs = maxs.ok_or_else(|| serde::de::Error::missing_field("maxs"))?;
+                let mins = Point::from(mins.coords.map(|e| SimdReal::from(e)));
+                let maxs = Point::from(maxs.coords.map(|e| SimdReal::from(e)));
+                Ok(SimdAabb { mins, maxs })
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>


### PR DESCRIPTION
This code:
```
use nalgebra::Isometry2;
use parry2d::shape::{SharedShape};

fn main() {
    let c = SharedShape::compound(
        vec![
            (Isometry2::default(), SharedShape::cuboid(5.0,5.0))
        ]
    );
    let s = serde_yaml::to_string(&c).unwrap();
    let c = serde_yaml::from_str::<SharedShape>(&s).unwrap();
    let s2 = serde_yaml::to_string(&c).unwrap();
    assert_eq!(s, s2);
}
```
Throws
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("qbvh.nodes[0].simd_aabb: invalid type: map, expected two arrays containing at least 16 floats", line: 23, column: 7)', crates/parry2d/examples/serde.rs:11:53
stack backtrace:
   0: rust_begin_unwind
             at /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/core/src/panicking.rs:64:14
   2: core::result::unwrap_failed
             at /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/core/src/result.rs:1791:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/core/src/result.rs:1113:23
   4: serde::main
             at ./crates/parry2d/examples/serde.rs:11:13
   5: core::ops::function::FnOnce::call_once
             at /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/core/src/ops/function.rs:507:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

And this code
```
use nalgebra::Isometry2;
use parry2d::shape::{SharedShape};

fn main() {
    let c = SharedShape::compound(
        vec![
            (Isometry2::default(), SharedShape::cuboid(5.0,5.0))
        ]
    );
    let s = ron::ser::to_string_pretty(
        &c, 
        ron::ser::PrettyConfig::default()
            .struct_names(true)
    ).unwrap();
    let c = ron::from_str::<SharedShape>(&s).unwrap();
    let s2 = ron::ser::to_string_pretty(
        &c, 
        ron::ser::PrettyConfig::default()
            .struct_names(true)
    ).unwrap();
    assert_eq!(s, s2);
}
```
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: SpannedError { code: ExpectedDifferentStructName { expected: "SimdAabb", found: "simd_aabb" }, position: Position { line: 29, col: 37 } }', crates/parry2d/examples/serde.rs:15:46
stack backtrace:
   0: rust_begin_unwind
             at /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/core/src/panicking.rs:64:14
   2: core::result::unwrap_failed
             at /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/core/src/result.rs:1791:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/core/src/result.rs:1113:23
   4: serde::main
             at ./crates/parry2d/examples/serde.rs:15:13
   5: core::ops::function::FnOnce::call_once
             at /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/core/src/ops/function.rs:507:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
I made the struct names match and added `visit_map` as described here:
https://serde.rs/deserialize-struct.html
