### PR TITLE
clippy: Fix mem_replace_with_default.

### DIFF
--- a/src/partitioning/qbvh/update.rs
+++ b/src/partitioning/qbvh/update.rs
@@ -377,7 +377,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
         workspace.to_sort.extend(0..workspace.orig_ids.len());
         let root_id = NodeIndex::new(0, 0);
 
-        let mut indices = std::mem::replace(&mut workspace.to_sort, vec![]);
+        let mut indices = std::mem::take(&mut workspace.to_sort);
         let (id, aabb) = self.do_recurse_rebalance(&mut indices, workspace, root_id, margin);
         workspace.to_sort = indices;
 

--- a/src/query/contact_manifolds/contact_manifold.rs
+++ b/src/query/contact_manifolds/contact_manifold.rs
@@ -141,7 +141,7 @@ impl<ManifoldData, ContactData: Default + Copy> ContactManifold<ManifoldData, Co
         #[cfg(feature = "dim2")]
         let points = self.points.clone();
         #[cfg(feature = "dim3")]
-        let points = std::mem::replace(&mut self.points, Vec::new());
+        let points = std::mem::take(&mut self.points);
         self.points.clear();
 
         ContactManifold {

--- a/src/query/contact_manifolds/contact_manifolds_composite_shape_composite_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_composite_shape_composite_shape.rs
@@ -98,7 +98,7 @@ pub fn contact_manifolds_composite_shape_composite_shape<'a, ManifoldData, Conta
 
     // Traverse qbvh1 first.
     let ls_aabb2_1 = ls_aabb2.transform_by(&pos12).loosened(prediction);
-    let mut old_manifolds = std::mem::replace(manifolds, Vec::new());
+    let mut old_manifolds = std::mem::take(manifolds);
 
     let mut leaf_fn1 = |leaf1: &u32| {
         composite1.map_part_at(*leaf1, &mut |part_pos1, part_shape1| {

--- a/src/query/contact_manifolds/contact_manifolds_composite_shape_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_composite_shape_shape.rs
@@ -84,7 +84,7 @@ pub fn contact_manifolds_composite_shape_shape<ManifoldData, ContactData>(
 
     // Traverse qbvh1 first.
     let ls_aabb2_1 = shape2.compute_aabb(&pos12).loosened(prediction);
-    let mut old_manifolds = std::mem::replace(manifolds, Vec::new());
+    let mut old_manifolds = std::mem::take(manifolds);
 
     let mut leaf1_fn = |leaf1: &u32| {
         composite1.map_part_at(*leaf1, &mut |part_pos1, part_shape1| {

--- a/src/query/contact_manifolds/contact_manifolds_halfspace_pfm.rs
+++ b/src/query/contact_manifolds/contact_manifolds_halfspace_pfm.rs
@@ -58,7 +58,7 @@ pub fn contact_manifold_halfspace_pfm<'a, ManifoldData, ContactData, S2>(
 
     // We do this clone to perform contact tracking and transfer impulses.
     // FIXME: find a more efficient way of doing this.
-    let old_manifold_points = std::mem::replace(&mut manifold.points, Default::default());
+    let old_manifold_points = std::mem::take(&mut manifold.points);
 
     for i in 0..feature2.num_vertices {
         let vtx2 = feature2.vertices[i];

--- a/src/query/contact_manifolds/contact_manifolds_heightfield_composite_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_heightfield_composite_shape.rs
@@ -91,7 +91,7 @@ pub fn contact_manifolds_heightfield_composite_shape<ManifoldData, ContactData>(
     let qbvh2 = composite2.qbvh();
     let mut stack2 = Vec::new();
     let ls_aabb2_1 = qbvh2.root_aabb().transform_by(pos12).loosened(prediction);
-    let mut old_manifolds = std::mem::replace(manifolds, Vec::new());
+    let mut old_manifolds = std::mem::take(manifolds);
 
     heightfield1.map_elements_in_local_aabb(&ls_aabb2_1, &mut |leaf1, part1| {
         #[cfg(feature = "dim2")]

--- a/src/query/contact_manifolds/contact_manifolds_heightfield_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_heightfield_shape.rs
@@ -125,7 +125,7 @@ pub fn contact_manifolds_heightfield_shape<ManifoldData, ContactData>(
      */
     // TODO: somehow precompute the Aabb and reuse it?
     let ls_aabb2 = shape2.compute_aabb(pos12).loosened(prediction);
-    let mut old_manifolds = std::mem::replace(manifolds, Vec::new());
+    let mut old_manifolds = std::mem::take(manifolds);
 
     heightfield1.map_elements_in_local_aabb(&ls_aabb2, &mut |i, part1| {
         #[cfg(feature = "dim2")]

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -575,8 +575,8 @@ impl TriMesh {
                 .map(|idx| [idx[0] + base_id, idx[1] + base_id, idx[2] + base_id]),
         );
 
-        let vertices = std::mem::replace(&mut self.vertices, Vec::new());
-        let indices = std::mem::replace(&mut self.indices, Vec::new());
+        let vertices = std::mem::take(&mut self.vertices);
+        let indices = std::mem::take(&mut self.indices);
         *self = TriMesh::with_flags(vertices, indices, self.flags);
     }
 

--- a/src/transformation/convex_hull3/convex_hull.rs
+++ b/src/transformation/convex_hull3/convex_hull.rs
@@ -250,7 +250,7 @@ fn fix_silhouette_topology(
         }
 
         let mut removing = None;
-        let old_facets_and_idx = std::mem::replace(out_facets_and_idx, Vec::new());
+        let old_facets_and_idx = std::mem::take(out_facets_and_idx);
 
         for i in 0..old_facets_and_idx.len() {
             let facet_id = (loop_start + i) % old_facets_and_idx.len();


### PR DESCRIPTION
When replacing something with the default value, can juse use `take` instead.