### PR TITLE
Fix a regression in ball vs. convex shape contact manifold calculation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.15.1
+
+### Fix
+
+- Fix a regression in ball vs. convex shape contact manifold calculation.
+
 ## v0.15.0
 
 ### Added

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."

--- a/src/utils/consts.rs
+++ b/src/utils/consts.rs
@@ -6,7 +6,6 @@ use crate::math::Real;
 // pub(crate) const COS_10_DEGREES: Real = 0.98480775301;
 // pub(crate) const COS_45_DEGREES: Real = 0.70710678118;
 // pub(crate) const SIN_45_DEGREES: Real = COS_45_DEGREES;
-pub(crate) const COS_0_DOT_1_DEGREES: Real = 0.99999847691;
 pub(crate) const COS_1_DEGREES: Real = 0.99984769515;
 // pub(crate) const COS_5_DEGREES: Real = 0.99619469809;
 pub(crate) const COS_FRAC_PI_8: Real = 0.92387953251;


### PR DESCRIPTION
This replaces the heuristic based on angle by a ray-cast activated only when a normal correction happened.