### PR TITLE
Fix voxel dim calc

### DIFF
--- a/src/transformation/voxelization/voxelized_volume.rs
+++ b/src/transformation/voxelization/voxelized_volume.rs
@@ -167,12 +167,12 @@ impl VoxelizedVolume {
         }
 
         #[cfg(feature = "dim3")]
-        if d[0] > d[1] && d[0] > d[2] {
+        if d[0] >= d[1] && d[0] >= d[2] {
             r = d[0];
             result.resolution[0] = resolution;
             result.resolution[1] = 2 + (resolution as Real * d[1] / d[0]) as u32;
             result.resolution[2] = 2 + (resolution as Real * d[2] / d[0]) as u32;
-        } else if d[1] > d[0] && d[1] > d[2] {
+        } else if d[1] >= d[0] && d[1] >= d[2] {
             r = d[1];
             result.resolution[1] = resolution;
             result.resolution[0] = 2 + (resolution as Real * d[0] / d[1]) as u32;


### PR DESCRIPTION
square flat shapes cause the voxel dimensions to be miscalculated and allocate vastly more voxels than intended. see [v-hacd latest](https://github.com/kmammou/v-hacd/blob/454913fad7d4071f374e3d9aee3e6ccc98bca84d/include/VHACD.h#L5113)