### PR TITLE
Re-add IntersectionCompositeShapeShapeBestFirstVisitor

### DIFF
--- a/src/query/intersection_test/mod.rs
+++ b/src/query/intersection_test/mod.rs
@@ -8,7 +8,7 @@ pub use self::intersection_test_ball_point_query::{
 #[cfg(feature = "std")]
 pub use self::intersection_test_composite_shape_shape::{
     intersection_test_composite_shape_shape, intersection_test_shape_composite_shape,
-    IntersectionCompositeShapeShapeVisitor,
+    IntersectionCompositeShapeShapeBestFirstVisitor, IntersectionCompositeShapeShapeVisitor,
 };
 pub use self::intersection_test_cuboid_cuboid::intersection_test_cuboid_cuboid;
 pub use self::intersection_test_cuboid_segment::{

--- a/src/query/intersection_test/mod.rs
+++ b/src/query/intersection_test/mod.rs
@@ -6,6 +6,8 @@ pub use self::intersection_test_ball_point_query::{
     intersection_test_ball_point_query, intersection_test_point_query_ball,
 };
 #[cfg(feature = "std")]
+// TODO: remove this once we get rid of IntersectionCompositeShapeShapeBestFirstVisitor
+#[allow(deprecated)]
 pub use self::intersection_test_composite_shape_shape::{
     intersection_test_composite_shape_shape, intersection_test_shape_composite_shape,
     IntersectionCompositeShapeShapeBestFirstVisitor, IntersectionCompositeShapeShapeVisitor,


### PR DESCRIPTION
This re-adds `IntersectionCompositeShapeShapeBestFirstVisitor` that was removed by #133. It’s marked as deprecated to avoid a breaking change just now.