### PR TITLE
explore examples using bevy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/parry2d", "crates/parry3d", "crates/parry2d-f64", "crates/parry3d-f64"]
+members = ["crates/parry2d", "crates/parry3d", "crates/parry2d-f64", "crates/parry3d-f64", "crates/bevy_examples"]
 resolver = "2"
 
 [patch.crates-io]

--- a/crates/bevy_examples/Cargo.toml
+++ b/crates/bevy_examples/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bevy_examples"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bevy = { version = "0.14.0", default-features = false, features = [
+    "bevy_gizmos",
+    "bevy_sprite",
+    "bevy_winit",
+] }
+parry2d = { version = "0.16.1", path = "../parry2d" }
+nalgebra = { version = "0.33.0", features = ["convert-glam027"] }

--- a/crates/bevy_examples/src/main.rs
+++ b/crates/bevy_examples/src/main.rs
@@ -1,0 +1,95 @@
+use nalgebra::{Point2, UnitComplex};
+use parry2d::{self as parry, utils::point_in_poly2d};
+
+use bevy::{color::palettes, prelude::*};
+
+type Point = Point2<f32>;
+
+#[derive(Resource)]
+pub struct RapierContext {
+    pub spikes: Vec<Point>,
+    pub test_points: Vec<Vec2>,
+}
+
+fn main() {
+    let mut app = App::new();
+
+    app.add_plugins(DefaultPlugins);
+    app.add_systems(Startup, init_physics);
+    app.add_systems(Update, (rotate, show_physics).chain());
+
+    app.run();
+}
+
+fn init_physics(mut commands: Commands) {
+    let spikes = spikes_polygon();
+    let test_points = grid_points();
+
+    commands.insert_resource(RapierContext {
+        spikes,
+        test_points,
+    });
+    commands.spawn(Camera2dBundle::default());
+}
+
+fn rotate(mut physics: ResMut<RapierContext>) {
+    let animation_rotation = UnitComplex::new(0.02);
+    physics
+        .spikes
+        .iter_mut()
+        .for_each(|pt| *pt = animation_rotation * *pt);
+}
+
+fn show_physics(mut gizmos: Gizmos, physics: Res<RapierContext>) {
+    for p in &physics.test_points {
+        let color = if point_in_poly2d(&Point::from(*p), &physics.spikes) {
+            palettes::basic::RED
+        } else {
+            palettes::basic::GREEN
+        };
+        gizmos.circle_2d(*p, 3f32, color);
+    }
+    let spike_len = physics.spikes.len();
+    for i in 0..spike_len {
+        let a = physics.spikes[i];
+        let b = physics.spikes[(i + 1) % spike_len];
+        gizmos.line_2d(a.into(), b.into(), palettes::basic::BLUE);
+    }
+}
+
+fn spikes_polygon() -> Vec<Point> {
+    let teeths = 3;
+    let width = 15.0 * 30f32;
+    let height = 7.5 * 30f32;
+    let tooth_width = width / (teeths as f32);
+    let center = Point::new(width / 2.0, height / 2.0);
+
+    let mut polygon: Vec<Point> = vec![
+        (Point::new(width, 0.0) - center).into(),
+        (Point::new(width, height) - center).into(),
+        (Point::new(0.0, height) - center).into(),
+    ];
+
+    for i in 0..teeths {
+        let x = i as f32 * tooth_width;
+        polygon.push((Point::new(x, 0.0) - center).into());
+        polygon.push((Point::new(x + tooth_width / 2.0, height * 1.5) - center).into());
+    }
+
+    polygon
+}
+
+fn grid_points() -> Vec<Vec2> {
+    let count = 40;
+    let spacing = 20f32;
+    let mut pts = vec![];
+    for i in 0..count {
+        for j in 0..count {
+            pts.push(Vec2::new(
+                (i as f32 - count as f32 / 2.0) * spacing,
+                (j as f32 - count as f32 / 2.0) * spacing,
+            ));
+        }
+    }
+    pts
+}


### PR DESCRIPTION
An experiment to see how bevy could be used as a rendering backend for examples.

The code can be quite similar to macroquad's when using gizmos.

The big downside of using bevy is that compilation time is 2.5x slower (your mileage may vary), see attached timings (~40 seconds with macroquad, ~110 seconds with bevy) :

[timings.zip](https://github.com/user-attachments/files/16131361/timings.zip)

I think it makes sense to keep macroquad while we don't need more advanced features.

If/when we need more, it's encouraging that we can migrate to bevy rather easily.