### PR TITLE
Fix normal direction for GJK ray casting inside non-solid shapes

### DIFF
--- a/src/query/ray/ray.rs
+++ b/src/query/ray/ray.rs
@@ -68,12 +68,16 @@ impl Ray {
     archive(as = "Self")
 )]
 pub struct RayIntersection {
-    /// The time of impact of the ray with the object.  The exact contact point can be computed
+    /// The time of impact of the ray with the object. The exact contact point can be computed
     /// with: `ray.point_at(toi)` or equivalently `origin + dir * toi` where `origin` is the origin of the ray;
     /// `dir` is its direction and `toi` is the value of this field.
     pub toi: Real,
 
     /// The normal at the intersection point.
+    ///
+    /// If the origin of the ray is inside of the shape and the shape is not solid,
+    /// the normal will point towards the interior of the shape.
+    /// Otherwise, the normal points outward.
     ///
     /// If the `toi` is exactly zero, the normal might not be reliable.
     // XXX: use a Unit<Vector> instead.

--- a/src/query/ray/ray_support_map.rs
+++ b/src/query/ray/ray_support_map.rs
@@ -47,10 +47,14 @@ where
                 simplex.reset(CSOPoint::single_point(supp - new_ray.origin.coords));
 
                 gjk::cast_local_ray(shape, simplex, &new_ray, shift + eps).and_then(
-                    |(toi, normal)| {
+                    |(toi, outward_normal)| {
                         let toi = shift - toi;
                         if toi <= max_toi {
-                            Some(RayIntersection::new(toi, normal, FeatureId::Unknown))
+                            Some(RayIntersection::new(
+                                toi,
+                                -outward_normal,
+                                FeatureId::Unknown,
+                            ))
                         } else {
                             None
                         }


### PR DESCRIPTION
# Objective

Many shapes like cylinders, cones, capsules, convex polyhedra, and convex polygons use support mapping and a variant of GJK for ray casting.

If the ray origin is inside of the shape and the shape is marked as non-solid (i.e. hollow), the ray casting method shifts the ray origin just outside of the shape and reverses the ray's direction before running GJK a second time. This acts as a way to find the hit point on the boundary as if the ray was to keep travelling inside the shape.

However, the actual final ray cast is still done from the *outside* of the shape, and the normal ends up pointing *outward*. This is *not* the expected result, as the specialized ray casting implementations for shapes like circles, rectangles, triangles, and so on return the normal pointing in the *interior* of the shape. This makes the ray casting behavior highly inconsistent between shapes, which could lead to critical and hard-to-debug bugs.

The normal should always be pointing in the interior of the shape for non-solid shapes when the ray origin is inside of the shape, even for GJK-based ray casts.

## Solution

Simply flip the normal for the non-solid interior hits. I also made the expected behavior clearer in the `RayIntersection` docs.

Before: (see how the capsule behavior is different)

https://github.com/dimforge/parry/assets/57632562/33c49586-c2ba-44d5-bb27-0361f1d05f2e

After:

https://github.com/dimforge/parry/assets/57632562/3e39948c-a6f6-4f2c-89c8-5f7060cfe207

There is also some visible instability with the GJK-based ray casting due to GJK not converging on a solution, but attempting to fix that is out of scope for this PR.