### PR TITLE
Upgrade http links to https in Cargo.toml

### DIFF
--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.13.4"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."
-documentation = "http://parry.rs/docs"
-homepage = "http://parry.rs"
+documentation = "https://parry.rs/docs"
+homepage = "https://parry.rs"
 repository = "https://github.com/dimforge/parry"
 readme = "README.md"
 keywords = [ "collision", "geometry", "distance", "ray", "convex" ]

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.13.4"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "2 dimensional collision detection library in Rust."
-documentation = "http://parry.rs/docs"
-homepage = "http://parry.rs"
+documentation = "https://parry.rs/docs"
+homepage = "https://parry.rs"
 repository = "https://github.com/dimforge/parry"
 readme = "README.md"
 keywords = [ "collision", "geometry", "distance", "ray", "convex" ]

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.13.4"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."
-documentation = "http://parry.rs/docs"
-homepage = "http://parry.rs"
+documentation = "https://parry.rs/docs"
+homepage = "https://parry.rs"
 repository = "https://github.com/dimforge/parry"
 readme = "README.md"
 keywords = [ "collision", "geometry", "distance", "ray", "convex" ]

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.13.4"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "3 dimensional collision detection library in Rust."
-documentation = "http://parry.rs/docs"
-homepage = "http://parry.rs"
+documentation = "https://parry.rs/docs"
+homepage = "https://parry.rs"
 repository = "https://github.com/dimforge/parry"
 readme = "README.md"
 keywords = [ "collision", "geometry", "distance", "ray", "convex" ]


### PR DESCRIPTION
This is an automatically-generated PR to update plain HTTP links in Cargo.toml

If there are any issues with this, you can reach out to @/Benjins on Github who is the original author of this automated PR

In file `crates/parry2d-f64/Cargo.toml`:
 - `http://parry.rs` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS
 - `http://parry.rs/docs` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

In file `crates/parry3d-f64/Cargo.toml`:
 - `http://parry.rs` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS
 - `http://parry.rs/docs` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

In file `crates/parry2d/Cargo.toml`:
 - `http://parry.rs` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS
 - `http://parry.rs/docs` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

In file `crates/parry3d/Cargo.toml`:
 - `http://parry.rs` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS
 - `http://parry.rs/docs` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

