### PR TITLE
QbvhUpdateWorkspace stack depth change u8 to u16 to prevent overflow

### DIFF
--- a/src/partitioning/qbvh/update.rs
+++ b/src/partitioning/qbvh/update.rs
@@ -17,7 +17,7 @@ mod tests;
 /// Re-using the same workspace for multiple QBVH modification isn’t mandatory, but it improves
 /// performances by avoiding useless allocation.
 pub struct QbvhUpdateWorkspace {
-    stack: Vec<(u32, u8)>,
+    stack: Vec<(u32, u16)>,
     dirty_parent_nodes: Vec<u32>,
     // For rebalancing.
     to_sort: Vec<usize>,
@@ -337,7 +337,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
 
         workspace.clear();
 
-        const MIN_CHANGED_DEPTH: u8 = 5; // TODO: find a good value
+        const MIN_CHANGED_DEPTH: u16 = 5; // TODO: find a good value
 
         for root_child in self.nodes[0].children {
             if root_child < self.nodes.len() as u32 {


### PR DESCRIPTION
QbvhUpdateWorkspace stack depth can be more than 255, so I changed u8 to u16.

After this change, I no longer received the error:
`attempt to add with overflow`
on the line:
`workspace.stack.push((child, depth + 1));`

Related error:
https://github.com/dimforge/rapier/issues/532