### PR TITLE
Enable tracing origins for mesh_intersection

### DIFF
--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -293,7 +293,7 @@ pub fn intersect_meshes_track(
         new_indices2.iter_mut().for_each(|idx| idx.swap(1, 2));
     }
 
-    new_indices1.append(&mut new_indices2);
+    new_indices1.append(&mut new_indices2.clone());
     new_indices1.append(&mut new_indices12);
 
     if !new_indices1.is_empty() {

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -280,7 +280,7 @@ pub fn intersect_meshes_track(
         }
     }
 
-    // Grab all the trinangles from the intersections.
+    // Grab all the trinangles from intersection1.
     for idx12 in &mut new_indices12 {
         for k in 0..3 {
             let new_id = *index_map.entry(idx12[k]).or_insert_with(|| {
@@ -292,6 +292,18 @@ pub fn intersect_meshes_track(
         }
     }
 
+    // Grab all the trinangles from intersection2.
+    for idx21 in &mut new_indices21 {
+        for k in 0..3 {
+            let new_id = *index_map.entry(idx21[k]).or_insert_with(|| {
+                let vtx = unified_vertex(mesh1, mesh2, &new_vertices12, &pos12, idx21[k]);
+                new_vertices.push(vtx);
+                new_vertices.len() - 1
+            });
+            idx21[k] = new_id as u32;
+        }
+    }
+
     if flip1 {
         new_indices1.iter_mut().for_each(|idx| idx.swap(1, 2));
     }
@@ -300,7 +312,6 @@ pub fn intersect_meshes_track(
         new_indices2.iter_mut().for_each(|idx| idx.swap(1, 2));
     }
 
-    // TODO track new_indices12 and indices21 separatly
     let tracks = vec![new_indices1.len(), new_indices2.len(), new_indices12.len(), new_indices21.len()];
     new_indices1.append(&mut new_indices2);
     new_indices1.append(&mut new_indices12);

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -79,6 +79,7 @@ pub fn intersect_meshes(
 
     let mut new_vertices12 = vec![];
     let mut new_indices12 = vec![];
+    let mut new_indices21 = vec![];
 
     cut_and_triangulate_intersections(
         &pos12,
@@ -88,6 +89,7 @@ pub fn intersect_meshes(
         flip2,
         &mut new_vertices12,
         &mut new_indices12,
+        &mut new_indices21,
         &mut intersections,
     );
 
@@ -157,6 +159,8 @@ pub fn intersect_meshes(
     }
 }
 
+
+/// Computes the intersection of two meshes, returns tracking meta
 pub fn intersect_meshes_track(
     pos1: &Isometry<Real>,
     mesh1: &TriMesh,
@@ -225,6 +229,7 @@ pub fn intersect_meshes_track(
 
     let mut new_vertices12 = vec![];
     let mut new_indices12 = vec![];
+    let mut new_indices21 = vec![];
 
     cut_and_triangulate_intersections(
         &pos12,
@@ -234,6 +239,7 @@ pub fn intersect_meshes_track(
         flip2,
         &mut new_vertices12,
         &mut new_indices12,
+        &mut new_indices21,
         &mut intersections,
     );
 
@@ -294,9 +300,10 @@ pub fn intersect_meshes_track(
     }
 
     // TODO track new_indices12 and indices21 separatly
-    let tracks = vec![new_indices1.len(), new_indices2.len(), new_indices12.len()];
+    let tracks = vec![new_indices1.len(), new_indices2.len(), new_indices12.len(), new_indices21.len()];
     new_indices1.append(&mut new_indices2);
     new_indices1.append(&mut new_indices12);
+    new_indices1.append(&mut new_indices21);
 
     if !new_indices1.is_empty() {
         Ok(Some((TriMesh::new(new_vertices, new_indices1), tracks)))
@@ -504,6 +511,7 @@ fn cut_and_triangulate_intersections(
     flip2: bool,
     new_vertices12: &mut Vec<Point<Real>>,
     new_indices12: &mut Vec<[u32; 3]>,
+    new_indices21: &mut Vec<[u32; 3]>,
     intersections: &mut Vec<(u32, u32)>,
 ) {
     let mut triangulations1 = HashMap::new();
@@ -634,6 +642,7 @@ fn cut_and_triangulate_intersections(
         &triangulations2,
         new_vertices12,
         new_indices12,
+        new_indices21,
     );
 }
 
@@ -684,6 +693,7 @@ fn extract_result(
     triangulations2: &HashMap<u32, Triangulation>,
     new_vertices12: &mut Vec<Point<Real>>,
     new_indices12: &mut Vec<[u32; 3]>,
+    new_indices21: &mut Vec<[u32; 3]>,
 ) {
     // Base ids for indexing in the first mesh vertices, second mesh vertices, and new vertices, as if they
     // are part of a single big array.
@@ -780,7 +790,7 @@ fn extract_result(
                 if flip2 {
                     idx.swap(1, 2);
                 }
-                new_indices12.push(idx);
+                new_indices21.push(idx);
             }
         }
     }

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -18,7 +18,7 @@ pub fn intersect_meshes(
     pos2: &Isometry<Real>,
     mesh2: &TriMesh,
     flip2: bool,
-) -> Result<Option<TriMesh>, MeshIntersectionError> {
+) -> Result<Option<(TriMesh, Vec<[u32; 3]>)>, MeshIntersectionError> {
     if mesh1.topology().is_none() || mesh2.topology().is_none() {
         return Err(MeshIntersectionError::MissingTopology);
     }
@@ -151,7 +151,10 @@ pub fn intersect_meshes(
     new_indices1.append(&mut new_indices12);
 
     if !new_indices1.is_empty() {
-        Ok(Some(TriMesh::new(new_vertices, new_indices1)))
+        Ok(Some((
+            TriMesh::new(new_vertices, new_indices1),
+            new_indices2,
+        )))
     } else {
         Ok(None)
     }

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -151,6 +151,7 @@ pub fn intersect_meshes(
 
     new_indices1.append(&mut new_indices2);
     new_indices1.append(&mut new_indices12);
+    new_indices1.append(&mut new_indices21);
 
     if !new_indices1.is_empty() {
         Ok(Some(TriMesh::new(new_vertices, new_indices1)))

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -18,6 +18,152 @@ pub fn intersect_meshes(
     pos2: &Isometry<Real>,
     mesh2: &TriMesh,
     flip2: bool,
+) -> Result<Option<TriMesh>, MeshIntersectionError> {
+    if mesh1.topology().is_none() || mesh2.topology().is_none() {
+        return Err(MeshIntersectionError::MissingTopology);
+    }
+
+    if mesh1.pseudo_normals().is_none() || mesh2.pseudo_normals().is_none() {
+        return Err(MeshIntersectionError::MissingPseudoNormals);
+    }
+
+    // NOTE: remove this, used for debugging only.
+    mesh1.assert_half_edge_topology_is_valid();
+    mesh2.assert_half_edge_topology_is_valid();
+
+    let pos12 = pos1.inv_mul(pos2);
+
+    // 1: collect all the potential triangle-triangle intersections.
+    let mut intersections = vec![];
+    let mut visitor = BoundingVolumeIntersectionsSimultaneousVisitor::with_relative_pos(
+        pos12,
+        |tri1: &u32, tri2: &u32| {
+            intersections.push((*tri1, *tri2));
+            true
+        },
+    );
+
+    mesh1.qbvh().traverse_bvtt(mesh2.qbvh(), &mut visitor);
+
+    let mut deleted_faces1: HashSet<u32> = HashSet::default();
+    let mut deleted_faces2: HashSet<u32> = HashSet::default();
+    let mut new_indices1 = vec![];
+    let mut new_indices2 = vec![];
+
+    for (fid1, fid2) in &intersections {
+        let tri1 = mesh1.triangle(*fid1);
+        let tri2 = mesh2.triangle(*fid2).transformed(&pos12);
+
+        if super::triangle_triangle_intersection(&tri1, &tri2).is_some() {
+            let _ = deleted_faces1.insert(*fid1);
+            let _ = deleted_faces2.insert(*fid2);
+        }
+    }
+
+    extract_connected_components(
+        &pos12,
+        &mesh1,
+        &mesh2,
+        flip2,
+        &deleted_faces1,
+        &mut new_indices1,
+    );
+    extract_connected_components(
+        &pos12.inverse(),
+        &mesh2,
+        &mesh1,
+        flip1,
+        &deleted_faces2,
+        &mut new_indices2,
+    );
+
+    let mut new_vertices12 = vec![];
+    let mut new_indices12 = vec![];
+
+    cut_and_triangulate_intersections(
+        &pos12,
+        &mesh1,
+        flip1,
+        &mesh2,
+        flip2,
+        &mut new_vertices12,
+        &mut new_indices12,
+        &mut intersections,
+    );
+
+    let old_vertices1 = mesh1.vertices();
+    let old_vertices2 = mesh2.vertices();
+
+    // At this point, we know what triangles we want from the first mesh,
+    // and the ones we want from the second mesh. Now we need to build the
+    // vertex buffer and adjust the indices accordingly.
+    let mut new_vertices = vec![];
+
+    // Maps from unified index to the final vertex index.
+    let mut index_map = HashMap::new();
+    let base_id2 = mesh1.vertices().len() as u32;
+
+    // Grab all the triangles from the connected component extracted from the first mesh.
+    for idx1 in &mut new_indices1 {
+        for k in 0..3 {
+            let new_id = *index_map.entry(idx1[k]).or_insert_with(|| {
+                let vtx = old_vertices1[idx1[k] as usize];
+                new_vertices.push(vtx);
+                new_vertices.len() - 1
+            });
+            idx1[k] = new_id as u32;
+        }
+    }
+
+    // Grab all the triangles from the connected component extracted from the second mesh.
+    for idx2 in &mut new_indices2 {
+        for k in 0..3 {
+            let new_id = *index_map.entry(base_id2 + idx2[k]).or_insert_with(|| {
+                let vtx = pos12 * old_vertices2[idx2[k] as usize];
+                new_vertices.push(vtx);
+                new_vertices.len() - 1
+            });
+            idx2[k] = new_id as u32;
+        }
+    }
+
+    // Grab all the trinangles from the intersections.
+    for idx12 in &mut new_indices12 {
+        for k in 0..3 {
+            let new_id = *index_map.entry(idx12[k]).or_insert_with(|| {
+                let vtx = unified_vertex(mesh1, mesh2, &new_vertices12, &pos12, idx12[k]);
+                new_vertices.push(vtx);
+                new_vertices.len() - 1
+            });
+            idx12[k] = new_id as u32;
+        }
+    }
+
+    if flip1 {
+        new_indices1.iter_mut().for_each(|idx| idx.swap(1, 2));
+    }
+
+    if flip2 {
+        new_indices2.iter_mut().for_each(|idx| idx.swap(1, 2));
+    }
+
+    new_indices1.append(&mut new_indices2);
+    new_indices1.append(&mut new_indices12);
+
+    if !new_indices1.is_empty() {
+        Ok(Some(TriMesh::new(new_vertices, new_indices1)))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn intersect_meshes_track(
+    pos1: &Isometry<Real>,
+    mesh1: &TriMesh,
+    flip1: bool,
+    pos2: &Isometry<Real>,
+    mesh2: &TriMesh,
+    flip2: bool,
 ) -> Result<Option<(TriMesh, Vec<[u32; 3]>)>, MeshIntersectionError> {
     if mesh1.topology().is_none() || mesh2.topology().is_none() {
         return Err(MeshIntersectionError::MissingTopology);

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -164,7 +164,7 @@ pub fn intersect_meshes_track(
     pos2: &Isometry<Real>,
     mesh2: &TriMesh,
     flip2: bool,
-) -> Result<Option<(TriMesh, Vec<[u32; 3]>)>, MeshIntersectionError> {
+) -> Result<Option<(TriMesh, Vec<usize>)>, MeshIntersectionError> {
     if mesh1.topology().is_none() || mesh2.topology().is_none() {
         return Err(MeshIntersectionError::MissingTopology);
     }
@@ -293,14 +293,13 @@ pub fn intersect_meshes_track(
         new_indices2.iter_mut().for_each(|idx| idx.swap(1, 2));
     }
 
-    new_indices1.append(&mut new_indices2.clone());
+    // TODO track new_indices12 and indices21 separatly
+    let tracks = vec![new_indices1.len(), new_indices2.len(), new_indices12.len()];
+    new_indices1.append(&mut new_indices2);
     new_indices1.append(&mut new_indices12);
 
     if !new_indices1.is_empty() {
-        Ok(Some((
-            TriMesh::new(new_vertices, new_indices1),
-            new_indices2,
-        )))
+        Ok(Some((TriMesh::new(new_vertices, new_indices1), tracks)))
     } else {
         Ok(None)
     }

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -19,7 +19,7 @@ pub fn intersect_meshes(
     mesh2: &TriMesh,
     flip2: bool,
 ) -> Result<Option<TriMesh>, MeshIntersectionError> {
-    let res = intersect_meshes_track(pos1, mesh1, flip1, pos2, mesh2, flip2);
+    let res = tracked_intersection(pos1, mesh1, flip1, pos2, mesh2, flip2);
     match res {
         Ok(Some((mesh, _tracks))) => Ok(Some(mesh)),
         Ok(None) => Ok(None),
@@ -32,7 +32,7 @@ pub fn intersect_meshes(
 ///
 /// The meshes must be oriented, have their half-edge topology computed, and must not be self-intersecting.
 /// The result mesh vertex coordinates are given in the local-space of `mesh1`.
-pub fn intersect_meshes_track(
+pub fn tracked_intersection(
     pos1: &Isometry<Real>,
     mesh1: &TriMesh,
     flip1: bool,

--- a/src/transformation/mesh_intersection/mod.rs
+++ b/src/transformation/mesh_intersection/mod.rs
@@ -1,4 +1,4 @@
-pub use self::mesh_intersection::intersect_meshes;
+pub use self::mesh_intersection::{intersect_meshes, intersect_meshes_track};
 pub use self::mesh_intersection_error::MeshIntersectionError;
 pub(self) use triangle_triangle_intersection::*;
 

--- a/src/transformation/mesh_intersection/mod.rs
+++ b/src/transformation/mesh_intersection/mod.rs
@@ -1,4 +1,4 @@
-pub use self::mesh_intersection::{intersect_meshes, intersect_meshes_track};
+pub use self::mesh_intersection::{intersect_meshes, tracked_intersection};
 pub use self::mesh_intersection_error::MeshIntersectionError;
 pub(self) use triangle_triangle_intersection::*;
 

--- a/src/transformation/mod.rs
+++ b/src/transformation/mod.rs
@@ -7,7 +7,7 @@ pub use self::convex_hull2::{convex_hull2 as convex_hull, convex_hull2_idx as co
 #[cfg(feature = "dim3")]
 pub use self::convex_hull3::{check_convex_hull, convex_hull, try_convex_hull, ConvexHullError};
 #[cfg(feature = "dim3")]
-pub use self::mesh_intersection::intersect_meshes;
+pub use self::mesh_intersection::{intersect_meshes, intersect_meshes_track};
 pub use self::polygon_intersection::{
     convex_polygons_intersection, convex_polygons_intersection_points,
 };

--- a/src/transformation/mod.rs
+++ b/src/transformation/mod.rs
@@ -7,7 +7,7 @@ pub use self::convex_hull2::{convex_hull2 as convex_hull, convex_hull2_idx as co
 #[cfg(feature = "dim3")]
 pub use self::convex_hull3::{check_convex_hull, convex_hull, try_convex_hull, ConvexHullError};
 #[cfg(feature = "dim3")]
-pub use self::mesh_intersection::{intersect_meshes, intersect_meshes_track};
+pub use self::mesh_intersection::{intersect_meshes, tracked_intersection};
 pub use self::polygon_intersection::{
     convex_polygons_intersection, convex_polygons_intersection_points,
 };


### PR DESCRIPTION
Made changes to mesh_intersection.rs 

Created an new function **tracked_intersection** that intersect meshes like **intersect_meshes**, but tracked_intersection also returns some metadata about the resulting trimesh so that the user can know from which input mesh each triangle was extracted.

Resolves #129 

There is a number of ways one could go about create the tracking metadata, feedback would be much appreciated :)