### PR TITLE
add a Debug impl for SharedShape

### DIFF
--- a/src/shape/compound.rs
+++ b/src/shape/compound.rs
@@ -18,7 +18,7 @@ use crate::utils::DefaultStorage;
 /// the main way of creating a concave shape from convex parts. Each parts can have its own
 /// delta transformation to shift or rotate it with regard to the other shapes.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Compound {
     shapes: Vec<(Isometry<Real>, SharedShape)>,
     qbvh: Qbvh<u32>,

--- a/src/shape/polyline.rs
+++ b/src/shape/polyline.rs
@@ -9,7 +9,7 @@ use crate::utils::DefaultStorage;
 #[cfg(not(feature = "std"))]
 use na::ComplexField; // for .abs()
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -85,7 +85,7 @@ pub enum ShapeType {
     Custom,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize))]
 /// Enum representing the shape with its actual type
 pub enum TypedShape<'a> {

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -5,7 +5,7 @@ use crate::shape::ConvexPolygon;
 use crate::shape::DeserializableTypedShape;
 use crate::shape::{
     Ball, Capsule, Compound, Cuboid, HalfSpace, HeightField, Polyline, RoundShape, Segment, Shape,
-    TriMesh, TriMeshFlags, Triangle,
+    TriMesh, TriMeshFlags, Triangle, ShapeType
 };
 #[cfg(feature = "dim3")]
 use crate::shape::{Cone, ConvexPolyhedron, Cylinder};
@@ -13,6 +13,7 @@ use crate::transformation::vhacd::{VHACDParameters, VHACD};
 use na::Unit;
 use std::ops::Deref;
 use std::sync::Arc;
+use std::fmt;
 
 /// The shape of a collider.
 #[derive(Clone)]
@@ -28,6 +29,13 @@ impl Deref for SharedShape {
 impl AsRef<dyn Shape> for SharedShape {
     fn as_ref(&self) -> &dyn Shape {
         &*self.0
+    }
+}
+
+impl fmt::Debug for SharedShape {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let shape_type: ShapeType = (*self.0).shape_type();
+        write!(f, "SharedShape ( Arc<{:?}> )", shape_type)
     }
 }
 

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -5,15 +5,15 @@ use crate::shape::ConvexPolygon;
 use crate::shape::DeserializableTypedShape;
 use crate::shape::{
     Ball, Capsule, Compound, Cuboid, HalfSpace, HeightField, Polyline, RoundShape, Segment, Shape,
-    TriMesh, TriMeshFlags, Triangle, ShapeType
+    TriMesh, TriMeshFlags, Triangle, TypedShape,
 };
 #[cfg(feature = "dim3")]
 use crate::shape::{Cone, ConvexPolyhedron, Cylinder};
 use crate::transformation::vhacd::{VHACDParameters, VHACD};
 use na::Unit;
+use std::fmt;
 use std::ops::Deref;
 use std::sync::Arc;
-use std::fmt;
 
 /// The shape of a collider.
 #[derive(Clone)]
@@ -34,8 +34,8 @@ impl AsRef<dyn Shape> for SharedShape {
 
 impl fmt::Debug for SharedShape {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let shape_type: ShapeType = (*self.0).shape_type();
-        write!(f, "SharedShape ( Arc<{:?}> )", shape_type)
+        let typed_shape: TypedShape = (*self.0).as_typed_shape();
+        write!(f, "SharedShape ( Arc<{:?}> )", typed_shape)
     }
 }
 

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -359,9 +359,9 @@ pub struct GenericTriMesh<Storage: TriMeshStorage> {
     flags: TriMeshFlags,
 }
 
-impl fmt::Debug for GenericTriMesh<DefaultStorage> {
+impl<Storage: TriMeshStorage> fmt::Debug for GenericTriMesh<Storage> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "GenericTriMesh<DefaultStorage>")
+        write!(f, "GenericTriMesh")
     }
 }
 

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -4,6 +4,7 @@ use crate::partitioning::QbvhStorage;
 use crate::partitioning::{GenericQbvh, Qbvh};
 use crate::shape::trimesh_storage::TriMeshStorage;
 use crate::shape::{FeatureId, Shape, Triangle, TypedSimdCompositeShape};
+use std::fmt;
 
 use crate::utils::{Array1, DefaultStorage, HashablePartialEq};
 #[cfg(feature = "dim3")]
@@ -356,6 +357,12 @@ pub struct GenericTriMesh<Storage: TriMeshStorage> {
     topology: Option<TriMeshTopology<Storage>>,
     connected_components: Option<TriMeshConnectedComponents<Storage>>,
     flags: TriMeshFlags,
+}
+
+impl fmt::Debug for GenericTriMesh<DefaultStorage> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "GenericTriMesh<DefaultStorage>")
+    }
 }
 
 /// A triangle-mesh.


### PR DESCRIPTION
Based on this issue in rapier: https://github.com/dimforge/rapier/issues/577

I implemented Debug for SharedShape by using the trait method to get the ShapeType, and then using that as the basis of the debug info. 

This is my first PR, I hope it's ok! I will post a corresponding one to rapier.