### PR TITLE
fix: don’t crash mesh/mesh intersection if some mesh coordinates are small denormal numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Fix
+
+- Fix occasional crash in mesh/mesh intersection if some of the vertex coordinates are very small.
+
 ## v0.16.0
 
 ### Fix

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -2,7 +2,7 @@ use super::{MeshIntersectionError, TriangleTriangleIntersection, EPS};
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::query::{visitors::BoundingVolumeIntersectionsSimultaneousVisitor, PointQuery};
 use crate::shape::{FeatureId, TriMesh, Triangle};
-use crate::utils::WBasis;
+use crate::utils::{self, WBasis};
 use na::{Point2, Vector2};
 use spade::{handles::FixedVertexHandle, ConstrainedDelaunayTriangulation, Triangulation as _};
 use std::collections::{HashMap, HashSet};
@@ -297,13 +297,22 @@ impl Triangulation {
 
         let vtx_handles = [
             delaunay
-                .insert(spade::Point2::new(ref_proj[0].x, ref_proj[0].y))
+                .insert(utils::sanitize_point(spade::Point2::new(
+                    ref_proj[0].x,
+                    ref_proj[0].y,
+                )))
                 .unwrap(),
             delaunay
-                .insert(spade::Point2::new(ref_proj[1].x, ref_proj[1].y))
+                .insert(utils::sanitize_point(spade::Point2::new(
+                    ref_proj[1].x,
+                    ref_proj[1].y,
+                )))
                 .unwrap(),
             delaunay
-                .insert(spade::Point2::new(ref_proj[2].x, ref_proj[2].y))
+                .insert(utils::sanitize_point(spade::Point2::new(
+                    ref_proj[2].x,
+                    ref_proj[2].y,
+                )))
                 .unwrap(),
         ];
 
@@ -401,7 +410,10 @@ fn cut_and_triangulate_intersections(
                         .entry(spade_key)
                         .or_insert_with(|| {
                             let point2d = triangulations[i].project(pt[i], orig_fid[i]);
-                            let handle = triangulations[i].delaunay.insert(point2d).unwrap();
+                            let handle = triangulations[i]
+                                .delaunay
+                                .insert(utils::sanitize_point(point2d))
+                                .unwrap();
                             let _ =
                                 spade_handle_to_intersection[i].insert((tri_ids[i], handle), key);
                             SpadeInfo { handle }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -29,7 +29,7 @@ pub use self::segments_intersection::{segments_intersection2d, SegmentsIntersect
 pub(crate) use self::sort::sort2;
 pub(crate) use self::sort::sort3;
 pub use self::sorted_pair::SortedPair;
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "std"))]
 pub(crate) use self::spade::sanitize_point;
 pub(crate) use self::weighted_value::WeightedValue;
 pub(crate) use self::wops::{simd_swap, WBasis, WCross, WSign};
@@ -61,7 +61,7 @@ mod sdp_matrix;
 mod segments_intersection;
 mod sort;
 mod sorted_pair;
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "std"))]
 mod spade;
 mod weighted_value;
 mod wops;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -29,6 +29,7 @@ pub use self::segments_intersection::{segments_intersection2d, SegmentsIntersect
 pub(crate) use self::sort::sort2;
 pub(crate) use self::sort::sort3;
 pub use self::sorted_pair::SortedPair;
+pub(crate) use self::spade::sanitize_point;
 pub(crate) use self::weighted_value::WeightedValue;
 pub(crate) use self::wops::{simd_swap, WBasis, WCross, WSign};
 
@@ -59,5 +60,6 @@ mod sdp_matrix;
 mod segments_intersection;
 mod sort;
 mod sorted_pair;
+mod spade;
 mod weighted_value;
 mod wops;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -29,6 +29,7 @@ pub use self::segments_intersection::{segments_intersection2d, SegmentsIntersect
 pub(crate) use self::sort::sort2;
 pub(crate) use self::sort::sort3;
 pub use self::sorted_pair::SortedPair;
+#[cfg(feature = "dim3")]
 pub(crate) use self::spade::sanitize_point;
 pub(crate) use self::weighted_value::WeightedValue;
 pub(crate) use self::wops::{simd_swap, WBasis, WCross, WSign};
@@ -60,6 +61,7 @@ mod sdp_matrix;
 mod segments_intersection;
 mod sort;
 mod sorted_pair;
+#[cfg(feature = "dim3")]
 mod spade;
 mod weighted_value;
 mod wops;

--- a/src/utils/spade.rs
+++ b/src/utils/spade.rs
@@ -1,0 +1,26 @@
+use crate::math::Real;
+
+/// Ensures the given coordinate doesn’t go out of the bounds of spade’s acceptable values.
+///
+/// Returns 0.0 if the coordinate is smaller than `spade::MIN_ALLOWED_VALUE`.
+/// Returns `spade::MAX_ALLOWED_VALUE` the coordinate is larger than `spade::MAX_ALLOWED_VALUE`.
+pub fn sanitize_coord(coord: Real) -> Real {
+    let abs = coord.abs();
+
+    #[allow(clippy::unnecessary_cast)]
+    if abs as f64 <= spade::MIN_ALLOWED_VALUE {
+        return 0.0;
+    }
+
+    #[cfg(feature = "f64")]
+    if abs > spade::MAX_ALLOWED_VALUE {
+        // This cannot happen in f32 since the max is 3.40282347E+38.
+        return spade::MAX_ALLOWED_VALUE * coord.signum();
+    }
+
+    coord
+}
+
+pub fn sanitize_point(point: spade::Point2<Real>) -> spade::Point2<Real> {
+    spade::Point2::new(sanitize_coord(point.x), sanitize_coord(point.y))
+}


### PR DESCRIPTION
The `spade` crate has restrictions on how small a denormal number can be when giving it input points. This PR sanitizes the coordinates by flushing small denormal numbers given to `spade` to 0.