### PR TITLE
Aabb wrt centre/issue #155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Fix a crash in `Qbvh::refit` that results from the QBVH tree becoming increasingly imbalanced.
 
+### Added
+
+- Add `Aabb::scaled_wrt_center` to scale an AABB while keeping its center unchanged.
+
 ## v0.13.6
 
 ### Fixed

--- a/crates/parry2d/tests/geometry/aabb_scale.rs
+++ b/crates/parry2d/tests/geometry/aabb_scale.rs
@@ -1,0 +1,16 @@
+use na::{Point2, Vector2};
+use parry2d::bounding_volume::Aabb;
+
+#[test]
+fn test_aabb_scale_wrt_center() {
+    let aabb = Aabb::from_half_extents(Point2::new(1.0, 2.0), Vector2::new(4.0, 5.0));
+    let scale = Vector2::new(10.0, -20.0);
+    let scaled_aabb = aabb.scaled_wrt_center(&scale);
+    let scaled_aabb_neg = aabb.scaled_wrt_center(&-scale);
+    let scaled_aabb_abs = aabb.scaled_wrt_center(&scale.abs());
+
+    assert_eq!(&scaled_aabb, &scaled_aabb_neg);
+    assert_eq!(&scaled_aabb, &scaled_aabb_abs);
+    assert_eq!(aabb.center(), scaled_aabb.center());
+    assert_eq!(scaled_aabb.half_extents(), Vector2::new(40.0, 100.0));
+}

--- a/crates/parry2d/tests/geometry/mod.rs
+++ b/crates/parry2d/tests/geometry/mod.rs
@@ -1,3 +1,4 @@
+mod aabb_scale;
 mod ball_ball_toi;
 mod ball_cuboid_contact;
 mod epa2;

--- a/crates/parry3d/tests/geometry/aabb_scale.rs
+++ b/crates/parry3d/tests/geometry/aabb_scale.rs
@@ -1,0 +1,16 @@
+use na::{Point3, Vector3};
+use parry3d::bounding_volume::Aabb;
+
+#[test]
+fn test_aabb_scale_wrt_center() {
+    let aabb = Aabb::from_half_extents(Point3::new(1.0, 2.0, 3.0), Vector3::new(4.0, 5.0, 6.0));
+    let scale = Vector3::new(10.0, -20.0, 50.0);
+    let scaled_aabb = aabb.scaled_wrt_center(&scale);
+    let scaled_aabb_neg = aabb.scaled_wrt_center(&-scale);
+    let scaled_aabb_abs = aabb.scaled_wrt_center(&scale.abs());
+
+    assert_eq!(&scaled_aabb, &scaled_aabb_neg);
+    assert_eq!(&scaled_aabb, &scaled_aabb_abs);
+    assert_eq!(aabb.center(), scaled_aabb.center());
+    assert_eq!(scaled_aabb.half_extents(), Vector3::new(40.0, 100.0, 300.0));
+}

--- a/crates/parry3d/tests/geometry/mod.rs
+++ b/crates/parry3d/tests/geometry/mod.rs
@@ -1,3 +1,4 @@
+mod aabb_scale;
 mod ball_ball_toi;
 mod ball_triangle_toi;
 mod convex_hull;

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -176,6 +176,46 @@ impl Aabb {
         }
     }
 
