### PR TITLE
feat: implement concave polylines intersection

### DIFF
--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["required-features", "std"]
 required-features = ["dim2", "f64"]
-std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade"]
+std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade", "thiserror"]
 dim2 = []
 f64 = []
 serde-serialize = ["serde", "nalgebra/serde-serialize", "arrayvec/serde", "bitflags/serde"]
@@ -60,8 +60,8 @@ spade = { version = "2", optional = true } # Make this optional?
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
-ordered-float = "4"
-thiserror = "1"
+ordered-float = { version = "4", default-features = false }
+thiserror = { version = "1", optional = true }
 
 [dev-dependencies]
 simba = { version = "0.8", default-features = false, features = ["partial_fixed_point_support"] }

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -60,6 +60,8 @@ spade = { version = "2", optional = true } # Make this optional?
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
+ordered-float = "4"
+thiserror = "1"
 
 [dev-dependencies]
 simba = { version = "0.8", default-features = false, features = ["partial_fixed_point_support"] }

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["required-features", "std"]
 required-features = ["dim2", "f32"]
-std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade"]
+std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade", "thiserror"]
 dim2 = []
 f32 = []
 serde-serialize = ["serde", "nalgebra/serde-serialize", "arrayvec/serde", "bitflags/serde"]
@@ -59,9 +59,9 @@ cust_core = { version = "0.1", optional = true }
 spade = { version = "2", optional = true }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
+ordered-float = { version = "4", default-features = false }
 log = "0.4"
-ordered-float = "4"
-thiserror = "1"
+thiserror = { version = "1", optional = true }
 
 [dev-dependencies]
 simba = { version = "0.8", default-features = false, features = ["partial_fixed_point_support"] }

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -60,9 +60,12 @@ spade = { version = "2", optional = true }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
+ordered-float = "4"
+thiserror = "1"
 
 [dev-dependencies]
 simba = { version = "0.8", default-features = false, features = ["partial_fixed_point_support"] }
 oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }
+macroquad = "0.4"

--- a/crates/parry2d/examples/point_in_poly2d.rs
+++ b/crates/parry2d/examples/point_in_poly2d.rs
@@ -1,0 +1,110 @@
+use macroquad::prelude::*;
+use nalgebra::{Point2, UnitComplex, Vector2};
+use parry2d::shape::Ball;
+use parry2d::transformation::polygons_intersection_points;
+use parry2d::utils::point_in_poly2d;
+
+const RENDER_SCALE: f32 = 30.0;
+
+#[macroquad::main("parry2d::utils::point_in_poly2d")]
+async fn main() {
+    let mut spikes = spikes_polygon();
+    let test_points = grid_points();
+
+    let animation_rotation = UnitComplex::new(0.02);
+    let spikes_render_pos = Point2::new(screen_width() / 2.0, screen_height() / 2.0);
+
+    for i in 0.. {
+        clear_background(BLACK);
+
+        /*
+         * Compute polygon intersections.
+         */
+        spikes
+            .iter_mut()
+            .for_each(|pt| *pt = animation_rotation * *pt);
+        draw_polygon(&spikes, RENDER_SCALE, spikes_render_pos, BLUE);
+
+        for point in &test_points {
+            if point_in_poly2d(point, &spikes) {
+                draw_point(*point, RENDER_SCALE, spikes_render_pos, RED);
+            } else {
+                draw_point(*point, RENDER_SCALE, spikes_render_pos, GREEN);
+            }
+        }
+
+        next_frame().await
+    }
+}
+
+fn spikes_polygon() -> Vec<Point2<f32>> {
+    let teeths = 3;
+    let width = 15.0;
+    let height = 7.5;
+    let tooth_width = width / (teeths as f32);
+    let center = Vector2::new(width / 2.0, height / 2.0);
+
+    let mut polygon = vec![
+        Point2::new(width, 0.0) - center,
+        Point2::new(width, height) - center,
+        Point2::new(0.0, height) - center,
+    ];
+
+    for i in 0..teeths {
+        let x = i as f32 * tooth_width;
+        polygon.push(Point2::new(x, 0.0) - center);
+        polygon.push(Point2::new(x + tooth_width / 2.0, height * 1.5) - center);
+    }
+
+    polygon
+}
+
+fn grid_points() -> Vec<Point2<f32>> {
+    let count = 40;
+    let spacing = 0.6;
+    let mut pts = vec![];
+    for i in 0..count {
+        for j in 0..count {
+            pts.push(Point2::new(
+                (i as f32 - count as f32 / 2.0) * spacing,
+                (j as f32 - count as f32 / 2.0) * spacing,
+            ));
+        }
+    }
+    pts
+}
+
+fn draw_polygon(polygon: &[Point2<f32>], scale: f32, shift: Point2<f32>, color: Color) {
+    for i in 0..polygon.len() {
+        let a = polygon[i];
+        let b = polygon[(i + 1) % polygon.len()];
+        draw_line(
+            a.x * scale + shift.x,
+            a.y * scale + shift.y,
+            b.x * scale + shift.x,
+            b.y * scale + shift.y,
+            2.0,
+            color,
+        );
+    }
+}
+
+fn draw_point(point: Point2<f32>, scale: f32, shift: Point2<f32>, color: Color) {
+    let edge_len = 0.15;
+    draw_line(
+        (point.x - edge_len) * scale + shift.x,
+        point.y * scale + shift.y,
+        (point.x + edge_len) * scale + shift.x,
+        point.y * scale + shift.y,
+        2.0,
+        color,
+    );
+    draw_line(
+        point.x * scale + shift.x,
+        (point.y - edge_len) * scale + shift.y,
+        point.x * scale + shift.x,
+        (point.y + edge_len) * scale + shift.y,
+        2.0,
+        color,
+    );
+}

--- a/crates/parry2d/examples/point_in_poly2d.rs
+++ b/crates/parry2d/examples/point_in_poly2d.rs
@@ -1,7 +1,5 @@
 use macroquad::prelude::*;
 use nalgebra::{Point2, UnitComplex, Vector2};
-use parry2d::shape::Ball;
-use parry2d::transformation::polygons_intersection_points;
 use parry2d::utils::point_in_poly2d;
 
 const RENDER_SCALE: f32 = 30.0;
