### PR TITLE
deps: Update `num-derive` from `0.3` to `0.4`.

### DIFF
--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -53,7 +53,7 @@ nalgebra        = { version = "0.32", default-features = false, features = [ "li
 approx          = { version = "0.5", default-features = false }
 serde           = { version = "1.0", optional = true, features = ["derive"] }
 rkyv            = { version = "0.7.41", optional = true }
-num-derive      = "0.3"
+num-derive      = "0.4"
 indexmap        = { version = "1", features = [ "serde-1" ], optional = true }
 rustc-hash      = { version = "1", optional = true }
 cust_core       = { version = "0.1", optional = true }

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -53,7 +53,7 @@ nalgebra        = { version = "0.32", default-features = false, features = [ "li
 approx          = { version = "0.5", default-features = false }
 serde           = { version = "1.0", optional = true, features = ["derive"] }
 rkyv            = { version = "0.7.41", optional = true }
-num-derive      = "0.3"
+num-derive      = "0.4"
 indexmap        = { version = "1", features = [ "serde-1" ], optional = true }
 rustc-hash      = { version = "1", optional = true }
 cust_core       = { version = "0.1", optional = true }

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -53,7 +53,7 @@ nalgebra   = { version = "0.32", default-features = false, features = [ "libm" ]
 approx     = { version = "0.5", default-features = false }
 serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}
 rkyv       = { version = "0.7.41", optional = true }
-num-derive = "0.3"
+num-derive = "0.4"
 indexmap   = { version = "1", features = [ "serde-1" ], optional = true }
 rustc-hash = { version = "1", optional = true }
 cust_core  = { version = "0.1", optional = true }

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -54,7 +54,7 @@ nalgebra   = { version = "0.32", default-features = false, features = [ "libm" ]
 approx     = { version = "0.5", default-features = false }
 serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}
 rkyv       = { version = "0.7.41", optional = true }
-num-derive = "0.3"
+num-derive = "0.4"
 indexmap   = { version = "1", features = [ "serde-1" ], optional = true }
 rustc-hash = { version = "1", optional = true }
 cust_core  = { version = "0.1", optional = true }


### PR DESCRIPTION
This removes the usage of `syn` v1 as it updated to using v2.