### PR TITLE
fix: don’t panic in EPA

### DIFF
--- a/src/query/epa/epa3.rs
+++ b/src/query/epa/epa3.rs
@@ -126,7 +126,11 @@ impl Face {
         } else if self.pts[1] == id {
             2
         } else {
-            assert_eq!(self.pts[2], id);
+            log::debug!(
+                "Hit unexpected state in EPA: found index {}, expected: {}.",
+                self.pts[2],
+                id
+            );
             0
         }
     }


### PR DESCRIPTION
An debug-log is preferable to a random panic in mathematical code.
Related to #202 