### PR TITLE
Composable QueryDispatcher

### DIFF
--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -1,15 +1,13 @@
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::query::details::ShapeCastOptions;
 use crate::query::{
-    self, details::NonlinearShapeCastMode, ClosestPoints, Contact, NonlinearRigidMotion,
-    QueryDispatcher, ShapeCastHit, Unsupported,
+    self, details::NonlinearShapeCastMode, query_dispatcher::QueryDispatcherComposite,
+    ClosestPoints, Contact, NonlinearRigidMotion, QueryDispatcher, ShapeCastHit, Unsupported,
 };
 #[cfg(feature = "std")]
 use crate::query::{
     contact_manifolds::{ContactManifoldsWorkspace, NormalConstraints},
-    query_dispatcher::{
-        PersistentQueryDispatcher, PersistentQueryDispatcherComposite, QueryDispatcherComposite,
-    },
+    query_dispatcher::{PersistentQueryDispatcher, PersistentQueryDispatcherComposite},
     ContactManifold,
 };
 use crate::shape::{HalfSpace, Segment, Shape, ShapeType};

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -7,7 +7,9 @@ use crate::query::{
 #[cfg(feature = "std")]
 use crate::query::{
     contact_manifolds::{ContactManifoldsWorkspace, NormalConstraints},
-    query_dispatcher::PersistentQueryDispatcher,
+    query_dispatcher::{
+        PersistentQueryDispatcher, PersistentQueryDispatcherComposite, QueryDispatcherComposite,
+    },
     ContactManifold,
 };
 use crate::shape::{HalfSpace, Segment, Shape, ShapeType};
@@ -16,9 +18,10 @@ use crate::shape::{HalfSpace, Segment, Shape, ShapeType};
 #[derive(Debug, Clone)]
 pub struct DefaultQueryDispatcher;
 
-impl QueryDispatcher for DefaultQueryDispatcher {
+impl QueryDispatcherComposite for DefaultQueryDispatcher {
     fn intersection_test(
         &self,
+        root_dispatcher: &dyn QueryDispatcher,
         pos12: &Isometry<Real>,
         shape1: &dyn Shape,
         shape2: &dyn Shape,
@@ -66,11 +69,17 @@ impl QueryDispatcher for DefaultQueryDispatcher {
             #[cfg(feature = "std")]
             if let Some(c1) = shape1.as_composite_shape() {
                 return Ok(query::details::intersection_test_composite_shape_shape(
-                    self, pos12, c1, shape2,
+                    root_dispatcher,
+                    pos12,
+                    c1,
+                    shape2,
                 ));
             } else if let Some(c2) = shape2.as_composite_shape() {
                 return Ok(query::details::intersection_test_shape_composite_shape(
-                    self, pos12, shape1, c2,
+                    root_dispatcher,
+                    pos12,
+                    shape1,
+                    c2,
                 ));
             }
 
@@ -83,6 +92,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
     /// Returns `0.0` if the objects are touching or penetrating.
     fn distance(
         &self,
+        root_dispatcher: &dyn QueryDispatcher,
         pos12: &Isometry<Real>,
         shape1: &dyn Shape,
         shape2: &dyn Shape,
@@ -125,11 +135,17 @@ impl QueryDispatcher for DefaultQueryDispatcher {
             #[cfg(feature = "std")]
             if let Some(c1) = shape1.as_composite_shape() {
                 return Ok(query::details::distance_composite_shape_shape(
-                    self, pos12, c1, shape2,
+                    root_dispatcher,
+                    pos12,
+                    c1,
+                    shape2,
                 ));
             } else if let Some(c2) = shape2.as_composite_shape() {
                 return Ok(query::details::distance_shape_composite_shape(
-                    self, pos12, shape1, c2,
+                    root_dispatcher,
+                    pos12,
+                    shape1,
+                    c2,
                 ));
             }
 
@@ -139,6 +155,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
 
     fn contact(
         &self,
+        root_dispatcher: &dyn QueryDispatcher,
         pos12: &Isometry<Real>,
         shape1: &dyn Shape,
         shape2: &dyn Shape,
@@ -181,11 +198,19 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 ));
             } else if let Some(c1) = shape1.as_composite_shape() {
                 return Ok(query::details::contact_composite_shape_shape(
-                    self, pos12, c1, shape2, prediction,
+                    root_dispatcher,
+                    pos12,
+                    c1,
+                    shape2,
+                    prediction,
                 ));
             } else if let Some(c2) = shape2.as_composite_shape() {
                 return Ok(query::details::contact_shape_composite_shape(
-                    self, pos12, shape1, c2, prediction,
+                    root_dispatcher,
+                    pos12,
+                    shape1,
+                    c2,
+                    prediction,
                 ));
             }
 
@@ -195,6 +220,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
 
     fn closest_points(
         &self,
+        root_dispatcher: &dyn QueryDispatcher,
         pos12: &Isometry<Real>,
         shape1: &dyn Shape,
         shape2: &dyn Shape,
@@ -257,11 +283,19 @@ impl QueryDispatcher for DefaultQueryDispatcher {
             #[cfg(feature = "std")]
             if let Some(c1) = shape1.as_composite_shape() {
                 return Ok(query::details::closest_points_composite_shape_shape(
-                    self, pos12, c1, shape2, max_dist,
+                    root_dispatcher,
+                    pos12,
+                    c1,
+                    shape2,
+                    max_dist,
                 ));
             } else if let Some(c2) = shape2.as_composite_shape() {
                 return Ok(query::details::closest_points_shape_composite_shape(
-                    self, pos12, shape1, c2, max_dist,
+                    root_dispatcher,
+                    pos12,
+                    shape1,
+                    c2,
+                    max_dist,
                 ));
             }
 
@@ -271,6 +305,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
 
     fn cast_shapes(
         &self,
+        root_dispatcher: &dyn QueryDispatcher,
         pos12: &Isometry<Real>,
         local_vel12: &Vector<Real>,
         shape1: &dyn Shape,
@@ -309,7 +344,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
             #[cfg(feature = "std")]
             if let Some(heightfield1) = shape1.as_heightfield() {
                 return query::details::cast_shapes_heightfield_shape(
-                    self,
+                    root_dispatcher,
                     pos12,
                     local_vel12,
                     heightfield1,
@@ -318,7 +353,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 );
             } else if let Some(heightfield2) = shape1.as_heightfield() {
                 return query::details::cast_shapes_shape_heightfield(
-                    self,
+                    root_dispatcher,
                     pos12,
                     local_vel12,
                     shape1,
@@ -336,7 +371,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 ));
             } else if let Some(c1) = shape1.as_composite_shape() {
                 return Ok(query::details::cast_shapes_composite_shape_shape(
-                    self,
+                    root_dispatcher,
                     pos12,
                     local_vel12,
                     c1,
@@ -345,7 +380,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 ));
             } else if let Some(c2) = shape2.as_composite_shape() {
                 return Ok(query::details::cast_shapes_shape_composite_shape(
-                    self,
+                    root_dispatcher,
                     pos12,
                     local_vel12,
                     shape1,
@@ -360,6 +395,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
 
     fn cast_shapes_nonlinear(
         &self,
+        root_dispatcher: &dyn QueryDispatcher,
         motion1: &NonlinearRigidMotion,
         shape1: &dyn Shape,
         motion2: &NonlinearRigidMotion,
@@ -377,14 +413,23 @@ impl QueryDispatcher for DefaultQueryDispatcher {
 
             Ok(
                 query::details::cast_shapes_nonlinear_support_map_support_map(
-                    self, motion1, sm1, shape1, motion2, sm2, shape2, start_time, end_time, mode,
+                    root_dispatcher,
+                    motion1,
+                    sm1,
+                    shape1,
+                    motion2,
+                    sm2,
+                    shape2,
+                    start_time,
+                    end_time,
+                    mode,
                 ),
             )
         } else {
             #[cfg(feature = "std")]
             if let Some(c1) = shape1.as_composite_shape() {
                 return Ok(query::details::cast_shapes_nonlinear_composite_shape_shape(
-                    self,
+                    root_dispatcher,
                     motion1,
                     c1,
                     motion2,
@@ -395,7 +440,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 ));
             } else if let Some(c2) = shape2.as_composite_shape() {
                 return Ok(query::details::cast_shapes_nonlinear_shape_composite_shape(
-                    self,
+                    root_dispatcher,
                     motion1,
                     shape1,
                     motion2,
@@ -418,7 +463,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
 }
 
 #[cfg(feature = "std")]
-impl<ManifoldData, ContactData> PersistentQueryDispatcher<ManifoldData, ContactData>
+impl<ManifoldData, ContactData> PersistentQueryDispatcherComposite<ManifoldData, ContactData>
     for DefaultQueryDispatcher
 where
     ManifoldData: Default + Clone,
@@ -426,6 +471,7 @@ where
 {
     fn contact_manifolds(
         &self,
+        root_dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
         pos12: &Isometry<Real>,
         shape1: &dyn Shape,
         shape2: &dyn Shape,
@@ -440,7 +486,13 @@ where
 
         if let (Some(composite1), Some(composite2)) = (composite1, composite2) {
             contact_manifolds_composite_shape_composite_shape(
-                self, pos12, composite1, composite2, prediction, manifolds, workspace,
+                root_dispatcher,
+                pos12,
+                composite1,
+                composite2,
+                prediction,
+                manifolds,
+                workspace,
             );
 
             return Ok(());
@@ -449,13 +501,19 @@ where
         match (shape1.shape_type(), shape2.shape_type()) {
             (ShapeType::TriMesh, _) | (_, ShapeType::TriMesh) => {
                 contact_manifolds_trimesh_shape_shapes(
-                    self, pos12, shape1, shape2, prediction, manifolds, workspace,
+                    root_dispatcher,
+                    pos12,
+                    shape1,
+                    shape2,
+                    prediction,
+                    manifolds,
+                    workspace,
                 );
             }
             (ShapeType::HeightField, _) => {
                 if let Some(composite2) = composite2 {
                     contact_manifolds_heightfield_composite_shape(
-                        self,
+                        root_dispatcher,
                         pos12,
                         &pos12.inverse(),
                         shape1.as_heightfield().unwrap(),
@@ -467,14 +525,20 @@ where
                     )
                 } else {
                     contact_manifolds_heightfield_shape_shapes(
-                        self, pos12, shape1, shape2, prediction, manifolds, workspace,
+                        root_dispatcher,
+                        pos12,
+                        shape1,
+                        shape2,
+                        prediction,
+                        manifolds,
+                        workspace,
                     );
                 }
             }
             (_, ShapeType::HeightField) => {
                 if let Some(composite1) = composite1 {
                     contact_manifolds_heightfield_composite_shape(
-                        self,
+                        root_dispatcher,
                         &pos12.inverse(),
                         pos12,
                         shape2.as_heightfield().unwrap(),
@@ -486,18 +550,31 @@ where
                     )
                 } else {
                     contact_manifolds_heightfield_shape_shapes(
-                        self, pos12, shape1, shape2, prediction, manifolds, workspace,
+                        root_dispatcher,
+                        pos12,
+                        shape1,
+                        shape2,
+                        prediction,
+                        manifolds,
+                        workspace,
                     );
                 }
             }
             _ => {
                 if let Some(composite1) = composite1 {
                     contact_manifolds_composite_shape_shape(
-                        self, pos12, composite1, shape2, prediction, manifolds, workspace, false,
+                        root_dispatcher,
+                        pos12,
+                        composite1,
+                        shape2,
+                        prediction,
+                        manifolds,
+                        workspace,
+                        false,
                     );
                 } else if let Some(composite2) = composite2 {
                     contact_manifolds_composite_shape_shape(
-                        self,
+                        root_dispatcher,
                         &pos12.inverse(),
                         composite2,
                         shape1,
@@ -511,7 +588,7 @@ where
                         manifolds.push(ContactManifold::new());
                     }
 
-                    return self.contact_manifold_convex_convex(
+                    return root_dispatcher.contact_manifold_convex_convex(
                         pos12,
                         shape1,
                         shape2,

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -15,7 +15,7 @@ use crate::query::{
 use crate::shape::{HalfSpace, Segment, Shape, ShapeType};
 
 /// A dispatcher that exposes built-in queries
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct DefaultQueryDispatcher;
 
 impl QueryDispatcherComposite for DefaultQueryDispatcher {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -38,8 +38,8 @@ pub use self::intersection_test::intersection_test;
 pub use self::nonlinear_shape_cast::{cast_shapes_nonlinear, NonlinearRigidMotion};
 pub use self::point::{PointProjection, PointQuery, PointQueryWithLocation};
 #[cfg(feature = "std")]
-pub use self::query_dispatcher::PersistentQueryDispatcher;
-pub use self::query_dispatcher::{QueryDispatcher, QueryDispatcherChain};
+pub use self::query_dispatcher::{PersistentQueryDispatcher, PersistentQueryDispatcherComposite};
+pub use self::query_dispatcher::{QueryDispatcher, QueryDispatcherChain, QueryDispatcherComposite};
 pub use self::ray::{Ray, RayCast, RayIntersection, SimdRay};
 pub use self::shape_cast::{cast_shapes, ShapeCastHit, ShapeCastOptions, ShapeCastStatus};
 pub use self::split::{IntersectResult, SplitResult};

--- a/src/query/query_dispatcher.rs
+++ b/src/query/query_dispatcher.rs
@@ -10,6 +10,42 @@ use crate::shape::Shape;
 
 #[cfg(feature = "std")]
 /// A query dispatcher for queries relying on spatial coherence, including contact-manifold computation.
+///
+/// Third-party crates adding custom shapes should implement
+/// this trait to allow pair-wise queries between the added shape and other shapes.
+///
+/// The `root_dispatcher` argument is a reference to the root dispatcher of the composite dispatcher.
+/// This is necessary to support recursive dispatching for composite shapes.
+pub trait PersistentQueryDispatcherComposite<ManifoldData = (), ContactData = ()>:
+    QueryDispatcherComposite
+{
+    fn contact_manifolds(
+        &self,
+        root_dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
+        pos12: &Isometry<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+        prediction: Real,
+        manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+        workspace: &mut Option<ContactManifoldsWorkspace>,
+    ) -> Result<(), Unsupported>;
+
+    fn contact_manifold_convex_convex(
+        &self,
+        pos12: &Isometry<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+        normal_constraints1: Option<&dyn NormalConstraints>,
+        normal_constraints2: Option<&dyn NormalConstraints>,
+        prediction: Real,
+        manifold: &mut ContactManifold<ManifoldData, ContactData>,
+    ) -> Result<(), Unsupported>;
+}
+
+#[cfg(feature = "std")]
+/// A query dispatcher for queries relying on spatial coherence, including contact-manifold computation.
+///
+/// This trait should not be implemented. Instead, implement the [`PersistentQueryDispatcherComposite`] trait.
 pub trait PersistentQueryDispatcher<ManifoldData = (), ContactData = ()>: QueryDispatcher {
     /// Compute all the contacts between two shapes.
     ///
@@ -41,10 +77,109 @@ pub trait PersistentQueryDispatcher<ManifoldData = (), ContactData = ()>: QueryD
     ) -> Result<(), Unsupported>;
 }
 
+impl<T, ManifoldData, ContactData> PersistentQueryDispatcher<ManifoldData, ContactData> for T
+where
+    T: PersistentQueryDispatcherComposite<ManifoldData, ContactData>,
+{
+    fn contact_manifolds(
+        &self,
+        pos12: &Isometry<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+        prediction: Real,
+        manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+        workspace: &mut Option<ContactManifoldsWorkspace>,
+    ) -> Result<(), Unsupported> {
+        <Self as PersistentQueryDispatcherComposite<ManifoldData, ContactData>>::contact_manifolds(
+            self, self, pos12, g1, g2, prediction, manifolds, workspace,
+        )
+    }
+
+    fn contact_manifold_convex_convex(
+        &self,
+        pos12: &Isometry<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+        normal_constraints1: Option<&dyn NormalConstraints>,
+        normal_constraints2: Option<&dyn NormalConstraints>,
+        prediction: Real,
+        manifold: &mut ContactManifold<ManifoldData, ContactData>,
+    ) -> Result<(), Unsupported> {
+        <Self as PersistentQueryDispatcherComposite<ManifoldData, ContactData>>::contact_manifold_convex_convex(self, pos12, g1, g2, normal_constraints1, normal_constraints2, prediction, manifold)
+    }
+}
+
 /// Dispatcher for pairwise queries.
 ///
-/// Custom implementations allow crates that support an abstract `QueryDispatcher` to handle custom
-/// shapes.
+/// Third-party crates adding custom shapes should implement
+/// this trait to allow pair-wise queries between the added shape and other shapes.
+///
+/// The `pos12` argument to most queries is the transform from the local space of `g2` to that of
+/// `g1`.
+///
+/// The `root_dispatcher` argument is a reference to the root dispatcher of the composite dispatcher.
+/// This is necessary to support recursive dispatching for composite shapes.
+pub trait QueryDispatcherComposite: Send + Sync {
+    fn intersection_test(
+        &self,
+        root_dispatcher: &dyn QueryDispatcher,
+        pos12: &Isometry<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+    ) -> Result<bool, Unsupported>;
+
+    fn distance(
+        &self,
+        root_dispatcher: &dyn QueryDispatcher,
+        pos12: &Isometry<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+    ) -> Result<Real, Unsupported>;
+
+    fn contact(
+        &self,
+        root_dispatcher: &dyn QueryDispatcher,
+        pos12: &Isometry<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+        prediction: Real,
+    ) -> Result<Option<Contact>, Unsupported>;
+
+    fn closest_points(
+        &self,
+        root_dispatcher: &dyn QueryDispatcher,
+        pos12: &Isometry<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+        max_dist: Real,
+    ) -> Result<ClosestPoints, Unsupported>;
+
+    fn cast_shapes(
+        &self,
+        root_dispatcher: &dyn QueryDispatcher,
+        pos12: &Isometry<Real>,
+        local_vel12: &Vector<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+        options: ShapeCastOptions,
+    ) -> Result<Option<ShapeCastHit>, Unsupported>;
+
+    fn cast_shapes_nonlinear(
+        &self,
+        root_dispatcher: &dyn QueryDispatcher,
+        motion1: &NonlinearRigidMotion,
+        g1: &dyn Shape,
+        motion2: &NonlinearRigidMotion,
+        g2: &dyn Shape,
+        start_time: Real,
+        end_time: Real,
+        stop_at_penetration: bool,
+    ) -> Result<Option<ShapeCastHit>, Unsupported>;
+}
+
+/// Dispatcher for pairwise queries.
+///
+/// This trait should not be implemented. Instead, implement the [`QueryDispatcherComposite`] trait.
 ///
 /// The `pos12` argument to most queries is the transform from the local space of `g2` to that of
 /// `g1`.
@@ -113,7 +248,7 @@ pub trait QueryDispatcher: Send + Sync {
     ) -> Result<Option<ShapeCastHit>, Unsupported>;
 
     /// Construct a `QueryDispatcher` that falls back on `other` for cases not handled by `self`
-    fn chain<U: QueryDispatcher>(self, other: U) -> QueryDispatcherChain<Self, U>
+    fn chain<U: QueryDispatcherComposite>(self, other: U) -> QueryDispatcherChain<Self, U>
     where
         Self: Sized,
     {
@@ -148,6 +283,88 @@ pub trait QueryDispatcher: Send + Sync {
     ) -> Result<Option<ShapeCastHit>, Unsupported>;
 }
 
+impl<T: QueryDispatcherComposite> QueryDispatcher for T {
+    fn intersection_test(
+        &self,
+        pos12: &Isometry<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+    ) -> Result<bool, Unsupported> {
+        <Self as QueryDispatcherComposite>::intersection_test(self, self, pos12, g1, g2)
+    }
+
+    fn distance(
+        &self,
+        pos12: &Isometry<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+    ) -> Result<Real, Unsupported> {
+        <Self as QueryDispatcherComposite>::distance(self, self, pos12, g1, g2)
+    }
+
+    fn contact(
+        &self,
+        pos12: &Isometry<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+        prediction: Real,
+    ) -> Result<Option<Contact>, Unsupported> {
+        <Self as QueryDispatcherComposite>::contact(self, self, pos12, g1, g2, prediction)
+    }
+
+    fn closest_points(
+        &self,
+        pos12: &Isometry<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+        max_dist: Real,
+    ) -> Result<ClosestPoints, Unsupported> {
+        <Self as QueryDispatcherComposite>::closest_points(self, self, pos12, g1, g2, max_dist)
+    }
+
+    fn cast_shapes(
+        &self,
+        pos12: &Isometry<Real>,
+        local_vel12: &Vector<Real>,
+        g1: &dyn Shape,
+        g2: &dyn Shape,
+        options: ShapeCastOptions,
+    ) -> Result<Option<ShapeCastHit>, Unsupported> {
+        <Self as QueryDispatcherComposite>::cast_shapes(
+            self,
+            self,
+            pos12,
+            local_vel12,
+            g1,
+            g2,
+            options,
+        )
+    }
+
+    fn cast_shapes_nonlinear(
+        &self,
+        motion1: &NonlinearRigidMotion,
+        g1: &dyn Shape,
+        motion2: &NonlinearRigidMotion,
+        g2: &dyn Shape,
+        start_time: Real,
+        end_time: Real,
+        stop_at_penetration: bool,
+    ) -> Result<Option<ShapeCastHit>, Unsupported> {
+        <Self as QueryDispatcherComposite>::cast_shapes_nonlinear(
+            self,
+            self,
+            motion1,
+            g1,
+            motion2,
+            g2,
+            start_time,
+            end_time,
+            stop_at_penetration,
+        )
+    }
+}
+
 /// The composition of two dispatchers
 pub struct QueryDispatcherChain<T, U>(T, U);
 
@@ -161,20 +378,23 @@ macro_rules! chain_method {
     }
 }
 
-impl<T, U> QueryDispatcher for QueryDispatcherChain<T, U>
+impl<T, U> QueryDispatcherComposite for QueryDispatcherChain<T, U>
 where
-    T: QueryDispatcher,
-    U: QueryDispatcher,
+    T: QueryDispatcherComposite,
+    U: QueryDispatcherComposite,
 {
     chain_method!(intersection_test(
+        root_dispatcher: &dyn QueryDispatcher,
         pos12: &Isometry<Real>,
         g1: &dyn Shape,
         g2: &dyn Shape,
     ) -> bool);
 
-    chain_method!(distance(pos12: &Isometry<Real>, g1: &dyn Shape, g2: &dyn Shape,) -> Real);
+    chain_method!(distance(
+        root_dispatcher: &dyn QueryDispatcher, pos12: &Isometry<Real>, g1: &dyn Shape, g2: &dyn Shape,) -> Real);
 
     chain_method!(contact(
+        root_dispatcher: &dyn QueryDispatcher,
         pos12: &Isometry<Real>,
         g1: &dyn Shape,
         g2: &dyn Shape,
@@ -182,6 +402,7 @@ where
     ) -> Option<Contact>);
 
     chain_method!(closest_points(
+        root_dispatcher: &dyn QueryDispatcher,
         pos12: &Isometry<Real>,
         g1: &dyn Shape,
         g2: &dyn Shape,
@@ -189,6 +410,7 @@ where
     ) -> ClosestPoints);
 
     chain_method!(cast_shapes(
+        root_dispatcher: &dyn QueryDispatcher,
         pos12: &Isometry<Real>,
         vel12: &Vector<Real>,
         g1: &dyn Shape,
@@ -197,6 +419,7 @@ where
     ) -> Option<ShapeCastHit>);
 
     chain_method!(cast_shapes_nonlinear(
+        root_dispatcher: &dyn QueryDispatcher,
         motion1: &NonlinearRigidMotion,
         g1: &dyn Shape,
         motion2: &NonlinearRigidMotion,
@@ -208,13 +431,14 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<ManifoldData, ContactData, T, U> PersistentQueryDispatcher<ManifoldData, ContactData>
+impl<ManifoldData, ContactData, T, U> PersistentQueryDispatcherComposite<ManifoldData, ContactData>
     for QueryDispatcherChain<T, U>
 where
-    T: PersistentQueryDispatcher<ManifoldData, ContactData>,
-    U: PersistentQueryDispatcher<ManifoldData, ContactData>,
+    T: PersistentQueryDispatcherComposite<ManifoldData, ContactData>,
+    U: PersistentQueryDispatcherComposite<ManifoldData, ContactData>,
 {
     chain_method!(contact_manifolds(
+        root_dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
         pos12: &Isometry<Real>,
         g1: &dyn Shape,
         g2: &dyn Shape,

--- a/src/query/query_dispatcher.rs
+++ b/src/query/query_dispatcher.rs
@@ -19,6 +19,13 @@ use crate::shape::Shape;
 pub trait PersistentQueryDispatcherComposite<ManifoldData = (), ContactData = ()>:
     QueryDispatcherComposite
 {
+    /// Compute all the contacts between two shapes.
+    ///
+    /// The output is written into `manifolds` and `context`. Both can persist
+    /// between multiple calls to `contacts` by re-using the result of the previous
+    /// call to `contacts`. This persistence can significantly improve collision
+    /// detection performances by allowing the underlying algorithms to exploit
+    /// spatial and temporal coherence.
     fn contact_manifolds(
         &self,
         root_dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
@@ -30,6 +37,7 @@ pub trait PersistentQueryDispatcherComposite<ManifoldData = (), ContactData = ()
         workspace: &mut Option<ContactManifoldsWorkspace>,
     ) -> Result<(), Unsupported>;
 
+    /// Computes the contact-manifold between two convex shapes.
     fn contact_manifold_convex_convex(
         &self,
         pos12: &Isometry<Real>,

--- a/src/query/query_dispatcher.rs
+++ b/src/query/query_dispatcher.rs
@@ -366,6 +366,7 @@ impl<T: QueryDispatcherComposite> QueryDispatcher for T {
 }
 
 /// The composition of two dispatchers
+#[derive(Clone, Copy, Debug)]
 pub struct QueryDispatcherChain<T, U>(T, U);
 
 macro_rules! chain_method {

--- a/src/query/query_dispatcher.rs
+++ b/src/query/query_dispatcher.rs
@@ -85,6 +85,7 @@ pub trait PersistentQueryDispatcher<ManifoldData = (), ContactData = ()>: QueryD
     ) -> Result<(), Unsupported>;
 }
 
+#[cfg(feature = "std")]
 impl<T, ManifoldData, ContactData> PersistentQueryDispatcher<ManifoldData, ContactData> for T
 where
     T: PersistentQueryDispatcherComposite<ManifoldData, ContactData>,


### PR DESCRIPTION
Resolves #8 

Implements @Ralith 's suggestion regarding composable `QueryDispatcher`.

> End-user ergonomics could be preserved by relegating the root_dispatcher argument to a trait for use only by shape implementers, and turning `QueryDispatcher` into a blanket-implemented trait that encapsulates the self.query(self, ...) dance, and provides a chain helper for composition.

I prefer this solution over the one suggested by @sebcrozet because @Ralith 's solution allows external crates to composably define shapes that need to dispatch recursively.