@@ -14,7 +12,7 @@ async fn main() {
     let animation_rotation = UnitComplex::new(0.02);
     let spikes_render_pos = Point2::new(screen_width() / 2.0, screen_height() / 2.0);
 
-    for i in 0.. {
+    loop {
         clear_background(BLACK);
 
         /*

--- a/crates/parry2d/examples/polygons_intersection2d.rs
+++ b/crates/parry2d/examples/polygons_intersection2d.rs
@@ -11,7 +11,6 @@ async fn main() {
     let mut animated_spikes = spikes.clone();
 
     let star = star_polygon();
-    let mut animated_star = star.clone();
 
     let animation_scale = 2.0;
     let animation_rotation = UnitComplex::new(0.008);
@@ -23,7 +22,10 @@ async fn main() {
         clear_background(BLACK);
 
         /*
-         * Compute polygon intersections.
+         *
+         * Compute the rotated/scaled polygons, and compute their intersection with the original
+         * polygon.
+         *
          */
         animated_spikes
             .iter_mut()
@@ -38,10 +40,13 @@ async fn main() {
                     * ((i as f32 / 100.0).sin().abs() * animation_scale)
             })
             .collect();
+
         let star_intersections = polygons_intersection_points(&star, &animated_star);
 
         /*
+         *
          * Render the polygons and their intersections.
+         *
          */
         draw_polygon(&spikes, RENDER_SCALE, spikes_render_pos, BLUE);
         draw_polygon(&animated_spikes, RENDER_SCALE, spikes_render_pos, GREEN);
@@ -60,9 +65,8 @@ async fn main() {
             for intersection in intersections {
                 draw_polygon(&intersection, RENDER_SCALE, spikes_render_pos, RED);
             }
-        } else {
-            eprintln!("Entered infinite loop.");
         }
+
         if let Ok(intersections) = star_intersections {
             draw_text(
                 &format!("# star intersections: {}", intersections.len()),
@@ -74,8 +78,6 @@ async fn main() {
             for intersection in intersections {
                 draw_polygon(&intersection, RENDER_SCALE, star_render_pos, RED);
             }
-        } else {
-            eprintln!("Entered infinite loop.");
         }
 
         next_frame().await

--- a/crates/parry2d/examples/polygons_intersection2d.rs
+++ b/crates/parry2d/examples/polygons_intersection2d.rs
@@ -1,10 +1,95 @@
 use macroquad::prelude::*;
 use nalgebra::{Point2, UnitComplex, Vector2};
+use parry2d::shape::Ball;
 use parry2d::transformation::polygons_intersection_points;
+
+const RENDER_SCALE: f32 = 30.0;
 
 #[macroquad::main("parry2d::utils::polygons_intersection_points")]
 async fn main() {
-    let teeths = 10;
+    let spikes = spikes_polygon();
+    let mut animated_spikes = spikes.clone();
+
+    let star = star_polygon();
+    let mut animated_star = star.clone();
+
+    let animation_scale = 2.0;
+    let animation_rotation = UnitComplex::new(0.008);
+
+    let spikes_render_pos = Point2::new(300.0, 300.0);
+    let star_render_pos = Point2::new(600.0, 300.0);
+
+    for i in 0.. {
+        clear_background(BLACK);
+
+        /*
+         * Compute polygon intersections.
+         */
+        animated_spikes
+            .iter_mut()
+            .for_each(|pt| *pt = animation_rotation * *pt);
+        let spikes_intersections = polygons_intersection_points(&spikes, &animated_spikes);
+
+        let animated_star: Vec<_> = star
+            .iter()
+            .map(|pt| {
+                animation_rotation.powf(i as f32)
+                    * *pt
+                    * ((i as f32 / 100.0).sin().abs() * animation_scale)
+            })
+            .collect();
+        let star_intersections = polygons_intersection_points(&star, &animated_star);
+
+        /*
+         * Render the polygons and their intersections.
+         */
+        draw_polygon(&spikes, RENDER_SCALE, spikes_render_pos, BLUE);
+        draw_polygon(&animated_spikes, RENDER_SCALE, spikes_render_pos, GREEN);
+
+        draw_polygon(&star, RENDER_SCALE, star_render_pos, BLUE);
+        draw_polygon(&animated_star, RENDER_SCALE, star_render_pos, GREEN);
+
+        if let Ok(intersections) = spikes_intersections {
+            draw_text(
+                &format!("# spikes intersections: {}", intersections.len()),
+                0.0,
+                15.0,
+                20.0,
+                WHITE,
+            );
+            for intersection in intersections {
+                draw_polygon(&intersection, RENDER_SCALE, spikes_render_pos, RED);
+            }
+        } else {
+            eprintln!("Entered infinite loop.");
+        }
+        if let Ok(intersections) = star_intersections {
+            draw_text(
+                &format!("# star intersections: {}", intersections.len()),
+                0.0,
+                30.0,
+                20.0,
+                WHITE,
+            );
+            for intersection in intersections {
+                draw_polygon(&intersection, RENDER_SCALE, star_render_pos, RED);
+            }
+        } else {
+            eprintln!("Entered infinite loop.");
+        }
+
+        next_frame().await
+    }
+}
+
+fn star_polygon() -> Vec<Point2<f32>> {
+    let mut star = Ball::new(1.5).to_polyline(10);
+    star.iter_mut().step_by(2).for_each(|pt| *pt = *pt * 0.6);
+    star
+}
+
+fn spikes_polygon() -> Vec<Point2<f32>> {
+    let teeths = 5;
     let width = 10.0;
     let height = 5.0;
     let tooth_width = width / (teeths as f32);
@@ -16,39 +101,13 @@ async fn main() {
         Point2::new(0.0, height) - center,
     ];
 
-    let teeths = 5;
     for i in 0..teeths {
         let x = i as f32 * tooth_width;
         polygon.push(Point2::new(x, 0.0) - center);
         polygon.push(Point2::new(x + tooth_width / 2.0, height * 0.8) - center);
     }
 
-    const RENDER_SCALE: f32 = 30.0;
-    let mut rotated_polygon = polygon.clone();
-    let rot = UnitComplex::new(0.008);
-    let shift = Point2::new(300.0, 300.0);
-
-    for i in 0.. {
-        println!("====================");
-        clear_background(BLACK);
-
-        rotated_polygon.iter_mut().for_each(|pt| *pt = rot * *pt);
-
-        draw_polygon(&polygon, RENDER_SCALE, shift, BLUE);
-        draw_polygon(&rotated_polygon, RENDER_SCALE, shift, GREEN);
-
-        if let Ok(intersections) = polygons_intersection_points(&polygon, &rotated_polygon) {
-            println!("Found num intersections: {}", intersections.len());
-            for intersection in intersections {
-                println!("Num vertices: {}", intersection.len());
-                draw_polygon(&intersection, RENDER_SCALE, shift, RED);
-            }
-        } else {
-            eprintln!("Entered inifinite loop.");
-        }
-
-        next_frame().await
-    }
+    polygon
 }
 
 fn draw_polygon(polygon: &[Point2<f32>], scale: f32, shift: Point2<f32>, color: Color) {

--- a/crates/parry2d/examples/polygons_intersection2d.rs
+++ b/crates/parry2d/examples/polygons_intersection2d.rs
@@ -1,0 +1,67 @@
+use macroquad::prelude::*;
+use nalgebra::{Point2, UnitComplex, Vector2};
+use parry2d::transformation::polygons_intersection_points;
+
+#[macroquad::main("parry2d::utils::polygons_intersection_points")]
+async fn main() {
+    let teeths = 10;
+    let width = 10.0;
+    let height = 5.0;
+    let tooth_width = width / (teeths as f32);
+    let center = Vector2::new(width / 2.0, height / 2.0);
+
+    let mut polygon = vec![
+        Point2::new(width, 0.0) - center,
+        Point2::new(width, height) - center,
+        Point2::new(0.0, height) - center,
+    ];
+
+    let teeths = 5;
+    for i in 0..teeths {
+        let x = i as f32 * tooth_width;
+        polygon.push(Point2::new(x, 0.0) - center);
+        polygon.push(Point2::new(x + tooth_width / 2.0, height * 0.8) - center);
+    }
+
+    const RENDER_SCALE: f32 = 30.0;
+    let mut rotated_polygon = polygon.clone();
+    let rot = UnitComplex::new(0.008);
+    let shift = Point2::new(300.0, 300.0);
+
+    for i in 0.. {
+        println!("====================");
+        clear_background(BLACK);
+
+        rotated_polygon.iter_mut().for_each(|pt| *pt = rot * *pt);
+
+        draw_polygon(&polygon, RENDER_SCALE, shift, BLUE);
+        draw_polygon(&rotated_polygon, RENDER_SCALE, shift, GREEN);
+
+        if let Ok(intersections) = polygons_intersection_points(&polygon, &rotated_polygon) {
+            println!("Found num intersections: {}", intersections.len());
+            for intersection in intersections {
+                println!("Num vertices: {}", intersection.len());
+                draw_polygon(&intersection, RENDER_SCALE, shift, RED);
+            }
+        } else {
+            eprintln!("Entered inifinite loop.");
+        }
+
+        next_frame().await
+    }
+}
+
+fn draw_polygon(polygon: &[Point2<f32>], scale: f32, shift: Point2<f32>, color: Color) {
+    for i in 0..polygon.len() {
+        let a = polygon[i];
+        let b = polygon[(i + 1) % polygon.len()];
+        draw_line(
+            a.x * scale + shift.x,
+            a.y * scale + shift.y,
+            b.x * scale + shift.x,
+            b.y * scale + shift.y,
+            2.0,
+            color,
+        );
+    }
+}

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -60,6 +60,8 @@ spade = { version = "2", optional = true } # Make this optional?
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
+ordered-float = "4"
+thiserror = "1"
 
 [dev-dependencies]
 oorandom = "11"

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["required-features", "std"]
 required-features = ["dim3", "f64"]
-std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade"]
+std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade", "thiserror"]
 dim3 = []
 f64 = []
 serde-serialize = ["serde", "nalgebra/serde-serialize", "bitflags/serde"]
@@ -53,15 +53,15 @@ approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 rkyv = { version = "0.7.41", optional = true }
 num-derive = "0.4"
-indexmap = { version = "2", features = [ "serde" ], optional = true }
+indexmap = { version = "2", features = ["serde"], optional = true }
 rustc-hash = { version = "1", optional = true }
 cust_core = { version = "0.1", optional = true }
 spade = { version = "2", optional = true } # Make this optional?
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
-ordered-float = "4"
-thiserror = "1"
+ordered-float = { version = "4", default-features = false }
+thiserror = { version = "1", optional = true }
 
 [dev-dependencies]
 oorandom = "11"

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["required-features", "std"]
 required-features = ["dim3", "f32"]
-std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade"]
+std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade", "thiserror"]
 dim3 = []
 f32 = []
 serde-serialize = ["serde", "nalgebra/serde-serialize", "bitflags/serde"]
@@ -54,15 +54,15 @@ approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 rkyv = { version = "0.7.41", optional = true }
 num-derive = "0.4"
-indexmap = { version = "2", features = [ "serde" ], optional = true }
+indexmap = { version = "2", features = ["serde"], optional = true }
 rustc-hash = { version = "1", optional = true }
 cust_core = { version = "0.1", optional = true }
 spade = { version = "2", optional = true } # Make this optional?
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
-ordered-float = "4"
-thiserror = "1"
+ordered-float = { version = "4", default-features = false }
+thiserror = { version = "1", optional = true }
 
 [dev-dependencies]
 oorandom = "11"

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -61,6 +61,8 @@ spade = { version = "2", optional = true } # Make this optional?
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
+ordered-float = "4"
+thiserror = "1"
 
 [dev-dependencies]
 oorandom = "11"

--- a/crates/parry3d/benches/query/ray.rs
+++ b/crates/parry3d/benches/query/ray.rs
@@ -13,7 +13,7 @@ use test::Bencher;
 #[macro_use]
 mod macros;
 
-// FIXME: will the randomness of `solid` and `max_time_of_impact` affect too much the benchmark?
+// TODO: will the randomness of `solid` and `max_time_of_impact` affect too much the benchmark?
 bench_method!(
     bench_ray_against_ball,
     cast_ray,

--- a/src/bounding_volume/aabb_utils.rs
+++ b/src/bounding_volume/aabb_utils.rs
@@ -16,7 +16,7 @@ where
     let mut basis = na::zero::<Vector<Real>>();
 
     for d in 0..DIM {
-        // FIXME: this could be further improved iterating on `m`'s columns, and passing
+        // TODO: this could be further improved iterating on `m`'s columns, and passing
         // Id as the transformation matrix.
         basis[d] = 1.0;
         max[d] = i.support_point(m, &basis)[d];
@@ -40,7 +40,7 @@ where
     let mut basis = na::zero::<Vector<Real>>();
 
     for d in 0..DIM {
-        // FIXME: this could be further improved iterating on `m`'s columns, and passing
+        // TODO: this could be further improved iterating on `m`'s columns, and passing
         // Id as the transformation matrix.
         basis[d] = 1.0;
         max[d] = i.local_support_point(&basis)[d];

--- a/src/bounding_volume/bounding_sphere.rs
+++ b/src/bounding_volume/bounding_sphere.rs
@@ -56,7 +56,7 @@ impl BoundingVolume for BoundingSphere {
 
     #[inline]
     fn intersects(&self, other: &BoundingSphere) -> bool {
-        // FIXME: refactor that with the code from narrow_phase::ball_ball::collide(...) ?
+        // TODO: refactor that with the code from narrow_phase::ball_ball::collide(...) ?
         let delta_pos = other.center - self.center;
         let distance_squared = delta_pos.norm_squared();
         let sum_radius = self.radius + other.radius;

--- a/src/bounding_volume/bounding_sphere_utils.rs
+++ b/src/bounding_volume/bounding_sphere_utils.rs
@@ -3,7 +3,7 @@ use crate::utils;
 use na::{self, ComplexField};
 
 /// Computes the bounding sphere of a set of point, given its center.
-// FIXME: return a bounding sphere?
+// TODO: return a bounding sphere?
 #[inline]
 pub fn point_cloud_bounding_sphere_with_center(
     pts: &[Point<Real>],
@@ -23,7 +23,7 @@ pub fn point_cloud_bounding_sphere_with_center(
 }
 
 /// Computes a bounding sphere of the specified set of point.
-// FIXME: return a bounding sphere?
+// TODO: return a bounding sphere?
 #[inline]
 pub fn point_cloud_bounding_sphere(pts: &[Point<Real>]) -> (Point<Real>, Real) {
     point_cloud_bounding_sphere_with_center(pts, utils::center(pts))

--- a/src/bounding_volume/bounding_volume.rs
+++ b/src/bounding_volume/bounding_volume.rs
@@ -6,7 +6,7 @@ use crate::math::{Point, Real};
 /// intersection, inclusion test. Two bounding volume must also be mergeable into a bigger bounding
 /// volume.
 pub trait BoundingVolume {
-    // FIXME: keep that ? What about non-spacial bounding volumes (e.g. bounding cones, curvature
+    // TODO: keep that ? What about non-spacial bounding volumes (e.g. bounding cones, curvature
     // bounds, etc.) ?
     /// Returns a point inside of this bounding volume. This is ideally its center.
     fn center(&self) -> Point<Real>;

--- a/src/partitioning/qbvh/traversal.rs
+++ b/src/partitioning/qbvh/traversal.rs
@@ -271,7 +271,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
 
     /// Retrieve all the data of the nodes with Aabbs intersecting
     /// the given Aabb:
-    // FIXME: implement a visitor pattern to merge intersect_aabb
+    // TODO: implement a visitor pattern to merge intersect_aabb
     // and intersect_ray into a single method.
     pub fn intersect_aabb(&self, aabb: &Aabb, out: &mut Vec<LeafData>) {
         if self.nodes.is_empty() {

--- a/src/query/closest_points/closest_points_composite_shape_shape.rs
+++ b/src/query/closest_points/closest_points_composite_shape_shape.rs
@@ -8,7 +8,7 @@ use na;
 use simba::simd::{SimdBool as _, SimdPartialOrd, SimdValue};
 
 /// Closest points between a composite shape and any other shape.
-pub fn closest_points_composite_shape_shape<D: ?Sized, G1: ?Sized>(
+pub fn closest_points_composite_shape_shape<D, G1>(
     dispatcher: &D,
     pos12: &Isometry<Real>,
     g1: &G1,
@@ -16,8 +16,8 @@ pub fn closest_points_composite_shape_shape<D: ?Sized, G1: ?Sized>(
     margin: Real,
 ) -> ClosestPoints
 where
-    D: QueryDispatcher,
-    G1: TypedSimdCompositeShape,
+    D: ?Sized + QueryDispatcher,
+    G1: ?Sized + TypedSimdCompositeShape,
 {
     let mut visitor =
         CompositeShapeAgainstShapeClosestPointsVisitor::new(dispatcher, pos12, g1, g2, margin);
@@ -30,7 +30,7 @@ where
 }
 
 /// Closest points between a shape and a composite shape.
-pub fn closest_points_shape_composite_shape<D: ?Sized, G2: ?Sized>(
+pub fn closest_points_shape_composite_shape<D, G2>(
     dispatcher: &D,
     pos12: &Isometry<Real>,
     g1: &dyn Shape,
@@ -38,8 +38,8 @@ pub fn closest_points_shape_composite_shape<D: ?Sized, G2: ?Sized>(
     margin: Real,
 ) -> ClosestPoints
 where
-    D: QueryDispatcher,
-    G2: TypedSimdCompositeShape,
+    D: ?Sized + QueryDispatcher,
+    G2: ?Sized + TypedSimdCompositeShape,
 {
     closest_points_composite_shape_shape(dispatcher, &pos12.inverse(), g2, g1, margin).flipped()
 }

--- a/src/query/closest_points/closest_points_line_line.rs
+++ b/src/query/closest_points/closest_points_line_line.rs
@@ -71,7 +71,7 @@ pub fn closest_points_line_line_parameters_eps<const D: usize>(
     }
 }
 
-// FIXME: can we re-used this for the segment/segment case?
+// TODO: can we re-used this for the segment/segment case?
 /// Closest points between two segments.
 #[inline]
 pub fn closest_points_line_line(

--- a/src/query/closest_points/closest_points_segment_segment.rs
+++ b/src/query/closest_points/closest_points_segment_segment.rs
@@ -23,7 +23,7 @@ pub fn closest_points_segment_segment(
     }
 }
 
-// FIXME: use this specialized procedure for distance/interference/contact determination as well.
+// TODO: use this specialized procedure for distance/interference/contact determination as well.
 /// Closest points between two segments.
 #[inline]
 pub fn closest_points_segment_segment_with_locations(

--- a/src/query/closest_points/closest_points_support_map_support_map.rs
+++ b/src/query/closest_points/closest_points_support_map_support_map.rs
@@ -6,15 +6,15 @@ use crate::shape::SupportMap;
 use na::Unit;
 
 /// Closest points between support-mapped shapes (`Cuboid`, `ConvexHull`, etc.)
-pub fn closest_points_support_map_support_map<G1: ?Sized, G2: ?Sized>(
+pub fn closest_points_support_map_support_map<G1, G2>(
     pos12: &Isometry<Real>,
     g1: &G1,
     g2: &G2,
     prediction: Real,
 ) -> ClosestPoints
 where
-    G1: SupportMap,
-    G2: SupportMap,
+    G1: ?Sized + SupportMap,
+    G2: ?Sized + SupportMap,
 {
     match closest_points_support_map_support_map_with_params(
         pos12,
@@ -36,7 +36,7 @@ where
 /// Closest points between support-mapped shapes (`Cuboid`, `ConvexHull`, etc.)
 ///
 /// This allows a more fine grained control other the underlying GJK algorigtm.
-pub fn closest_points_support_map_support_map_with_params<G1: ?Sized, G2: ?Sized>(
+pub fn closest_points_support_map_support_map_with_params<G1, G2>(
     pos12: &Isometry<Real>,
     g1: &G1,
     g2: &G2,
@@ -45,11 +45,11 @@ pub fn closest_points_support_map_support_map_with_params<G1: ?Sized, G2: ?Sized
     init_dir: Option<Vector<Real>>,
 ) -> GJKResult
 where
-    G1: SupportMap,
-    G2: SupportMap,
+    G1: ?Sized + SupportMap,
+    G2: ?Sized + SupportMap,
 {
     let dir = match init_dir {
-        // FIXME: or pos12.translation.vector (without the minus sign) ?
+        // TODO: or pos12.translation.vector (without the minus sign) ?
         None => -pos12.translation.vector,
         Some(dir) => dir,
     };

--- a/src/query/contact/contact_composite_shape_shape.rs
+++ b/src/query/contact/contact_composite_shape_shape.rs
@@ -6,7 +6,7 @@ use crate::shape::{Shape, SimdCompositeShape};
 use crate::utils::IsometryOpt;
 
 /// Best contact between a composite shape (`Mesh`, `Compound`) and any other shape.
-pub fn contact_composite_shape_shape<D: ?Sized, G1: ?Sized>(
+pub fn contact_composite_shape_shape<D, G1>(
     dispatcher: &D,
     pos12: &Isometry<Real>,
     g1: &G1,
@@ -14,8 +14,8 @@ pub fn contact_composite_shape_shape<D: ?Sized, G1: ?Sized>(
     prediction: Real,
 ) -> Option<Contact>
 where
-    D: QueryDispatcher,
-    G1: SimdCompositeShape,
+    D: ?Sized + QueryDispatcher,
+    G1: ?Sized + SimdCompositeShape,
 {
     // Find new collisions
     let ls_aabb2 = g2.compute_aabb(pos12).loosened(prediction);

--- a/src/query/contact/contact_support_map_support_map.rs
+++ b/src/query/contact/contact_support_map_support_map.rs
@@ -7,15 +7,15 @@ use crate::shape::SupportMap;
 use na::Unit;
 
 /// Contact between support-mapped shapes (`Cuboid`, `ConvexHull`, etc.)
-pub fn contact_support_map_support_map<G1: ?Sized, G2: ?Sized>(
+pub fn contact_support_map_support_map<G1, G2>(
     pos12: &Isometry<Real>,
     g1: &G1,
     g2: &G2,
     prediction: Real,
 ) -> Option<Contact>
 where
-    G1: SupportMap,
-    G2: SupportMap,
+    G1: ?Sized + SupportMap,
+    G2: ?Sized + SupportMap,
 {
     let simplex = &mut VoronoiSimplex::new();
     match contact_support_map_support_map_with_params(pos12, g1, g2, prediction, simplex, None) {

--- a/src/query/contact_manifolds/contact_manifold.rs
+++ b/src/query/contact_manifolds/contact_manifold.rs
@@ -182,7 +182,7 @@ impl<ManifoldData, ContactData: Default + Copy> ContactManifold<ManifoldData, Co
         // const DOT_THRESHOLD: Real = 0.crate::COS_10_DEGREES;
         // const DOT_THRESHOLD: Real = crate::utils::COS_5_DEGREES;
         const DOT_THRESHOLD: Real = crate::utils::COS_1_DEGREES;
-        const DIST_SQ_THRESHOLD: Real = 1.0e-6; // FIXME: this should not be hard-coded.
+        const DIST_SQ_THRESHOLD: Real = 1.0e-6; // TODO: this should not be hard-coded.
         self.try_update_contacts_eps(pos12, DOT_THRESHOLD, DIST_SQ_THRESHOLD)
     }
 

--- a/src/query/contact_manifolds/contact_manifolds_capsule_capsule.rs
+++ b/src/query/contact_manifolds/contact_manifolds_capsule_capsule.rs
@@ -43,7 +43,7 @@ pub fn contact_manifold_capsule_capsule<'a, ManifoldData, ContactData>(
     );
 
     // We do this clone to perform contact tracking and transfer impulses.
-    // FIXME: find a more efficient way of doing this.
+    // TODO: find a more efficient way of doing this.
     let old_manifold_points = manifold.points.clone();
     manifold.clear();
 

--- a/src/query/contact_manifolds/contact_manifolds_cuboid_capsule.rs
+++ b/src/query/contact_manifolds/contact_manifolds_cuboid_capsule.rs
@@ -123,7 +123,7 @@ pub fn contact_manifold_cuboid_capsule<'a, ManifoldData, ContactData>(
     }
 
     // We do this clone to perform contact tracking and transfer impulses.
-    // FIXME: find a more efficient way of doing this.
+    // TODO: find a more efficient way of doing this.
     let old_manifold_points = manifold.points.clone();
     manifold.clear();
 

--- a/src/query/contact_manifolds/contact_manifolds_cuboid_cuboid.rs
+++ b/src/query/contact_manifolds/contact_manifolds_cuboid_cuboid.rs
@@ -77,7 +77,7 @@ pub fn contact_manifold_cuboid_cuboid<'a, ManifoldData, ContactData: Default + C
     }
 
     // We do this clone to perform contact tracking and transfer impulses.
-    // FIXME: find a more efficient way of doing this.
+    // TODO: find a more efficient way of doing this.
     let old_manifold_points = manifold.points.clone();
     manifold.clear();
 

--- a/src/query/contact_manifolds/contact_manifolds_cuboid_triangle.rs
+++ b/src/query/contact_manifolds/contact_manifolds_cuboid_triangle.rs
@@ -141,7 +141,7 @@ pub fn contact_manifold_cuboid_triangle<'a, ManifoldData, ContactData>(
     }
 
     // We do this clone to perform contact tracking and transfer impulses.
-    // FIXME: find a more efficient way of doing this.
+    // TODO: find a more efficient way of doing this.
     let old_manifold_points = manifold.points.clone();
     manifold.clear();
 

--- a/src/query/contact_manifolds/contact_manifolds_halfspace_pfm.rs
+++ b/src/query/contact_manifolds/contact_manifolds_halfspace_pfm.rs
@@ -57,7 +57,7 @@ pub fn contact_manifold_halfspace_pfm<'a, ManifoldData, ContactData, S2>(
     pfm2.local_support_feature(&-normal1_2, &mut feature2);
 
     // We do this clone to perform contact tracking and transfer impulses.
-    // FIXME: find a more efficient way of doing this.
+    // TODO: find a more efficient way of doing this.
     let old_manifold_points = std::mem::take(&mut manifold.points);
 
     for i in 0..feature2.num_vertices {

--- a/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
@@ -115,7 +115,7 @@ pub fn contact_manifolds_trimesh_shape<ManifoldData, ContactData>(
         new_local_aabb2.mins -= extra_margin;
         new_local_aabb2.maxs += extra_margin;
 
-        let local_aabb2 = new_local_aabb2; // .loosened(prediction * 2.0); // FIXME: what would be the best value?
+        let local_aabb2 = new_local_aabb2; // .loosened(prediction * 2.0); // TODO: what would be the best value?
         std::mem::swap(
             &mut workspace.old_interferences,
             &mut workspace.interferences,

--- a/src/query/distance/distance_support_map_support_map.rs
+++ b/src/query/distance/distance_support_map_support_map.rs
@@ -32,7 +32,7 @@ where
     G1: SupportMap,
     G2: SupportMap,
 {
-    // FIXME: or m2.translation - m1.translation ?
+    // TODO: or m2.translation - m1.translation ?
     let dir = init_dir.unwrap_or_else(|| -pos12.translation.vector);
 
     if let Some(dir) = Unit::try_new(dir, crate::math::DEFAULT_EPSILON) {
@@ -50,6 +50,6 @@ where
         GJKResult::Intersection => 0.0,
         GJKResult::ClosestPoints(p1, p2, _) => na::distance(&p1, &p2),
         GJKResult::Proximity(_) => unreachable!(),
-        GJKResult::NoIntersection(_) => 0.0, // FIXME: GJK did not converge.
+        GJKResult::NoIntersection(_) => 0.0, // TODO: GJK did not converge.
     }
 }

--- a/src/query/epa/epa2.rs
+++ b/src/query/epa/epa2.rs
@@ -321,7 +321,7 @@ impl EPA {
                 if f.1 {
                     let dist = f.0.normal.dot(&f.0.proj.coords);
                     if dist < curr_dist {
-                        // FIXME: if we reach this point, there were issues due to
+                        // TODO: if we reach this point, there were issues due to
                         // numerical errors.
                         let cpts = f.0.closest_points(&self.vertices);
                         return Some((cpts.0, cpts.1, f.0.normal));

--- a/src/query/epa/epa3.rs
+++ b/src/query/epa/epa3.rs
@@ -355,7 +355,7 @@ impl EPA {
             let first_new_face_id = self.faces.len();
 
             if self.silhouette.is_empty() {
-                // FIXME: Something went very wrong because we failed to extract a silhouette…
+                // TODO: Something went very wrong because we failed to extract a silhouette…
                 return None;
             }
 
@@ -364,7 +364,7 @@ impl EPA {
                     let new_face_id = self.faces.len();
                     let new_face;
 
-                    // FIXME: NLL
+                    // TODO: NLL
                     {
                         let face_adj = &mut self.faces[edge.face_id];
                         let pt_id1 = face_adj.pts[(edge.opp_pt_id + 2) % 3];
@@ -383,7 +383,7 @@ impl EPA {
                         let pt = self.vertices[self.faces[new_face_id].pts[0]].point.coords;
                         let dist = self.faces[new_face_id].normal.dot(&pt);
                         if dist < curr_dist {
-                            // FIXME: if we reach this point, there were issues due to
+                            // TODO: if we reach this point, there were issues due to
                             // numerical errors.
                             let points = face.closest_points(&self.vertices);
                             return Some((points.0, points.1, face.normal));

--- a/src/query/gjk/gjk.rs
+++ b/src/query/gjk/gjk.rs
@@ -99,7 +99,7 @@ where
     let _eps_tol: Real = eps_tol();
     let _eps_rel: Real = ComplexField::sqrt(_eps_tol);
 
-    // FIXME: reset the simplex if it is empty?
+    // TODO: reset the simplex if it is empty?
     let mut proj = simplex.project_origin_and_reduce();
 
     let mut old_dir;
@@ -268,7 +268,7 @@ where
     let support_point = CSOPoint::from_shapes(pos12, g1, g2, &dir);
     simplex.reset(support_point.translate(&-curr_ray.origin.coords));
 
-    // FIXME: reset the simplex if it is empty?
+    // TODO: reset the simplex if it is empty?
     let mut proj = simplex.project_origin_and_reduce();
     let mut max_bound = Real::max_value();
     let mut dir;
@@ -346,7 +346,7 @@ where
         if max_bound - min_bound <= _eps_rel * max_bound {
             // This is needed when using fixed-points to avoid missing
             // some castes.
-            // FIXME: I feel like we should always return `Some` in
+            // TODO: I feel like we should always return `Some` in
             // this case, even with floating-point numbers. Though it
             // has not been sufficinetly tested with floats yet to be sure.
             if cfg!(feature = "improved_fixed_point_support") {

--- a/src/query/gjk/voronoi_simplex2.rs
+++ b/src/query/gjk/voronoi_simplex2.rs
@@ -98,7 +98,7 @@ impl VoronoiSimplex {
             self.proj[0] = 1.0;
             self.vertices[0].point
         } else if self.dim == 1 {
-            // FIXME: NLL
+            // TODO: NLL
             let (proj, location) = {
                 let seg = Segment::new(self.vertices[0].point, self.vertices[1].point);
                 seg.project_local_point_and_get_location(&Point::<Real>::origin(), true)
@@ -123,7 +123,7 @@ impl VoronoiSimplex {
             proj.point
         } else {
             assert!(self.dim == 2);
-            // FIXME: NLL
+            // TODO: NLL
             let (proj, location) = {
                 let tri = Triangle::new(
                     self.vertices[0].point,

--- a/src/query/gjk/voronoi_simplex3.rs
+++ b/src/query/gjk/voronoi_simplex3.rs
@@ -125,7 +125,7 @@ impl VoronoiSimplex {
             self.proj[0] = 1.0;
             self.vertices[0].point
         } else if self.dim == 1 {
-            // FIXME: NLL
+            // TODO: NLL
             let (proj, location) = {
                 let seg = Segment::new(self.vertices[0].point, self.vertices[1].point);
                 seg.project_local_point_and_get_location(&Point::<Real>::origin(), true)
@@ -150,7 +150,7 @@ impl VoronoiSimplex {
 
             proj.point
         } else if self.dim == 2 {
-            // FIXME: NLL
+            // TODO: NLL
             let (proj, location) = {
                 let tri = Triangle::new(
                     self.vertices[0].point,
@@ -192,7 +192,7 @@ impl VoronoiSimplex {
             proj.point
         } else {
             assert!(self.dim == 3);
-            // FIXME: NLL
+            // TODO: NLL
             let (proj, location) = {
                 let tetr = Tetrahedron::new(
                     self.vertices[0].point,

--- a/src/query/nonlinear_shape_cast/nonlinear_shape_cast_support_map_support_map.rs
+++ b/src/query/nonlinear_shape_cast/nonlinear_shape_cast_support_map_support_map.rs
@@ -148,7 +148,7 @@ where
                 if let Some((normal1, dist)) =
                     Unit::try_new_and_get(pos12 * p2 - p1, crate::math::DEFAULT_EPSILON)
                 {
-                    // FIXME: do the "inverse transform unit vector" only when we are about to return.
+                    // TODO: do the "inverse transform unit vector" only when we are about to return.
                     result.normal1 = normal1;
                     result.normal2 = pos12.inverse_transform_unit_vector(&-normal1);
 
@@ -203,7 +203,7 @@ where
             ClosestPoints::Disjoint => {
                 // TODO: this case should be unreachable and needs some debugging
                 //       see: https://github.com/dimforge/parry/issues/176
-                log::error!(
+                log::debug!(
                     "Closest points not found despite setting the max distance to infinity."
                 );
                 result.status = ShapeCastStatus::Failed;

--- a/src/query/point/point_aabb.rs
+++ b/src/query/point/point_aabb.rs
@@ -140,7 +140,7 @@ impl PointQuery for Aabb {
         if solid || !shift.is_zero() {
             shift.norm()
         } else {
-            // FIXME: optimize that.
+            // TODO: optimize that.
             -na::distance(pt, &self.project_local_point(pt, solid).point)
         }
     }

--- a/src/query/point/point_composite_shape.rs
+++ b/src/query/point/point_composite_shape.rs
@@ -32,7 +32,7 @@ impl PointQuery for Polyline {
         (proj, polyline_feature)
     }
 
-    // FIXME: implement distance_to_point too?
+    // TODO: implement distance_to_point too?
 
     #[inline]
     fn contains_local_point(&self, point: &Point<Real>) -> bool {
@@ -70,7 +70,7 @@ impl PointQuery for TriMesh {
         (proj, feature_id)
     }
 
-    // FIXME: implement distance_to_point too?
+    // TODO: implement distance_to_point too?
 
     #[inline]
     fn contains_local_point(&self, point: &Point<Real>) -> bool {

--- a/src/query/point/point_heightfield.rs
+++ b/src/query/point/point_heightfield.rs
@@ -59,11 +59,11 @@ impl PointQuery for HeightField {
         &self,
         point: &Point<Real>,
     ) -> (PointProjection, FeatureId) {
-        // FIXME: compute the feature properly.
+        // TODO: compute the feature properly.
         (self.project_local_point(point, false), FeatureId::Unknown)
     }
 
-    // FIXME: implement distance_to_point too?
+    // TODO: implement distance_to_point too?
 
     #[inline]
     fn contains_local_point(&self, _point: &Point<Real>) -> bool {

--- a/src/query/point/point_round_shape.rs
+++ b/src/query/point/point_round_shape.rs
@@ -8,12 +8,12 @@ use crate::shape::{FeatureId, RoundShape, SupportMap};
 impl<S: SupportMap> PointQuery for RoundShape<S> {
     #[inline]
     fn project_local_point(&self, point: &Point<Real>, solid: bool) -> PointProjection {
-        #[cfg(not(feature = "std"))] // FIXME: can’t be used without std because of EPA
+        #[cfg(not(feature = "std"))] // TODO: can’t be used without std because of EPA
         return unimplemented!(
             "The projection of points on a round shapes isn’t supported on no-std platforms yet."
         );
 
-        #[cfg(feature = "std")] // FIXME: can’t be used without std because of EPA
+        #[cfg(feature = "std")] // TODO: can’t be used without std because of EPA
         return crate::query::details::local_point_projection_on_support_map(
             self,
             &mut VoronoiSimplex::new(),

--- a/src/query/point/point_segment.rs
+++ b/src/query/point/point_segment.rs
@@ -77,7 +77,7 @@ impl PointQueryWithLocation for Segment {
             proj = self.a + ab * u;
         }
 
-        // FIXME: is this acceptable?
+        // TODO: is this acceptable?
         let inside = relative_eq!(proj, *pt);
 
         (PointProjection::new(inside, proj), location)

--- a/src/query/ray/ray_support_map.rs
+++ b/src/query/ray/ray_support_map.rs
@@ -43,7 +43,7 @@ where
                 let shift = (supp - ray.origin).dot(&ndir) + eps;
                 let new_ray = Ray::new(ray.origin + ndir * shift, -ray.dir);
 
-                // FIXME: replace by? : simplex.translate_by(&(ray.origin - new_ray.origin));
+                // TODO: replace by? : simplex.translate_by(&(ray.origin - new_ray.origin));
                 simplex.reset(CSOPoint::single_point(supp - new_ray.origin.coords));
 
                 gjk::cast_local_ray(shape, simplex, &new_ray, shift + eps).and_then(

--- a/src/query/split/split_trimesh.rs
+++ b/src/query/split/split_trimesh.rs
@@ -153,7 +153,7 @@ impl TriMesh {
                 if intersection_features.0 == FeatureId::Unknown {
                     intersection_features.0 = fid;
                 } else {
-                    // FIXME: this assertion may fire if the triangle is coplanar with the edge?
+                    // TODO: this assertion may fire if the triangle is coplanar with the edge?
                     // assert_eq!(intersection_features.1, FeatureId::Unknown);
                     intersection_features.1 = fid;
                 }
@@ -462,7 +462,7 @@ impl TriMesh {
                 if intersection_features.0 == FeatureId::Unknown {
                     intersection_features.0 = fid;
                 } else {
-                    // FIXME: this assertion may fire if the triangle is coplanar with the edge?
+                    // TODO: this assertion may fire if the triangle is coplanar with the edge?
                     // assert_eq!(intersection_features.1, FeatureId::Unknown);
                     intersection_features.1 = fid;
                 }

--- a/src/query/visitors/point_intersections_visitor.rs
+++ b/src/query/visitors/point_intersections_visitor.rs
@@ -4,7 +4,7 @@ use crate::partitioning::{SimdVisitStatus, SimdVisitor};
 use simba::simd::{SimdBool as _, SimdValue};
 use std::marker::PhantomData;
 
-// FIXME: add a point cost fn.
+// TODO: add a point cost fn.
 
 /// Spatial partitioning structure visitor collecting nodes that may contain a given point.
 pub struct PointIntersectionsVisitor<'a, T, F> {

--- a/src/shape/convex_polygon.rs
+++ b/src/shape/convex_polygon.rs
@@ -260,7 +260,7 @@ impl ConvexPolyhedron for ConvexPolygon {
         out: &mut ConvexPolygonalFeature,
     ) {
         out.clear();
-        // FIXME: actualy find the support feature.
+        // TODO: actualy find the support feature.
         self.support_face_toward(transform, dir, out)
     }
 

--- a/src/shape/convex_polyhedron.rs
+++ b/src/shape/convex_polyhedron.rs
@@ -374,7 +374,7 @@ impl ConvexPolyhedron {
             vertices_adj_to_face,
         };
 
-        // FIXME: for debug.
+        // TODO: for debug.
         // res.check_geometry();
 
         Some(res)

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -48,7 +48,7 @@ impl Cuboid {
     /// the dot product with `dir`.
     #[cfg(feature = "dim2")]
     pub fn vertex_feature_id(vertex: Point<Real>) -> u32 {
-        // FIXME: is this still correct with the f64 version?
+        // TODO: is this still correct with the f64 version?
         #[allow(clippy::unnecessary_cast)] // Unnecessary for f32 but necessary for f64.
         {
             ((vertex.x.to_bits() >> 31) & 0b001 | (vertex.y.to_bits() >> 30) & 0b010) as u32
@@ -94,7 +94,7 @@ impl Cuboid {
     /// the dot product with `local_dir`.
     #[cfg(feature = "dim3")]
     pub fn support_feature(&self, local_dir: Vector<Real>) -> PolygonalFeature {
-        // FIXME: this should actually return the feature.
+        // TODO: this should actually return the feature.
         // And we should change all the callers of this method to use
         // `.support_face` instead of this method to preserve their old behavior.
         self.support_face(local_dir)
@@ -498,7 +498,7 @@ impl ConvexPolyhedron for Cuboid {
         let mut iamax = 0;
         let mut amax = local_dir[0].abs();
 
-        // FIXME: we should use nalgebra's iamax method.
+        // TODO: we should use nalgebra's iamax method.
         for i in 1..DIM {
             let candidate = local_dir[i].abs();
             if candidate > amax {

--- a/src/shape/heightfield2.rs
+++ b/src/shape/heightfield2.rs
@@ -162,7 +162,7 @@ impl HeightField {
 
     /// Iterator through all the segments of this heightfield.
     pub fn segments(&self) -> impl Iterator<Item = Segment> + '_ {
-        // FIXME: this is not very efficient since this wil
+        // TODO: this is not very efficient since this wil
         // recompute shared points twice.
         (0..self.num_cells()).filter_map(move |i| self.segment_at(i))
     }
@@ -226,7 +226,7 @@ impl HeightField {
         let min_x = self.quantize_floor(ref_mins.x, seg_length);
         let max_x = self.quantize_ceil(ref_maxs.x, seg_length);
 
-        // FIXME: find a way to avoid recomputing the same vertices
+        // TODO: find a way to avoid recomputing the same vertices
         // multiple times.
         for i in min_x..max_x {
             if self.is_segment_removed(i) {

--- a/src/shape/heightfield3.rs
+++ b/src/shape/heightfield3.rs
@@ -709,7 +709,7 @@ impl HeightField {
         let max_x = self.quantize_ceil(ref_maxs.x, cell_width, ncells_x);
         let max_z = self.quantize_ceil(ref_maxs.z, cell_height, ncells_z);
 
-        // FIXME: find a way to avoid recomputing the same vertices
+        // TODO: find a way to avoid recomputing the same vertices
         // multiple times.
         for j in min_x..max_x {
             for i in min_z..max_z {

--- a/src/transformation/convex_hull3/convex_hull.rs
+++ b/src/transformation/convex_hull3/convex_hull.rs
@@ -49,7 +49,7 @@ pub fn try_convex_hull(
             continue;
         }
 
-        // FIXME: use triangles[i].furthest_point instead.
+        // TODO: use triangles[i].furthest_point instead.
         let pt_id = indexed_support_point_id(
             &triangles[i].normal,
             &normalized_points[..],
@@ -86,7 +86,7 @@ pub fn try_convex_hull(
             )?;
 
             // Check that the silhouette is valid.
-            // FIXME: remove this debug code.
+            // TODO: remove this debug code.
             // {
             //     for (facet, id) in &silhouette_loop_facets_and_idx {
             //         assert!(triangles[*facet].valid);
@@ -110,7 +110,7 @@ pub fn try_convex_hull(
                     ));
                 }
 
-                // FIXME: this is very harsh.
+                // TODO: this is very harsh.
                 triangles[i].valid = true;
                 break;
             }
@@ -208,7 +208,7 @@ fn fix_silhouette_topology(
     removed_facets: &mut Vec<usize>,
     triangles: &mut [TriangleFacet],
 ) -> Result<(), ConvexHullError> {
-    // FIXME: don't allocate this everytime.
+    // TODO: don't allocate this everytime.
     let mut workspace = vec![0; points.len()];
     let mut needs_fixing = false;
 
@@ -351,7 +351,7 @@ fn attach_and_push_facets(
     }
 
     // Assign to each facets some of the points which can see it.
-    // FIXME: refactor this with the others.
+    // TODO: refactor this with the others.
     for curr_facet in removed_facets.iter() {
         for visible_point in triangles[*curr_facet].visible_points.iter() {
             if points[*visible_point] == points[point] {
@@ -410,7 +410,7 @@ fn attach_and_push_facets(
     }
 
     // Push facets.
-    // FIXME: can we avoid the tmp vector `new_facets` ?
+    // TODO: can we avoid the tmp vector `new_facets` ?
     triangles.append(&mut new_facets);
 }
 

--- a/src/transformation/convex_hull3/initial_mesh.rs
+++ b/src/transformation/convex_hull3/initial_mesh.rs
@@ -178,7 +178,7 @@ pub fn try_get_initial_mesh(
                 let mut facets = vec![f1, f2];
 
                 // … and attribute visible points to each one of them.
-                // FIXME: refactor this with the two others.
+                // TODO: refactor this with the two others.
                 for point in 0..normalized_points.len() {
                     if normalized_points[point] == normalized_points[p1]
                         || normalized_points[point] == normalized_points[p2]

--- a/src/transformation/mod.rs
+++ b/src/transformation/mod.rs
@@ -9,7 +9,8 @@ pub use self::convex_hull3::{check_convex_hull, convex_hull, try_convex_hull, Co
 #[cfg(feature = "dim3")]
 pub use self::mesh_intersection::intersect_meshes;
 pub use self::polygon_intersection::{
-    convex_polygons_intersection, convex_polygons_intersection_points,
+    convex_polygons_intersection, convex_polygons_intersection_points, polygons_intersection,
+    polygons_intersection_points,
 };
 
 mod convex_hull2;

--- a/src/transformation/polygon_intersection.rs
+++ b/src/transformation/polygon_intersection.rs
@@ -452,6 +452,21 @@ pub fn polygons_intersection(
         }
     }
 
+    // If there are no intersection, check if one polygon is inside the other.
+    if intersections[0].is_empty() {
+        if utils::point_in_poly2d(&poly1[0], &poly2) {
+            for pt_id in 0..poly1.len() {
+                out(Some(PolylinePointLocation::OnVertex(pt_id)), None)
+            }
+            out(None, None);
+        } else if utils::point_in_poly2d(&poly2[0], &poly1) {
+            for pt_id in 0..poly2.len() {
+                out(None, Some(PolylinePointLocation::OnVertex(pt_id)))
+            }
+            out(None, None);
+        }
+    }
+
     Ok(())
 }
 

--- a/src/transformation/polygon_intersection.rs
+++ b/src/transformation/polygon_intersection.rs
@@ -1,8 +1,14 @@
+use log::error;
 use na::Point2;
+use ordered_float::OrderedFloat;
+use std::cmp::Ordering;
 
 use crate::math::Real;
-use crate::shape::{SegmentPointLocation, Triangle, TriangleOrientation};
+use crate::shape::{Segment, SegmentPointLocation, Triangle, TriangleOrientation};
+use crate::utils::hashmap::HashMap;
 use crate::utils::{self, SegmentsIntersection};
+
+const EPS: Real = Real::EPSILON * 100.0;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum InFlag {
@@ -12,6 +18,7 @@ enum InFlag {
 }
 
 /// Location of a point on a polyline.
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum PolylinePointLocation {
     /// Point on a vertex.
     OnVertex(usize),
@@ -20,6 +27,24 @@ pub enum PolylinePointLocation {
 }
 
 impl PolylinePointLocation {
+    /// The barycentric coordinates such that the point in the intersected segment `[a, b]` is
+    /// equal to `a + (b - a) * centered_bcoords`.
+    fn centered_bcoords(&self, edge: [usize; 2]) -> Real {
+        match self {
+            Self::OnVertex(vid) => {
+                if *vid == edge[0] {
+                    0.0
+                } else {
+                    1.0
+                }
+            }
+            Self::OnEdge(ia, ib, bcoords) => {
+                assert_eq!([*ia, *ib], edge);
+                bcoords[1]
+            }
+        }
+    }
+
     /// Computes the point corresponding to this location.
     pub fn to_point(&self, pts: &[Point2<Real>]) -> Point2<Real> {
         match self {
@@ -65,9 +90,7 @@ pub fn convex_polygons_intersection(
     poly2: &[Point2<Real>],
     mut out: impl FnMut(Option<PolylinePointLocation>, Option<PolylinePointLocation>),
 ) {
-    const EPS: Real = Real::EPSILON * 100.0;
-
-    // FIXME: this does not handle correctly the case where the
+    // TODO: this does not handle correctly the case where the
     // first triangle of the polygon is degenerate.
     let rev1 = poly1.len() > 2
         && Triangle::orientation2d(&poly1[0], &poly1[1], &poly1[2], EPS)
@@ -75,8 +98,6 @@ pub fn convex_polygons_intersection(
     let rev2 = poly2.len() > 2
         && Triangle::orientation2d(&poly2[0], &poly2[1], &poly2[2], EPS)
             == TriangleOrientation::Clockwise;
-
-    // println!("rev1: {}, rev2: {}", rev1, rev2);
 
     let n = poly1.len();
     let m = poly2.len();
@@ -101,8 +122,6 @@ pub fn convex_polygons_intersection(
         } else {
             ((b + m - 1) % m, b)
         };
-
-        // println!("Current indices: ({}, {}), ({}, {})", a1, a2, b1, b2);
 
         let dir_edge1 = poly1[a2] - poly1[a1];
         let dir_edge2 = poly2[b2] - poly2[b1];
@@ -264,4 +283,250 @@ pub fn convex_polygons_intersection(
 fn advance(a: usize, aa: &mut usize, n: usize) -> usize {
     *aa += 1;
     (a + 1) % n
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum PolygonsIntersectionError {
+    #[error("Infinite loop detected; input polygons are ill-formed.")]
+    InfiniteLoop,
+}
+
+/// Compute intersections between two polygons that may be non-convex but that must not self-intersect.
+///
+/// The resulting polygon is output vertex-by-vertex to the `out` closure.
+/// If two `None` are given to the `out` closure, then one connected component of the intersection
+/// polygon is complete.
+///
+/// If the polygons are known to be convex, use [`convex_polygons_intersection_points`] instead for better
+/// performances.
+pub fn polygons_intersection_points(
+    poly1: &[Point2<Real>],
+    poly2: &[Point2<Real>],
+) -> Result<Vec<Vec<Point2<Real>>>, PolygonsIntersectionError> {
+    let mut result = vec![];
+    let mut curr_poly = vec![];
+    polygons_intersection(poly1, poly2, |loc1, loc2| {
+        if let Some(loc1) = loc1 {
+            curr_poly.push(loc1.to_point(poly1))
+        } else if let Some(loc2) = loc2 {
+            curr_poly.push(loc2.to_point(poly2))
+        } else if !curr_poly.is_empty() {
+            result.push(std::mem::take(&mut curr_poly));
+        }
+    })?;
+
+    Ok(result)
+}
+
+/// Compute intersections between two polygons that may be non-convex but that must not self-intersect.
+///
+/// The resulting polygon is output vertex-by-vertex to the `out` closure.
+/// If two `None` are given to the `out` closure, then one connected component of the intersection
+/// polygon is complete.
+///
+/// If the polygons are known to be convex, use [`convex_polygons_intersection`] instead for better
+/// performances.
+pub fn polygons_intersection(
+    poly1: &[Point2<Real>],
+    poly2: &[Point2<Real>],
+    mut out: impl FnMut(Option<PolylinePointLocation>, Option<PolylinePointLocation>),
+) -> Result<(), PolygonsIntersectionError> {
+    #[derive(Debug)]
+    struct ToTraverse {
+        poly: usize,
+        edge: EdgeId,
+    }
+
+    let (intersections, num_intersections) = compute_sorted_edge_intersections(poly1, poly2);
+    let mut visited = vec![false; num_intersections];
+    let segment = |eid: EdgeId, poly: &[Point2<Real>]| [poly[eid], poly[(eid + 1) % poly.len()]];
+
+    // Traverse all the intersections.
+    for inters in intersections[0].values() {
+        for inter in inters {
+            if visited[inter.id] {
+                continue;
+            }
+
+            // We found an intersection we haven’t visited yet, traverse the loop, alternating
+            // between poly1 and poly2 when reaching an intersection.
+            let mut num_points_emitted = 0; // Guard against infinite loops if the polygon isn’t well-formed.
+
+            let [a1, b1] = segment(inter.edges[0], poly1);
+            let [a2, b2] = segment(inter.edges[1], poly2);
+            let poly_to_traverse = match Triangle::orientation2d(&a1, &b1, &a2, EPS) {
+                TriangleOrientation::Clockwise => 1,
+                TriangleOrientation::CounterClockwise => 0,
+                TriangleOrientation::Degenerate => {
+                    match Triangle::orientation2d(&a1, &b1, &b2, EPS) {
+                        TriangleOrientation::Clockwise => 0,
+                        TriangleOrientation::CounterClockwise => 1,
+                        TriangleOrientation::Degenerate => {
+                            error!("Unhandled edge-edge overlap case.");
+                            0
+                        }
+                    }
+                }
+            };
+
+            #[derive(Debug)]
+            enum TraversalStatus {
+                OnVertex,
+                OnIntersection(usize),
+            }
+
+            let polys = [poly1, poly2];
+            let mut to_traverse = ToTraverse {
+                poly: poly_to_traverse,
+                edge: inter.edges[poly_to_traverse],
+            };
+
+            let mut status = TraversalStatus::OnIntersection(inter.id);
+
+            for loop_id in 0.. {
+                if loop_id > poly1.len() * poly2.len() {
+                    return Err(PolygonsIntersectionError::InfiniteLoop);
+                }
+
+                let empty = Vec::new();
+                let edge_inters = intersections[to_traverse.poly]
+                    .get(&to_traverse.edge)
+                    .unwrap_or(&empty);
+
+                match status {
+                    TraversalStatus::OnIntersection(inter_id) => {
+                        let (curr_inter_pos, curr_inter) = edge_inters
+                            .iter()
+                            .enumerate()
+                            .find(|(_, inter)| inter.id == inter_id)
+                            .unwrap_or_else(|| unreachable!());
+
+                        if visited[curr_inter.id] {
+                            // We already saw this intersection: we looped back to the start of
+                            // the intersection polygon.
+                            out(None, None);
+                            break;
+                        }
+
+                        out(Some(curr_inter.locs[0]), Some(curr_inter.locs[1]));
+                        visited[curr_inter.id] = true;
+
+                        if curr_inter_pos + 1 < edge_inters.len() {
+                            // There are other intersections after this one.
+                            // Move forward to the next intersection point and move on to traversing
+                            // the other polygon.
+                            let next_inter = &edge_inters[curr_inter_pos + 1];
+                            to_traverse.poly = (to_traverse.poly + 1) % 2;
+                            to_traverse.edge = next_inter.edges[to_traverse.poly];
+                            status = TraversalStatus::OnIntersection(next_inter.id);
+                        } else {
+                            // This was the last intersection, move to the next vertex on the
+                            // same polygon.
+                            to_traverse.edge =
+                                (to_traverse.edge + 1) % polys[to_traverse.poly].len();
+                            status = TraversalStatus::OnVertex;
+                        }
+                    }
+                    TraversalStatus::OnVertex => {
+                        let location = PolylinePointLocation::OnVertex(to_traverse.edge);
+
+                        if to_traverse.poly == 0 {
+                            out(Some(location), None);
+                        } else {
+                            out(None, Some(location))
+                        };
+
+                        if let Some(first_intersection) = edge_inters.get(0) {
+                            // Jump on the first intersection and move on to the other polygon.
+                            to_traverse.poly = (to_traverse.poly + 1) % 2;
+                            to_traverse.edge = first_intersection.edges[to_traverse.poly];
+                            status = TraversalStatus::OnIntersection(first_intersection.id);
+                        } else {
+                            // Move forward to the next vertex/edge on the same polygon.
+                            to_traverse.edge =
+                                (to_traverse.edge + 1) % polys[to_traverse.poly].len();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+type EdgeId = usize;
+type IntersectionId = usize;
+
+#[derive(Copy, Clone, Debug)]
+struct IntersectionPoint {
+    id: IntersectionId,
+    edges: [EdgeId; 2],
+    locs: [PolylinePointLocation; 2],
+}
+
+fn compute_sorted_edge_intersections(
+    poly1: &[Point2<Real>],
+    poly2: &[Point2<Real>],
+) -> ([HashMap<EdgeId, Vec<IntersectionPoint>>; 2], usize) {
+    let mut inter1: HashMap<EdgeId, Vec<IntersectionPoint>> = HashMap::default();
+    let mut inter2: HashMap<EdgeId, Vec<IntersectionPoint>> = HashMap::default();
+    let mut id = 0;
+
+    // Find the intersections.
+    // TODO: this is a naive O(n²) check. Could use an acceleration structure for large polygons.
+    for i1 in 0..poly1.len() {
+        let j1 = (i1 + 1) % poly1.len();
+
+        for i2 in 0..poly2.len() {
+            let j2 = (i2 + 1) % poly2.len();
+
+            let Some(inter) =
+                utils::segments_intersection2d(&poly1[i1], &poly1[j1], &poly2[i2], &poly2[j2], EPS)
+            else {
+                continue;
+            };
+
+            match inter {
+                SegmentsIntersection::Point { loc1, loc2 } => {
+                    let loc1 = PolylinePointLocation::from_segment_point_location(i1, j1, loc1);
+                    let loc2 = PolylinePointLocation::from_segment_point_location(i2, j2, loc2);
+                    let intersection = IntersectionPoint {
+                        id,
+                        edges: [i1, i2],
+                        locs: [loc1, loc2],
+                    };
+                    inter1.entry(i1).or_default().push(intersection);
+                    inter2.entry(i2).or_default().push(intersection);
+                    id += 1;
+                }
+                SegmentsIntersection::Segment {
+                    first_loc1,
+                    first_loc2,
+                    second_loc1,
+                    second_loc2,
+                } => {
+                    // TODO
+                    error!("Collinear segment-segment intersections not properly handled yet.");
+                }
+            }
+        }
+    }
+
+    // Sort the intersections.
+    for inters in inter1.values_mut() {
+        inters.sort_by_key(|a| {
+            let edge = [a.edges[0], (a.edges[0] + 1) % poly1.len()];
+            OrderedFloat(a.locs[0].centered_bcoords(edge))
+        });
+    }
+
+    for inters in inter2.values_mut() {
+        inters.sort_by_key(|a| {
+            let edge = [a.edges[1], (a.edges[1] + 1) % poly2.len()];
+            OrderedFloat(a.locs[1].centered_bcoords(edge))
+        });
+    }
+
+    ([inter1, inter2], id)
 }

--- a/src/transformation/utils.rs
+++ b/src/transformation/utils.rs
@@ -24,7 +24,7 @@ pub fn scaled(mut points: Vec<Point<Real>>, scale: Vector<Real>) -> Vec<Point<Re
     points
 }
 
-// FIXME: remove that in favor of `push_xy_circle` ?
+// TODO: remove that in favor of `push_xy_circle` ?
 /// Pushes a discretized counterclockwise circle to a buffer.
 #[cfg(feature = "dim3")]
 #[inline]

--- a/src/utils/as_bytes.rs
+++ b/src/utils/as_bytes.rs
@@ -28,4 +28,4 @@ generic_as_bytes_impl!(Point2, 2);
 generic_as_bytes_impl!(Vector3, 3);
 generic_as_bytes_impl!(Point3, 3);
 
-// FIXME: implement for all `T: Copy` instead?
+// TODO: implement for all `T: Copy` instead?

--- a/src/utils/point_in_poly2d.rs
+++ b/src/utils/point_in_poly2d.rs
@@ -48,7 +48,7 @@ pub fn point_in_poly2d(pt: &Point2<Real>, poly: &[Point2<Real>]) -> bool {
         let seg_dir = b - a;
         let dpt = pt - a;
         let perp = dpt.perp(&seg_dir);
-        winding += match (dpt.y > 0.0, b.y > pt.y) {
+        winding += match (dpt.y >= 0.0, b.y > pt.y) {
             (true, true) if perp < 0.0 => 1,
             (false, false) if perp > 0.0 => -1,
             _ => 0,
@@ -61,6 +61,7 @@ pub fn point_in_poly2d(pt: &Point2<Real>, poly: &[Point2<Real>]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shape::Ball;
 
     #[test]
     fn point_in_poly2d_concave() {
@@ -131,5 +132,19 @@ mod tests {
         .map(Point2::from);
         let pt = Point2::from([596.0181884765625, 427.9162902832031]);
         assert!(point_in_poly2d(&pt, &poly));
+    }
+
+    #[test]
+    fn point_in_poly2d_concave_exact_vertex_bug() {
+        let poly = Ball::new(1.0).to_polyline(10);
+        assert!(point_in_poly2d(&Point2::origin(), &poly));
+        assert!(point_in_poly2d(&Point2::new(-0.25, 0.0), &poly));
+        assert!(point_in_poly2d(&Point2::new(0.25, 0.0), &poly));
+        assert!(point_in_poly2d(&Point2::new(0.0, -0.25), &poly));
+        assert!(point_in_poly2d(&Point2::new(0.0, 0.25), &poly));
+        assert!(!point_in_poly2d(&Point2::new(-2.0, 0.0), &poly));
+        assert!(!point_in_poly2d(&Point2::new(2.0, 0.0), &poly));
+        assert!(!point_in_poly2d(&Point2::new(0.0, -2.0), &poly));
+        assert!(!point_in_poly2d(&Point2::new(0.0, 2.0), &poly));
     }
 }

--- a/src/utils/point_in_poly2d.rs
+++ b/src/utils/point_in_poly2d.rs
@@ -61,7 +61,6 @@ pub fn point_in_poly2d(pt: &Point2<Real>, poly: &[Point2<Real>]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::shape::Ball;
 
     #[test]
     fn point_in_poly2d_concave() {
@@ -135,8 +134,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "dim2")]
     fn point_in_poly2d_concave_exact_vertex_bug() {
-        let poly = Ball::new(1.0).to_polyline(10);
+        let poly = crate::shape::Ball::new(1.0).to_polyline(10);
         assert!(point_in_poly2d(&Point2::origin(), &poly));
         assert!(point_in_poly2d(&Point2::new(-0.25, 0.0), &poly));
         assert!(point_in_poly2d(&Point2::new(0.25, 0.0), &poly));

--- a/src/utils/segments_intersection.rs
+++ b/src/utils/segments_intersection.rs
@@ -148,7 +148,7 @@ fn parallel_intersection(
 // Assumes the three points are collinear.
 fn between(a: &Point2<Real>, b: &Point2<Real>, c: &Point2<Real>) -> Option<SegmentPointLocation> {
     // If ab not vertical, check betweenness on x; else on y.
-    // FIXME: handle cases wher we actually are on a vertex (to return OnEdge instead of OnVertex)?
+    // TODO: handle cases wher we actually are on a vertex (to return OnEdge instead of OnVertex)?
     if a.x != b.x {
         if a.x <= c.x && c.x <= b.x {
             let bcoord = (c.x - a.x) / (b.x - a.x);


### PR DESCRIPTION
This implements the calculation of the intersection polygon(s) between two non-convex (non-self-intersecting) polygons.
Adds an example based on `macroquad` (for rendering).


https://github.com/dimforge/parry/assets/1734958/e7c61b8a-443a-4436-a300-bb67e73c5291

This also adds an example based on `macroquad` for the point-in-polygon2d check:

https://github.com/dimforge/parry/assets/1734958/cd89afee-02f4-432f-9c85-ee1466008e8a

