### PR TITLE
Fix `unexpected_cfgs` warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 members = ["crates/parry2d", "crates/parry3d", "crates/parry2d-f64", "crates/parry3d-f64"]
 resolver = "2"
 
+[workspace.lints]
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("dim2", "dim3", "f32", "f64"))',
+    # This one should be investigated as to why it exists, not hooked up, etc.
+    'cfg(feature, values("improved_fixed_point_support"))',
+] }
+
 [patch.crates-io]
 parry2d = { path = "crates/parry2d" }
 parry3d = { path = "crates/parry3d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ resolver = "2"
 [workspace.lints]
 rust.unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(feature, values("dim2", "dim3", "f32", "f64"))',
-    # This one should be investigated as to why it exists, not hooked up, etc.
-    'cfg(feature, values("improved_fixed_point_support"))',
+    # "wavefront" is only used for 3D crates.
+    'cfg(feature, values("wavefront"))',
 ] }
 
 [patch.crates-io]

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -16,6 +16,9 @@ edition = "2021"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[lints]
+workspace = true
+
 [features]
 default = ["required-features", "std"]
 required-features = ["dim2", "f64"]

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -16,6 +16,9 @@ edition = "2021"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[lints]
+workspace = true
+
 [features]
 default = ["required-features", "std"]
 required-features = ["dim2", "f32"]

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -16,6 +16,9 @@ edition = "2021"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[lints]
+workspace = true
+
 [features]
 default = ["required-features", "std"]
 required-features = ["dim3", "f64"]

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -16,6 +16,9 @@ edition = "2021"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[lints]
+workspace = true
+
 [features]
 default = ["required-features", "std"]
 required-features = ["dim3", "f32"]


### PR DESCRIPTION
This will add a one line warning from `cargo` until 1.80 (which is due for release soon).