### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## v0.16.0
+
+### Fix
+
+- Fix edge case where some of the principal angular inertia are clamped to zero
+  for decimeter-sized objects.
+- Have ball-ball shape casting take into account the `stop_on_penetration` flags.
+- Don’t panic in EPA for a corner case that needs some additional debugging. Show a debug log instead.
+
+### Added
+
+- Implement concave polygons intersections: `polygons_intersection_points`, `polygon_intersection`.
+
+### Modified
+
+- Update `bitflags` to version ^2.3
+- Update `nalgebra` to 0.33.
+- Update `indexmap` to 2.
+
 ## v0.15.1
 
 ### Fix

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."


### PR DESCRIPTION
## v0.16.0

### Fix

- Fix edge case where some of the principal angular inertia are clamped to zero
  for decimeter-sized objects.
- Have ball-ball shape casting take into account the `stop_on_penetration` flags.
- Don’t panic in EPA for a corner case that needs some additional debugging. Show a debug log instead.

### Added

- Implement concave polygons intersections: `polygons_intersection_points`, `polygon_intersection`.

### Modified

- Update `bitflags` to version ^2.3
- Update `nalgebra` to 0.33.
- Update `indexmap` to 2.
