### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## unreleased
+## v0.15.0
 
 ### Added
 
@@ -27,7 +27,7 @@ This version modifies many names related to shape-casting:
   `query::time_of_impact) now take a `ShapeCastOptions` instead of the `max_toi` and
   `stop_at_penetration` arguments.
 - Rename `query::nonlinear_time_of_impact` to `query::cast_shapes_nonlinear`.
-- Rename `QueryDispatcher::nonlinear_time_of_impact` to `QueryDispatcher::cast_sahpes_nonlinear`.
+- Rename `QueryDispatcher::nonlinear_time_of_impact` to `QueryDispatcher::cast_shapes_nonlinear`.
 - Rename `NonlinearTOIMode` to `NonlinearShapeCastMode`, and `NonlinearTOIMode::DirectionalTOI` to
   `NonlinearShapeCastMode::Directional`.
 - Rename `TimeOfImpactStatus::Penetrating` to `ShapeCastStatus::PenetratingOrWithinTargetDist`.

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."


### PR DESCRIPTION
### Added

- Add `ShapeCastOptions` that includes two new options for (linear) shape-casting.
  `ShapeCastOptions::target_distance` which will return a hit as soon as the moving
  shapes are closer than this distance; and `compute_impact_geometry_on_penetration`
  which forces the calculation of proper witness points and normals even if the shapes
  are initially intersecting (`time_of_impact == 0.0`).

### Modified

This version modifies many names related to shape-casting:

- Renamed `TOI` to `ShapeCastHit`.
- Renamed `TOIStatus` to `ShapeCastStatus`.
- Rename `RayIntersection::toi` to `RayIntersection::time_of_impact`.
- More generally, all occurrences of the word `toi` have been replaced by `time_of_impact`
  for better clarity.
- Rename `query::time_of_impact` to `query::cast_shapes`. More generally, all the
  functions prefixed with `time_of_impact_` (e.g. `time_of_impact_ball_ball`) are
  now prefixed with `cast_shapes_` (e.g. `cast_shapes_ball_ball`).
- Rename `QueryDispatcher::time_of_impact` to `QueryDispatcher::cast_shapes`.
- The (linear) shape-casting functions like `query::cast_shapes` (previously named
  `query::time_of_impact) now take a `ShapeCastOptions` instead of the `max_toi` and
  `stop_at_penetration` arguments.
- Rename `query::nonlinear_time_of_impact` to `query::cast_shapes_nonlinear`.
- Rename `QueryDispatcher::nonlinear_time_of_impact` to `QueryDispatcher::cast_shapes_nonlinear`.
- Rename `NonlinearTOIMode` to `NonlinearShapeCastMode`, and `NonlinearTOIMode::DirectionalTOI` to
  `NonlinearShapeCastMode::Directional`.
- Rename `TimeOfImpactStatus::Penetrating` to `ShapeCastStatus::PenetratingOrWithinTargetDist`.