+    #[inline]
+    #[cfg(feature = "dim2")]
+    pub fn scaled_wrt_center(self, scale: &Vector<Real>) -> Self {
+        let center: Point<Real> = na::center(&self.mins, &self.maxs);
+
+        let translated_min = na::Translation2::from(center).transform_point(&self.mins);
+        let translated_max = na::Translation2::from(center).transform_point(&self.maxs);
+
+        let transformed_min = translated_min.coords.component_mul(scale);
+        let transformed_max = translated_max.coords.component_mul(scale);
+
+        let a = transformed_min + center;
+        let b = transformed_max + center;
+
+        Self {
+            mins: a.inf(&b).into(),
+            maxs: a.sup(&b).into(),
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "dim3")]
+    pub fn scaled_wrt_center(self, scale: &Vector<Real>) -> Self {
+        let center: Point<Real> = na::center(&self.mins, &self.maxs);
+
+        let translated_min = na::Translation3::from(center).transform_point(&self.mins);
+        let translated_max = na::Translation3::from(center).transform_point(&self.maxs);
+
+        let transformed_min = translated_min.coords.component_mul(scale);
+        let transformed_max = translated_max.coords.component_mul(scale);
+
+        let a = transformed_min + center;
+        let b = transformed_max + center;
+
+        Self {
+            mins: a.inf(&b).into(),
+            maxs: a.sup(&b).into(),
+        }
+    }
+
     /// The smallest bounding sphere containing this `Aabb`.
     #[inline]
     pub fn bounding_sphere(&self) -> BoundingSphere {

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -176,52 +176,20 @@ impl Aabb {
         }
     }
 
+    /// Returns an AABB with the same center as `self` but with extents scaled by `scale`.
+    ///
+    /// # Parameters
+    /// - `scale`: the scaling factor. It can be non-uniform and/or negative. The AABB being
+    ///            symmetric wrt. its center, a negative scale value has the same effect as scaling
+    ///            by its absolute value.
     #[inline]
