### PR TITLE
deps: Update to bitflags 2.x

### DIFF
--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["dim2", "f64"]
 std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade"]
 dim2 = []
 f64 = []
-serde-serialize = ["serde", "nalgebra/serde-serialize", "arrayvec/serde"]
+serde-serialize = ["serde", "nalgebra/serde-serialize", "arrayvec/serde", "bitflags/serde"]
 rkyv-serialize = ["rkyv/validation", "nalgebra/rkyv-serialize", "simba/rkyv-serialize"]
 bytemuck-serialize = ["bytemuck", "nalgebra/convert-bytemuck"]
 simd-stable = ["simba/wide", "simd-is-enabled"]
@@ -41,7 +41,7 @@ required-features = ["required-features"]
 
 [dependencies]
 either = { version = "1", default-features = false }
-bitflags = "1"
+bitflags = "2.3"
 downcast-rs = { version = "1", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 smallvec = "1"

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["dim2", "f32"]
 std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade"]
 dim2 = []
 f32 = []
-serde-serialize = ["serde", "nalgebra/serde-serialize", "arrayvec/serde"]
+serde-serialize = ["serde", "nalgebra/serde-serialize", "arrayvec/serde", "bitflags/serde"]
 rkyv-serialize = ["rkyv/validation", "nalgebra/rkyv-serialize", "simba/rkyv-serialize"]
 bytemuck-serialize = ["bytemuck", "nalgebra/convert-bytemuck"]
 simd-stable = ["simba/wide", "simd-is-enabled"]
@@ -41,7 +41,7 @@ required-features = ["required-features"]
 
 [dependencies]
 either = { version = "1", default-features = false }
-bitflags = "1"
+bitflags = "2.3"
 downcast-rs = { version = "1", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 smallvec = "1"

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["dim3", "f64"]
 std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade"]
 dim3 = []
 f64 = []
-serde-serialize = ["serde", "nalgebra/serde-serialize"]
+serde-serialize = ["serde", "nalgebra/serde-serialize", "bitflags/serde"]
 rkyv-serialize = ["rkyv/validation", "nalgebra/rkyv-serialize", "simba/rkyv-serialize"]
 bytemuck-serialize = ["bytemuck", "nalgebra/convert-bytemuck"]
 simd-stable = ["simba/wide", "simd-is-enabled"]
@@ -41,7 +41,7 @@ required-features = ["required-features"]
 
 [dependencies]
 either = { version = "1", default-features = false }
-bitflags = "1"
+bitflags = "2.3"
 downcast-rs = { version = "1", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 smallvec = "1"

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["dim3", "f32"]
 std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade"]
 dim3 = []
 f32 = []
-serde-serialize = ["serde", "nalgebra/serde-serialize"]
+serde-serialize = ["serde", "nalgebra/serde-serialize", "bitflags/serde"]
 rkyv-serialize = ["rkyv/validation", "nalgebra/rkyv-serialize", "simba/rkyv-serialize"]
 bytemuck-serialize = ["bytemuck", "nalgebra/convert-bytemuck"]
 
@@ -42,7 +42,7 @@ required-features = ["required-features"]
 
 [dependencies]
 either = { version = "1", default-features = false }
-bitflags = "1"
+bitflags = "2.3"
 downcast-rs = { version = "1", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 smallvec = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,9 +59,6 @@ extern crate core as std;
 extern crate serde;
 #[macro_use]
 extern crate approx;
-#[macro_use]
-#[cfg(feature = "dim3")]
-extern crate bitflags;
 extern crate num_traits as num;
 
 pub extern crate either;

--- a/src/partitioning/qbvh/qbvh.rs
+++ b/src/partitioning/qbvh/qbvh.rs
@@ -1,6 +1,5 @@
 use crate::bounding_volume::{Aabb, SimdAabb};
 use crate::math::{Real, Vector};
-use bitflags::bitflags;
 
 use na::SimdValue;
 
@@ -80,16 +79,18 @@ impl NodeIndex {
     }
 }
 
-bitflags! {
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    #[cfg_attr(
-        feature = "rkyv",
-        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
-        archive(as = "Self")
-    )]
-    #[derive(Default)]
-    /// The status of a QBVH node.
-    pub struct QbvhNodeFlags: u8 {
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+/// The status of a QBVH node.
+pub struct QbvhNodeFlags(u8);
+
+bitflags::bitflags! {
+    impl QbvhNodeFlags: u8 {
         /// If this bit is set, the node is a leaf.
         const LEAF = 0b0001;
         /// If this bit is set, this node was recently changed.

--- a/src/shape/heightfield3.rs
+++ b/src/shape/heightfield3.rs
@@ -10,16 +10,18 @@ use na::{Point3, Unit};
 #[cfg(not(feature = "std"))]
 use na::ComplexField;
 
-bitflags! {
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    #[cfg_attr(
-        feature = "rkyv",
-        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
-        archive(as = "Self"),
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
 )]
-    #[derive(Default)]
-    /// The status of the cell of an heightfield.
-    pub struct HeightFieldCellStatus: u8 {
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+/// The status of the cell of an heightfield.
+pub struct HeightFieldCellStatus(u8);
+
+bitflags::bitflags! {
+    impl HeightFieldCellStatus: u8 {
         /// If this bit is set, the concerned heightfield cell is subdivided using a Z pattern.
         const ZIGZAG_SUBDIVISION = 0b00000001;
         /// If this bit is set, the leftmost triangle of the concerned heightfield cell is removed.
@@ -27,21 +29,23 @@ bitflags! {
         /// If this bit is set, the rightmost triangle of the concerned heightfield cell is removed.
         const RIGHT_TRIANGLE_REMOVED = 0b00000100;
         /// If this bit is set, both triangles of the concerned heightfield cell are removed.
-        const CELL_REMOVED = Self::LEFT_TRIANGLE_REMOVED.bits | Self::RIGHT_TRIANGLE_REMOVED.bits;
+        const CELL_REMOVED = Self::LEFT_TRIANGLE_REMOVED.bits() | Self::RIGHT_TRIANGLE_REMOVED.bits();
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+/// Flags controlling the behavior of some operations involving heightfields.
+pub struct HeightFieldFlags(u8);
+
 bitflags::bitflags! {
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    #[cfg_attr(
-        feature = "rkyv",
-        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
-        archive(as = "Self"),
-    )]
-    #[repr(C)]
-    #[derive(Default)]
-    /// Flags controlling the behavior of some operations involving heightfields.
-    pub struct HeightFieldFlags: u8 {
+    impl HeightFieldFlags: u8 {
         /// If set, a special treatment will be applied to contact manifold calculation to eliminate
         /// or fix contacts normals that could lead to incorrect bumps in physics simulation (especially
         /// on flat surfaces).

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -187,17 +187,19 @@ impl TriMeshTopology {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+/// The status of the cell of an heightfield.
+pub struct TriMeshFlags(u16);
+
 bitflags::bitflags! {
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    #[cfg_attr(
-        feature = "rkyv",
-        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
-        archive(as = "Self"),
-    )]
-    #[repr(C)]
-    #[derive(Default)]
-    /// The status of the cell of an heightfield.
-    pub struct TriMeshFlags: u16 {
+    impl TriMeshFlags: u16 {
         /// If set, the half-edge topology of the trimesh will be computed if possible.
         const HALF_EDGE_TOPOLOGY = 1;
         /// If set, the half-edge topology and connected components of the trimesh will be computed if possible.


### PR DESCRIPTION
This also removes an old style macro_use / extern crate for bitflags and makes all uses use the same syntax.