### PR TITLE
ci: Add `build-doc` job to test building docs.

### DIFF
--- a/.github/workflows/parry-ci-build.yml
+++ b/.github/workflows/parry-ci-build.yml
@@ -67,3 +67,15 @@ jobs:
         run: xargo build --verbose --no-default-features --features required-features --target=x86_64-unknown-linux-gnu;
       - name: build thumbv7em-none-eabihf
         run: xargo build --verbose --no-default-features --features required-features --target=thumbv7em-none-eabihf;
+  build-doc:
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      - name: install stable Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: stable
+      - name: cargo doc
+        run: cargo doc --workspace --features bytemuck-serialize,serde-serialize,rkyv-serialize,parallel --no-deps --document-private-items

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -347,7 +347,7 @@ pub trait Shape: RayCast + PointQuery + DowncastSync {
     ///
     /// In some cases, the resulting shape doesn’t have the same type as Self. For example,
     /// if a non-uniform scale is provided and Self as a [`Ball`], then the result will be discretized
-    /// (based on the `num_subdivisions` parameter) as a [`ConvexPolyhedron`] (in 3D) or [`ConvexPolygon`] (in 2D).
+    /// (based on the `num_subdivisions` parameter) as a `ConvexPolyhedron` (in 3D) or `ConvexPolygon` (in 2D).
     #[cfg(feature = "std")]
     fn scale_dyn(&self, scale: &Vector<Real>, num_subdivisions: u32) -> Option<Box<dyn Shape>>;
 


### PR DESCRIPTION
This doesn't use nightly (like docs.rs does) because there are other warnings on nightly builds that would break this.

Also, I used `parallel` here but that isn't tested yet by other build configs.