### PR TITLE
Ensure convex polygon does not panic due to invalid amount of points

### DIFF
--- a/src/shape/convex_polygon.rs
+++ b/src/shape/convex_polygon.rs
@@ -32,6 +32,9 @@ impl ConvexPolygon {
     /// Convexity of the input polyline is not checked.
     /// Returns `None` if all points form an almost flat line.
     pub fn from_convex_polyline(mut points: Vec<Point<Real>>) -> Option<Self> {
+        if points.is_empty() {
+            return None;
+        }
         let eps = ComplexField::sqrt(crate::math::DEFAULT_EPSILON);
         let mut normals = Vec::with_capacity(points.len());
         // First, compute all normals.

--- a/src/shape/convex_polygon.rs
+++ b/src/shape/convex_polygon.rs
@@ -34,7 +34,6 @@ impl ConvexPolygon {
     pub fn from_convex_polyline(mut points: Vec<Point<Real>>) -> Option<Self> {
         let eps = ComplexField::sqrt(crate::math::DEFAULT_EPSILON);
         let mut normals = Vec::with_capacity(points.len());
-
         // First, compute all normals.
         for i1 in 0..points.len() {
             let i2 = (i1 + 1) % points.len();
@@ -63,8 +62,8 @@ impl ConvexPolygon {
         let new_length = points.len() - nremoved;
         points.truncate(new_length);
         normals.truncate(new_length);
-
-        if !points.is_empty() {
+        
+        if points.len() > 2  {
             Some(ConvexPolygon { points, normals })
         } else {
             None

--- a/src/shape/convex_polygon.rs
+++ b/src/shape/convex_polygon.rs
@@ -65,8 +65,8 @@ impl ConvexPolygon {
         let new_length = points.len() - nremoved;
         points.truncate(new_length);
         normals.truncate(new_length);
-        
-        if points.len() > 2  {
+
+        if points.len() > 2 {
             Some(ConvexPolygon { points, normals })
         } else {
             None


### PR DESCRIPTION
I'm constantly running into panics, due to

```
parry2d-0.13.5\src\shape\convex_polygon.rs:185:59:
index out of bounds: the len is 2 but the index is 2
```

This occurs more often than _normally_ (I assume), because I create compound shapes at runtime after deforming objects into smaller ones.

It should not be possible to create a polygon that has less than 3 points. Also, it should be ensured that no empty points is passed. That fixes another crash where `normals[0]` indexes points that don't exist.