### PR TITLE
ci: Update actions.

### DIFF
--- a/.github/workflows/parry-ci-build.yml
+++ b/.github/workflows/parry-ci-build.yml
@@ -13,7 +13,7 @@ jobs:
   check-fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check formatting
       run: cargo fmt -- --check
   build-native:
@@ -21,7 +21,7 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo apt-get install -y cmake libxcb-composite0-dev
     - name: Build parry2d
       run: cargo build --verbose -p parry2d;
@@ -40,7 +40,7 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: rustup target add wasm32-unknown-unknown
       - name: build parry2d
         run: cd crates/parry2d && cargo build --verbose --target wasm32-unknown-unknown;
@@ -49,12 +49,11 @@ jobs:
   build-no-std:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
           components: rustfmt
       - name: install xargo
         run: cp .github/Xargo.toml .; rustup component add rust-src; cargo install -f xargo;
@@ -69,11 +68,10 @@ jobs:
         with:
           cuda: '11.5.0'
       - name: Install nightly-2021-12-04
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2021-12-04
-          override: true
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: rustup target add nvptx64-nvidia-cuda
       - run: cargo build --no-default-features --features required-features,cuda
       - run: cargo build --no-default-features --features required-features,cuda --target=nvptx64-nvidia-cuda


### PR DESCRIPTION
These are generating warnings about using deprecated stuff within the GitHub Actions UI.

In particular, the `actions-rs/toolchain` hasn't been maintained in some time.