### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## v0.17.0
 
 ### Added
 

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.16.1"
+version = "0.17.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.16.1"
+version = "0.17.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.16.1"
+version = "0.17.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.16.1"
+version = "0.17.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."


### PR DESCRIPTION
## v0.17.0

### Added

- Add `Triangle::robust_scaled_normal` and `Triangle::robust_normal` as a more robust way to compute the triangles
  normal for thin triangles that generally cause numerical instabilities.
- Add `Triangle::angle_closest_to_90` to find the triangle’s vertex with an angle closest to 90 degree.
- Add the `wavefront` feature that enables `TriMesh::to_obj_file` for exporting a mesh as an obj file.
- Add `Shape::scale_dyn` for scaling a shape as a trait-object.

### Modified

- `TypedShape::Custom(u32)` is now `TypedShape::Custom(&dyn Shape)`.
- `AabbSetsInterferencesCollector::tolerence` is now spelled correctly as `tolerance`.
- `Real` is now exposed through a `use` statement,
  so that an indirection is removed in documentation:
  previous occurrences of `Real` now show `f32` or `f64`.
- Significantly improved the general stability of mesh/mesh intersection calculation.
- Rename `Shape::clone_box` to `Shape::clone_dyn` (the `clone_box` method still exists but has been
  deprecated).
- Make `try_convex_hull` return an error instead of panicking if less than 3 input points are given.
