### PR TITLE
Add `clone_scaled` to Shape traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   normal for thin triangles that generally cause numerical instabilities.
 - Add `Triangle::angle_closest_to_90` to find the triangle’s vertex with an angle closest to 90 degree.
 - Add the `wavefront` feature that enables `TriMesh::to_obj_file` for exporting a mesh as an obj file.
+- Add `Shape::scale_dyn` for scaling a shape as a trait-object.
 
 ### Modified
 
@@ -17,6 +18,8 @@
   so that an indirection is removed in documentation:
   previous occurrences of `Real` now show `f32` or `f64`.
 - Significantly improved the general stability of mesh/mesh intersection calculation.
+- Rename `Shape::clone_box` to `Shape::clone_dyn` (the `clone_box` method still exists but has been
+  deprecated).
 
 ## v0.16.1
 

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -344,7 +344,7 @@ pub trait Shape: RayCast + PointQuery + DowncastSync {
     fn clone_dyn(&self) -> Box<dyn Shape>;
 
     /// Scales this shape by `scale` into a boxed trait-object.
-    /// 
+    ///
     /// In some cases, the resulting shape doesn’t have the same type as Self. For example,
     /// if a non-uniform scale is provided and Self as a [`Ball`], then the result will be discretized
     /// (based on the `num_subdivisions` parameter) as a [`ConvexPolyhedron`] (in 3D) or [`ConvexPolygon`] (in 2D).

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -25,7 +25,6 @@ use crate::shape::{ConvexPolyhedron, RoundConvexPolyhedron};
 #[cfg(feature = "std")]
 use crate::shape::{ConvexPolygon, RoundConvexPolygon};
 use downcast_rs::{impl_downcast, DowncastSync};
-use either::Either::{Left, Right};
 use na::{RealField, Unit};
 use num::Zero;
 use num_derive::FromPrimitive;

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -51,7 +51,7 @@ impl SharedShape {
     /// and a mutable reference to that instance is returned.
     pub fn make_mut(&mut self) -> &mut dyn Shape {
         if Arc::get_mut(&mut self.0).is_none() {
-            let unique_self = self.0.clone_box();
+            let unique_self = self.0.clone_dyn();
             self.0 = unique_self.into();
         }
         Arc::get_mut(&mut self.0).unwrap()


### PR DESCRIPTION
We currently have some generic logic for scaling `Shape` in `bevy_rapier`. It seems reasonable to put this in the `Shape` trait so that the same logic can be reused elsewhere.