### PR TITLE
Fix rustdoc error in `Triangle`.

### DIFF
--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -893,10 +893,13 @@ impl Shape for Triangle {
 
     fn feature_normal_at_point(
         &self,
-        feature: FeatureId,
+        _feature: FeatureId,
         _point: &Point<Real>,
     ) -> Option<Unit<Vector<Real>>> {
-        self.feature_normal(feature)
+        #[cfg(feature = "dim2")]
+        return None;
+        #[cfg(feature = "dim3")]
+        return self.feature_normal(_feature);
     }
 }
 

--- a/src/shape/triangle.rs
+++ b/src/shape/triangle.rs
@@ -1,15 +1,20 @@
 //! Definition of the triangle shape.
 
 use crate::math::{Isometry, Point, Real, Vector};
-use crate::shape::{FeatureId, SupportMap};
+use crate::shape::{ SupportMap};
 use crate::shape::{PolygonalFeature, Segment};
 use crate::utils;
 
 use na::{self, ComplexField, Unit};
 use num::Zero;
-#[cfg(feature = "dim3")]
-use std::f64;
 use std::mem;
+
+
+#[cfg(feature = "dim3")]
+use {
+    std::f64,
+    crate::shape::{self, FeatureId},
+};
 
 #[cfg(feature = "dim2")]
 use crate::shape::PackedFeatureId;
@@ -138,6 +143,7 @@ impl Triangle {
     /// The normal points such that it is collinear to `AB × AC` (where `×` denotes the cross
     /// product).
     #[inline]
+    #[cfg(feature = "dim3")]
     pub fn normal(&self) -> Option<Unit<Vector<Real>>> {
         Unit::try_new(self.scaled_normal(), crate::math::DEFAULT_EPSILON)
     }
@@ -232,10 +238,10 @@ impl Triangle {
     /// product).
     ///
     /// Note that on thin triangles the calculated normals can suffer from numerical issues.
-    #[cfg_attr(feature = "dim3", doc = "For a more robust (but more computationally")]
-    #[cfg_attr(feature = "dim3", doc = "expensive) normal calculation, see")]
-    #[cfg_attr(feature = "dim3", doc = "[`Triangle::robust_scaled_normal`].")]
+    /// For a more robust (but more computationally expensive) normal calculation, see
+    /// [`Triangle::robust_scaled_normal`].
     #[inline]
+    #[cfg(feature = "dim3")]
     pub fn scaled_normal(&self) -> Vector<Real> {
         let ab = self.b - self.a;
         let ac = self.c - self.a;
@@ -537,6 +543,7 @@ impl Triangle {
     }
 
     /// The normal of the given feature of this shape.
+    #[cfg(feature = "dim3")]
     pub fn feature_normal(&self, _: FeatureId) -> Option<Unit<Vector<Real>>> {
         self.normal()
     }

--- a/src/shape/triangle.rs
+++ b/src/shape/triangle.rs
@@ -1,7 +1,7 @@
 //! Definition of the triangle shape.
 
 use crate::math::{Isometry, Point, Real, Vector};
-use crate::shape::{ SupportMap};
+use crate::shape::SupportMap;
 use crate::shape::{PolygonalFeature, Segment};
 use crate::utils;
 
@@ -9,11 +9,10 @@ use na::{self, ComplexField, Unit};
 use num::Zero;
 use std::mem;
 
-
 #[cfg(feature = "dim3")]
 use {
-    std::f64,
     crate::shape::{self, FeatureId},
+    std::f64,
 };
 
 #[cfg(feature = "dim2")]

--- a/src/shape/triangle.rs
+++ b/src/shape/triangle.rs
@@ -10,10 +10,7 @@ use num::Zero;
 use std::mem;
 
 #[cfg(feature = "dim3")]
-use {
-    crate::shape::{self, FeatureId},
-    std::f64,
-};
+use {crate::shape::FeatureId, std::f64};
 
 #[cfg(feature = "dim2")]
 use crate::shape::PackedFeatureId;

--- a/src/shape/triangle.rs
+++ b/src/shape/triangle.rs
@@ -230,9 +230,11 @@ impl Triangle {
     ///
     /// The vector points such that it is collinear to `AB × AC` (where `×` denotes the cross
     /// product).
+    ///
     /// Note that on thin triangles the calculated normals can suffer from numerical issues.
-    /// For a more robust (but more computationally expensive) normal calculation, see
-    /// [`Triangle::robust_scaled_normal`].
+    #[cfg_attr(feature = "dim3", doc = "For a more robust (but more computationally")]
+    #[cfg_attr(feature = "dim3", doc = "expensive) normal calculation, see")]
+    #[cfg_attr(feature = "dim3", doc = "[`Triangle::robust_scaled_normal`].")]
     #[inline]
     pub fn scaled_normal(&self) -> Vector<Real> {
         let ab = self.b - self.a;


### PR DESCRIPTION
Commit 4ffa010f99a38ebd6d7ac763355403e98454fc09 introduced a method that is only available with feature = "dim3", but a method that is present when feature = "dim2" was linking to it. The doc commnets referencing it must be protected by `cfg_attr` checks.