### PR TITLE
Fix some docstrings in `tetrahedron.rs`

### DIFF
--- a/src/shape/tetrahedron.rs
+++ b/src/shape/tetrahedron.rs
@@ -24,13 +24,13 @@ use rkyv::{bytecheck, CheckBytes};
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct Tetrahedron {
-    /// The tetrahedron first point.
+    /// The tetrahedron's first point.
     pub a: Point<Real>,
-    /// The tetrahedron first point.
+    /// The tetrahedron's second point.
     pub b: Point<Real>,
-    /// The tetrahedron first point.
+    /// The tetrahedron's third point.
     pub c: Point<Real>,
-    /// The tetrahedron first point.
+    /// The tetrahedron's fourth point.
     pub d: Point<Real>,
 }
 
@@ -41,7 +41,7 @@ pub enum TetrahedronPointLocation {
     OnVertex(u32),
     /// The point lies on an edge.
     ///
-    /// The 0-st edge is the segment AB.
+    /// The 0-th edge is the segment AB.
     /// The 1-st edge is the segment AC.
     /// The 2-nd edge is the segment AD.
     /// The 3-rd edge is the segment BC.
@@ -106,7 +106,7 @@ impl TetrahedronPointLocation {
 }
 
 impl Tetrahedron {
-    /// Creates a tetrahedron from three points.
+    /// Creates a tetrahedron from four points.
     #[inline]
     pub fn new(a: Point<Real>, b: Point<Real>, c: Point<Real>, d: Point<Real>) -> Tetrahedron {
         Tetrahedron { a, b, c, d }
@@ -151,7 +151,7 @@ impl Tetrahedron {
 
     /// Returns the i-th edge of this tetrahedron.
     ///
-    /// The 0-st edge is the segment AB.
+    /// The 0-th edge is the segment AB.
     /// The 1-st edge is the segment AC.
     /// The 2-nd edge is the segment AD.
     /// The 3-rd edge is the segment BC.
@@ -171,7 +171,7 @@ impl Tetrahedron {
 
     /// Returns the indices of the vertices of the i-th edge of this tetrahedron.
     ///
-    /// The 0-st edge is the segment AB.
+    /// The 0-th edge is the segment AB.
     /// The 1-st edge is the segment AC.
     /// The 2-nd edge is the segment AD.
     /// The 3-rd edge is the segment BC.
@@ -217,8 +217,8 @@ impl Tetrahedron {
 
     /// Computes the signed volume of this tetrahedron.
     ///
-    /// If it is positive, `p4` is on the half-space pointed by the normal of the oriented triangle
-    /// `(p1, p2, p3)`.
+    /// If it is positive, `p4` is on the half-space pointed by the normal
+    /// of the oriented triangle `(p1, p2, p3)`.
     #[inline]
     pub fn signed_volume(&self) -> Real {
         let p1p2 = self.b - self.a;


### PR DESCRIPTION
When reading [docs about the `parry3d::shape::Tetrahedron` struct](https://docs.rs/parry3d/latest/parry3d/shape/struct.Tetrahedron.html) I noticed that the `Tetrahedron`'s `new()` method had the following description:

> Creates a tetrahedron from three points.

This PR fixes that oversight (and some others).
