### PR TITLE
intersection_with_plane: insert adjacencies in the correct order

### DIFF
--- a/src/query/split/split_trimesh.rs
+++ b/src/query/split/split_trimesh.rs
@@ -429,8 +429,13 @@ impl TriMesh {
             }
         };
         let mut add_segment_adjacencies_symmetric = |idx_a: usize, idx_b| {
-            add_segment_adjacencies(idx_a, idx_b);
-            add_segment_adjacencies(idx_b, idx_a);
+            if idx_a < idx_b {
+                add_segment_adjacencies(idx_a, idx_b);
+                add_segment_adjacencies(idx_b, idx_a);
+            } else {
+                add_segment_adjacencies(idx_b, idx_a);
+                add_segment_adjacencies(idx_a, idx_b);
+            }
         };
 
         let mut intersections_found = HashMap::default();


### PR DESCRIPTION
When computing plane intersection with a lot of trimeshes with `intersection_with_plane`, I sometimes get an exception:
```
thread 'Async Compute Task Pool (2)' panicked at 'assertion failed: idx_a <= index_adjacencies.len()', parry/crates/parry3d/../../src/query/split/split_trimesh.rs:423:13
stack backtrace:
   0:        0x10174e024 - std::backtrace_rs::backtrace::libunwind::trace::h77b39d3188241b9b
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:        0x10174e024 - std::backtrace_rs::backtrace::trace_unsynchronized::h255fc0d6f6a27160
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:        0x10174e024 - std::sys_common::backtrace::_print_fmt::hc63b2fe172b28820
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/sys_common/backtrace.rs:65:5
   3:        0x10174e024 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h523fafbfdb8f0857
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/sys_common/backtrace.rs:44:22
   4:        0x10176b060 - core::fmt::rt::Argument::fmt::h4c8d9e4aebabcbc2
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/fmt/rt.rs:138:9
   5:        0x10176b060 - core::fmt::write::hf94a55b5a3abd106
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/fmt/mod.rs:1094:21
   6:        0x10174baa8 - std::io::Write::write_fmt::hc7c6bf1da111b052
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/io/mod.rs:1714:15
   7:        0x10174de7c - std::sys_common::backtrace::_print::h12835c9b28903edc
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/sys_common/backtrace.rs:47:5
   8:        0x10174de7c - std::sys_common::backtrace::print::h68ede8fb1e716cba
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/sys_common/backtrace.rs:34:9
   9:        0x10174f3a4 - std::panicking::default_hook::{{closure}}::hba2205c2705c60bb
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:269:22
  10:        0x10174f134 - std::panicking::default_hook::h9d927e01472bad1a
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:288:9
  11:        0x10174f8d4 - std::panicking::rust_panic_with_hook::h8654c51ef9980a29
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:705:13
  12:        0x10174f7a4 - std::panicking::begin_panic_handler::{{closure}}::hd188a636b3b90298
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:595:13
  13:        0x10174e404 - std::sys_common::backtrace::__rust_end_short_backtrace::hc331d455ac21f427
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/sys_common/backtrace.rs:151:18
  14:        0x10174f54c - rust_begin_unwind
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:593:5
  15:        0x101821420 - core::panicking::panic_fmt::h4f2054f72ff905b1
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/panicking.rs:67:14
  16:        0x101821490 - core::panicking::panic::h4d2ee9cac0d6e9c1
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/panicking.rs:117:5
  17:        0x100794858 - parry3d::query::split::split_trimesh::<impl parry3d::shape::trimesh::GenericTriMesh<parry3d::utils::array::DefaultStorage>>::intersection_with_local_plane::{{closure}}::hf0af3e819d35725b
  18:        0x100793cc0 - parry3d::query::split::split_trimesh::<impl parry3d::shape::trimesh::GenericTriMesh<parry3d::utils::array::DefaultStorage>>::intersection_with_local_plane::ha32e9fcad1fd0abf
  19:        0x1007937fc - parry3d::query::split::split_trimesh::<impl parry3d::shape::trimesh::GenericTriMesh<parry3d::utils::array::DefaultStorage>>::intersection_with_plane::hb786bb6c1d316b73
```

This PR changes the insertion order in the adjacency vector so that the smallest one is always inserted first. It fixes the panic for me.