### PR TITLE
Fix `clippy::doc_lazy_continuation` lints

### DIFF
--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -90,7 +90,7 @@ impl Aabb {
     /// # Arguments:
     ///   * `mins` - position of the point with the smallest coordinates.
     ///   * `maxs` - position of the point with the highest coordinates. Each component of `mins`
-    ///   must be smaller than the related components of `maxs`.
+    ///     must be smaller than the related components of `maxs`.
     #[inline]
     pub fn new(mins: Point<Real>, maxs: Point<Real>) -> Aabb {
         Aabb { mins, maxs }

--- a/src/query/gjk/gjk.rs
+++ b/src/query/gjk/gjk.rs
@@ -76,10 +76,10 @@ pub fn project_origin<G: ?Sized + SupportMap>(
 /// * simplex - the simplex to be used by the GJK algorithm. It must be already initialized
 ///             with at least one point on the shape boundary.
 /// * exact_dist - if `false`, the gjk will stop as soon as it can prove that the origin is at
-/// a distance smaller than `max_dist` but not inside of `shape`. In that case, it returns a
-/// `GJKResult::Proximity(sep_axis)` where `sep_axis` is a separating axis. If `false` the gjk will
-/// compute the exact distance and return `GJKResult::Projection(point)` if the origin is closer
-/// than `max_dist` but not inside `shape`.
+///   a distance smaller than `max_dist` but not inside of `shape`. In that case, it returns a
+///   `GJKResult::Proximity(sep_axis)` where `sep_axis` is a separating axis. If `false` the gjk will
+///   compute the exact distance and return `GJKResult::Projection(point)` if the origin is closer
+///   than `max_dist` but not inside `shape`.
 pub fn closest_points<G1, G2>(
     pos12: &Isometry<Real>,
     g1: &G1,

--- a/src/shape/polyline.rs
+++ b/src/shape/polyline.rs
@@ -218,6 +218,7 @@ impl Polyline {
     ///   `num_indices == self.indices.len()`.
     /// - This polyline is oriented counter-clockwise.
     /// - In 3D, the polyline is assumed to be fully coplanar, on a plane with normal given by
+    ///
     /// These properties are not checked.
     pub fn project_local_point_assuming_solid_interior_ccw(
         &self,


### PR DESCRIPTION
These are new in Rust 1.80