### PR TITLE
Treat TriMesh as solid in project_local_point_and_get_feature with dim2

### DIFF
--- a/crates/parry2d/tests/query/mod.rs
+++ b/crates/parry2d/tests/query/mod.rs
@@ -1,1 +1,2 @@
+mod point_composite_shape;
 mod point_triangle;

--- a/crates/parry2d/tests/query/point_composite_shape.rs
+++ b/crates/parry2d/tests/query/point_composite_shape.rs
@@ -1,0 +1,26 @@
+use na::Point2;
+use parry2d::{query::PointQuery, shape::TriMesh};
+
+#[test]
+fn project_local_point_and_get_feature_gets_the_enclosing_triangle() {
+    let vertices = vec![
+        Point2::new(0.0, 1.0),
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(1.0, 1.0),
+    ];
+
+    let mesh = TriMesh::new(vertices, vec![[0, 1, 2], [3, 0, 2]]);
+    let query_pt = Point2::new(0.6, 0.6); // Inside the top-right triangle (index 1)
+
+    let (proj, feat) = mesh.project_local_point_and_get_feature(&query_pt);
+
+    let correct_tri_idx = 1;
+    let correct_tri = mesh.triangle(correct_tri_idx);
+
+    let is_inside_correct = correct_tri.contains_local_point(&query_pt);
+
+    assert!(is_inside_correct);
+    assert_eq!(proj.is_inside, is_inside_correct);
+    assert_eq!(feat.unwrap_face(), correct_tri_idx);
+}

--- a/crates/parry2d/tests/query/point_composite_shape.rs
+++ b/crates/parry2d/tests/query/point_composite_shape.rs
@@ -24,3 +24,46 @@ fn project_local_point_and_get_feature_gets_the_enclosing_triangle() {
     assert_eq!(proj.is_inside, is_inside_correct);
     assert_eq!(feat.unwrap_face(), correct_tri_idx);
 }
+
+#[test]
+fn project_local_point_and_get_feature_projects_correctly_from_outside() {
+    let vertices = vec![
+        Point2::new(0.0, 1.0),
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(1.0, 1.0),
+    ];
+
+    let mesh = TriMesh::new(vertices, vec![[0, 1, 2], [3, 0, 2]]);
+
+    {
+        let query_pt = Point2::new(-1.0, 0.0); // Inside the top-right triangle (index 1)
+
+        let (proj, feat) = mesh.project_local_point_and_get_feature(&query_pt);
+
+        let correct_tri_idx = 0;
+        let correct_tri = mesh.triangle(correct_tri_idx);
+
+        let is_inside_correct = correct_tri.contains_local_point(&query_pt);
+
+        assert_eq!(is_inside_correct, false);
+        assert_eq!(proj.is_inside, is_inside_correct);
+        assert_eq!(proj.point, Point2::origin());
+        assert_eq!(feat.unwrap_face(), correct_tri_idx);
+    }
+    {
+        let query_pt = Point2::new(0.5, 2.0); // Inside the top-right triangle (index 1)
+
+        let (proj, feat) = mesh.project_local_point_and_get_feature(&query_pt);
+
+        let correct_tri_idx = 1;
+        let correct_tri = mesh.triangle(correct_tri_idx);
+
+        let is_inside_correct = correct_tri.contains_local_point(&query_pt);
+
+        assert_eq!(is_inside_correct, false);
+        assert_eq!(proj.is_inside, is_inside_correct);
+        assert_eq!(proj.point, Point2::new(0.5, 1.0));
+        assert_eq!(feat.unwrap_face(), correct_tri_idx);
+    }
+}

--- a/src/query/point/point_composite_shape.rs
+++ b/src/query/point/point_composite_shape.rs
@@ -61,10 +61,7 @@ impl PointQuery for TriMesh {
             return (proj, feature_id);
         }
 
-        #[cfg(feature = "dim3")]
-        let solid = false;
-        #[cfg(feature = "dim2")]
-        let solid = true;
+        let solid = cfg!(feature = "dim2");
 
         let mut visitor =
             PointCompositeShapeProjWithFeatureBestFirstVisitor::new(self, point, solid);

--- a/src/query/point/point_composite_shape.rs
+++ b/src/query/point/point_composite_shape.rs
@@ -61,8 +61,13 @@ impl PointQuery for TriMesh {
             return (proj, feature_id);
         }
 
+        #[cfg(feature = "dim3")]
+        let solid = false;
+        #[cfg(feature = "dim2")]
+        let solid = true;
+
         let mut visitor =
-            PointCompositeShapeProjWithFeatureBestFirstVisitor::new(self, point, false);
+            PointCompositeShapeProjWithFeatureBestFirstVisitor::new(self, point, solid);
         let (proj, (id, _feature)) = self.qbvh().traverse_best_first(&mut visitor).unwrap().1;
         let feature_id = FeatureId::Face(id);
         (proj, feature_id)


### PR DESCRIPTION
Fixes the issue in 2D where `project_local_point_and_get_feature` of `TriMesh` would NOT return a triangle enclosing the point. This can happen when two triangles share an edge and that edge is closest to the query point.

This can happen because `project_local_point_and_get_feature` does not treat `TriMesh` as solid. However, in 2D TriMeshes can be treated as solid.

This change introduced by this PR is a subtly breaking change, because earlier versions would project to one of the edges.
I think breaking this API "contract" is reasonable, because the earlier behavior was misleading, with the returned `PointProjection` telling that the point was not inside and the feature id being incorrect, and always being set to a Face variant anyway.