### PR TITLE
Fixed polyline flat indices method

### DIFF
--- a/src/shape/polyline.rs
+++ b/src/shape/polyline.rs
@@ -109,7 +109,7 @@ impl Polyline {
     /// A flat view of the index buffer of this mesh.
     pub fn flat_indices(&self) -> &[u32] {
         unsafe {
-            let len = self.indices.len() * 3;
+            let len = self.indices.len() * 2;
             let data = self.indices.as_ptr() as *const u32;
             std::slice::from_raw_parts(data, len)
         }


### PR DESCRIPTION
Currently, the polyline flat_indices method seems to be copied over from the Triangle shape without proper adjustment.
This PR should fix the invalid casting.