-    #[cfg(feature = "dim2")]
     pub fn scaled_wrt_center(self, scale: &Vector<Real>) -> Self {
-        let center: Point<Real> = na::center(&self.mins, &self.maxs);
-
-        let translated_min = na::Translation2::from(center)
-            .inverse()
-            .transform_point(&self.mins);
-        let translated_max = na::Translation2::from(center)
-            .inverse()
-            .transform_point(&self.maxs);
-
-        let transformed_min = translated_min.coords.component_mul(scale);
-        let transformed_max = translated_max.coords.component_mul(scale);
-
-        let a = center + transformed_min;
-        let b = center + transformed_max;
-
-        Self {
-            mins: a.inf(&b).into(),
-            maxs: a.sup(&b).into(),
-        }
-    }
-
-    #[inline]
-    #[cfg(feature = "dim3")]
-    pub fn scaled_wrt_center(self, scale: &Vector<Real>) -> Self {
-        let center: Point<Real> = na::center(&self.mins, &self.maxs);
-
-        let translated_min = na::Translation3::from(center)
-            .inverse()
-            .transform_point(&self.mins);
-        let translated_max = na::Translation3::from(center)
-            .inverse()
-            .transform_point(&self.maxs);
-
-        let transformed_min = translated_min.coords.component_mul(scale);
-        let transformed_max = translated_max.coords.component_mul(scale);
-
-        let a = center + transformed_min;
-        let b = center + transformed_max;
-
-        Self {
-            mins: a.inf(&b).into(),
-            maxs: a.sup(&b).into(),
-        }
+        let center = self.center();
+        // Multiply the extents by the scale. Negative scaling might modify the half-extent
+        // sign, so we take the absolute value. The AABB being symmetric that absolute value
+        // is  valid.
+        let half_extents = self.half_extents().component_mul(scale).abs();
+        Self::from_half_extents(center, half_extents)
     }
 
     /// The smallest bounding sphere containing this `Aabb`.

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -181,14 +181,18 @@ impl Aabb {
     pub fn scaled_wrt_center(self, scale: &Vector<Real>) -> Self {
         let center: Point<Real> = na::center(&self.mins, &self.maxs);
 
-        let translated_min = na::Translation2::from(center).transform_point(&self.mins);
-        let translated_max = na::Translation2::from(center).transform_point(&self.maxs);
+        let translated_min = na::Translation2::from(center)
+            .inverse()
+            .transform_point(&self.mins);
+        let translated_max = na::Translation2::from(center)
+            .inverse()
+            .transform_point(&self.maxs);
 
         let transformed_min = translated_min.coords.component_mul(scale);
         let transformed_max = translated_max.coords.component_mul(scale);
 
-        let a = transformed_min + center;
-        let b = transformed_max + center;
+        let a = center + transformed_min;
+        let b = center + transformed_max;
 
         Self {
             mins: a.inf(&b).into(),
@@ -201,14 +205,18 @@ impl Aabb {
     pub fn scaled_wrt_center(self, scale: &Vector<Real>) -> Self {
         let center: Point<Real> = na::center(&self.mins, &self.maxs);
 
-        let translated_min = na::Translation3::from(center).transform_point(&self.mins);
-        let translated_max = na::Translation3::from(center).transform_point(&self.maxs);
+        let translated_min = na::Translation3::from(center)
+            .inverse()
+            .transform_point(&self.mins);
+        let translated_max = na::Translation3::from(center)
+            .inverse()
+            .transform_point(&self.maxs);
 
         let transformed_min = translated_min.coords.component_mul(scale);
         let transformed_max = translated_max.coords.component_mul(scale);
 
-        let a = transformed_min + center;
-        let b = transformed_max + center;
+        let a = center + transformed_min;
+        let b = center + transformed_max;
 
         Self {
             mins: a.inf(&b).into(),

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -183,6 +183,7 @@ impl Aabb {
     ///            symmetric wrt. its center, a negative scale value has the same effect as scaling
     ///            by its absolute value.
     #[inline]
+    #[must_use]
     pub fn scaled_wrt_center(self, scale: &Vector<Real>) -> Self {
         let center = self.center();
         // Multiply the extents by the scale. Negative scaling might modify the half-extent

--- a/src/bounding_volume/mod.rs
+++ b/src/bounding_volume/mod.rs
@@ -62,22 +62,3 @@ pub mod details {
     pub use super::aabb_utils::{local_point_cloud_aabb, local_support_map_aabb, point_cloud_aabb};
     pub use super::bounding_sphere_utils::point_cloud_bounding_sphere;
 }
-
-#[cfg(test)]
-mod quick_tests {
-    use super::*;
-    use crate::math::{Point, Vector};
-
-    #[test]
-    #[cfg(feature = "dim2")]
-    fn aabb_rescale_wrt_origin_2d() {
-        let x1 = Point::new(1.0, 1.0);
-        let x2 = Point::new(2.0, 2.0);
-        let scale = Vector::new(2.0, 2.0);
-        let aabb = Aabb::new(x1, x2);
-        let aabbp = aabb.scaled_wrt_center(&scale);
-        let xp1 = Point::new(0.5, 0.5);
-        let xp2 = Point::new(2.5, 2.5);
-        assert_eq!(aabbp, Aabb::new(xp1, xp2));
-    }
-}

--- a/src/bounding_volume/mod.rs
+++ b/src/bounding_volume/mod.rs
@@ -62,3 +62,22 @@ pub mod details {
     pub use super::aabb_utils::{local_point_cloud_aabb, local_support_map_aabb, point_cloud_aabb};
     pub use super::bounding_sphere_utils::point_cloud_bounding_sphere;
 }
+
+#[cfg(test)]
+mod quick_tests {
+    use super::*;
+    use crate::math::{Point, Vector};
+
+    #[test]
+    #[cfg(feature = "dim2")]
+    fn aabb_rescale_wrt_origin_2d() {
+        let x1 = Point::new(1.0, 1.0);
+        let x2 = Point::new(2.0, 2.0);
+        let scale = Vector::new(2.0, 2.0);
+        let aabb = Aabb::new(x1, x2);
+        let aabbp = aabb.scaled_wrt_center(&scale);
+        let xp1 = Point::new(0.5, 0.5);
+        let xp2 = Point::new(2.5, 2.5);
+        assert_eq!(aabbp, Aabb::new(xp1, xp2));
+    }
+}


### PR DESCRIPTION
I wrote the function that would allow for an `aabb` to be scaled with respect to its centre instead of the origin ( Issue #155 ). I added a unit test as a sanity check that this was doing the right thing, but not anything comprehensive.