### PR TITLE
Improve convergence of epa algorithm in case it's stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Modified
+
+- Improve convergence of epa algorithm in degenerate configurations.
+
 ## v0.17.0
 
 ### Added

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -90,7 +90,7 @@ simba = { version = "0.9", default-features = false }
 oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }
-macroquad = "0.4"
+macroquad = "0.4.12"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]

--- a/crates/parry2d/tests/geometry/epa_convergence.rs
+++ b/crates/parry2d/tests/geometry/epa_convergence.rs
@@ -1,0 +1,42 @@
+use na::Vector2;
+use parry2d::{
+    math::{Isometry, Point, Real},
+    query,
+    shape::{Capsule, ConvexPolygon, SharedShape},
+};
+
+/// Original issue: https://github.com/dimforge/parry/issues/205
+#[test]
+fn capsule_convergence() {
+    let shape1 = Capsule::new_y(5.0, 10.0);
+    let mut vec = Vec::<Point<Real>>::with_capacity(3);
+    vec.push(Point::<Real>::new(64.0, 507.0));
+    vec.push(Point::<Real>::new(440.0, 326.0));
+    vec.push(Point::<Real>::new(1072.0, 507.0));
+    let shape2 = ConvexPolygon::from_convex_polyline(vec);
+    let shape2 = shape2.unwrap();
+    let transform1 = Isometry::new(Vector2::new(381.592, 348.491), 0.0);
+    let transform2 = Isometry::new(Vector2::new(0.0, 0.0), 0.0);
+
+    let _res = query::details::contact_support_map_support_map(
+        &transform1.inv_mul(&transform2),
+        &shape1,
+        &shape2,
+        10.0,
+    )
+    .expect("Penetration not found.");
+    let shared_shape1 = SharedShape::new(shape1);
+    let shared_shape2 = SharedShape::new(shape2);
+
+    if let Ok(Some(_contact)) = query::contact(
+        &transform1,
+        shared_shape1.as_ref(),
+        &transform2,
+        shared_shape2.as_ref(),
+        1.0,
+    ) {
+        println!("collision");
+    } else {
+        panic!("no collision");
+    }
+}

--- a/crates/parry2d/tests/geometry/mod.rs
+++ b/crates/parry2d/tests/geometry/mod.rs
@@ -2,5 +2,6 @@ mod aabb_scale;
 mod ball_ball_toi;
 mod ball_cuboid_contact;
 mod epa2;
+mod epa_convergence;
 mod ray_cast;
 mod time_of_impact2;

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -88,7 +88,7 @@ obj = { version = "0.10.2", optional = true }
 oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }
-macroquad = "0.4"
+macroquad = "0.4.12"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]

--- a/crates/parry3d/examples/plane_intersection.rs
+++ b/crates/parry3d/examples/plane_intersection.rs
@@ -88,7 +88,8 @@ fn mquad_mesh_from_points(trimesh: &(Vec<Point3<Real>>, Vec<[u32; 3]>), camera_p
             .map(|p| Vertex {
                 position: mquad_from_na(*p),
                 uv: Vec2::new(p.x, p.y),
-                color: DARKGRAY,
+                color: DARKGRAY.into(),
+                normal: Vec4::ZERO,
             })
             .collect(),
         indices.iter().flatten().map(|v| *v as u16).collect(),
@@ -125,14 +126,15 @@ fn mquad_compute_normals(points: &Vec<Vertex>, indices: &Vec<u16>, cam_pos: Vec3
 
         for &i in indices.iter() {
             let mut color = points[i as usize].color;
-            color.r *= brightness_mod;
-            color.g *= brightness_mod;
-            color.b *= brightness_mod;
+            color[0] = (color[0] as f32 * brightness_mod) as u8;
+            color[1] = (color[1] as f32 * brightness_mod) as u8;
+            color[2] = (color[2] as f32 * brightness_mod) as u8;
 
             vertices.push(Vertex {
                 position: points[i as usize].position,
                 uv: Vec2::ZERO,
                 color: color,
+                normal: Vec4::ZERO,
             });
         }
     }

--- a/src/query/epa/epa2.rs
+++ b/src/query/epa/epa2.rs
@@ -164,7 +164,7 @@ impl EPA {
         G2: ?Sized + SupportMap,
     {
         let _eps: Real = crate::math::DEFAULT_EPSILON;
-        let _eps_tol = _eps * 100.0;
+        let _eps_tol = _eps * 1000.0;
 
         self.reset();
 

--- a/src/query/epa/epa2.rs
+++ b/src/query/epa/epa2.rs
@@ -333,7 +333,7 @@ impl EPA {
             }
 
             niter += 1;
-            eprintln!("Iteration {}: dir = {:?}, curr_dist = {}, candidate_max_dist = {} max_dist = {}, support_point_id = {}", niter, curr_dist, candidate_max_dist, max_dist, support_point_id);
+            eprintln!("Iteration {}: curr_dist = {}, candidate_max_dist = {} max_dist = {}, support_point_id = {}", niter, curr_dist, candidate_max_dist, max_dist, support_point_id);
             if niter > 10000 {
                 return None;
             }

--- a/src/query/epa/epa2.rs
+++ b/src/query/epa/epa2.rs
@@ -334,7 +334,7 @@ impl EPA {
 
             niter += 1;
             eprintln!("Iteration {}: curr_dist = {}, candidate_max_dist = {} max_dist = {}, support_point_id = {}", niter, curr_dist, candidate_max_dist, max_dist, support_point_id);
-            if niter > 10000 {
+            if niter > 100 {
                 return None;
             }
         }

--- a/src/query/epa/epa2.rs
+++ b/src/query/epa/epa2.rs
@@ -333,9 +333,6 @@ impl EPA {
             }
 
             niter += 1;
-            if niter % 1000 == 0 {
-                eprintln!("Iteration {}: dir = {:?}, max_dist = {}, curr_dist = {} support_point_id = {} candidate_max_dist = {}", niter, dir, max_dist, curr_dist, support_point_id, candidate_max_dist);
-            }
             if niter > 10000 {
                 return None;
             }

--- a/src/query/epa/epa2.rs
+++ b/src/query/epa/epa2.rs
@@ -334,7 +334,7 @@ impl EPA {
 
             niter += 1;
             if niter % 1000 == 0 {
-                eprintln!("Iteration {}: dir = {:?}, max_bound = {}, min_bound = {}", niter, dir, max_bound, min_bound);
+                eprintln!("Iteration {}: dir = {:?}, max_dist = {}, curr_dist = {} support_point_id = {} candidate_max_dist = {}", niter, dir, max_dist, curr_dist, support_point_id, candidate_max_dist);
             }
             if niter > 10000 {
                 return None;

--- a/src/query/epa/epa2.rs
+++ b/src/query/epa/epa2.rs
@@ -333,6 +333,9 @@ impl EPA {
             }
 
             niter += 1;
+            if niter % 1000 == 0 {
+                eprintln!("Iteration {}: dir = {:?}, max_bound = {}, min_bound = {}", niter, dir, max_bound, min_bound);
+            }
             if niter > 10000 {
                 return None;
             }

--- a/src/query/epa/epa2.rs
+++ b/src/query/epa/epa2.rs
@@ -304,7 +304,8 @@ impl EPA {
             if max_dist - curr_dist < _eps_tol ||
                 // Accept the intersection as the algorithm is stuck and no new points will be found
                 // This happens because of numerical stability issue
-                ((curr_dist - old_dist).abs() < _eps && candidate_max_dist < max_dist) {
+                ((curr_dist - old_dist).abs() < _eps && candidate_max_dist < max_dist)
+            {
                 let best_face = &self.faces[best_face_id.id];
                 let cpts = best_face.closest_points(&self.vertices);
                 return Some((cpts.0, cpts.1, best_face.normal));

--- a/src/query/epa/epa2.rs
+++ b/src/query/epa/epa2.rs
@@ -333,6 +333,7 @@ impl EPA {
             }
 
             niter += 1;
+            eprintln!("Iteration {}: dir = {:?}, curr_dist = {}, candidate_max_dist = {} max_dist = {}, support_point_id = {}", niter, curr_dist, candidate_max_dist, max_dist, support_point_id);
             if niter > 10000 {
                 return None;
             }

--- a/src/query/epa/epa3.rs
+++ b/src/query/epa/epa3.rs
@@ -315,6 +315,7 @@ impl EPA {
         let mut niter = 0;
         let mut max_dist = Real::max_value();
         let mut best_face_id = *self.heap.peek().unwrap();
+        let mut old_dist = 0.0;
 
         /*
          * Run the expansion.
@@ -340,11 +341,16 @@ impl EPA {
 
             let curr_dist = -face_id.neg_dist;
 
-            if max_dist - curr_dist < _eps_tol {
+            if max_dist - curr_dist < _eps_tol ||
+                // Accept the intersection as the algorithm is stuck and no new points will be found
+                // This happens because of numerical stability issue
+                ((curr_dist - old_dist).abs() < _eps && candidate_max_dist < max_dist) {
                 let best_face = &self.faces[best_face_id.id];
                 let points = best_face.closest_points(&self.vertices);
                 return Some((points.0, points.1, best_face.normal));
             }
+
+            old_dist = curr_dist;
 
             self.faces[face_id.id].deleted = true;
 
@@ -411,7 +417,7 @@ impl EPA {
             // self.check_topology(); // NOTE: for debugging only.
 
             niter += 1;
-            if niter > 10000 {
+            if niter > 100 {
                 return None;
             }
         }

--- a/src/query/epa/epa3.rs
+++ b/src/query/epa/epa3.rs
@@ -344,7 +344,8 @@ impl EPA {
             if max_dist - curr_dist < _eps_tol ||
                 // Accept the intersection as the algorithm is stuck and no new points will be found
                 // This happens because of numerical stability issue
-                ((curr_dist - old_dist).abs() < _eps && candidate_max_dist < max_dist) {
+                ((curr_dist - old_dist).abs() < _eps && candidate_max_dist < max_dist)
+            {
                 let best_face = &self.faces[best_face_id.id];
                 let points = best_face.closest_points(&self.vertices);
                 return Some((points.0, points.1, best_face.normal));

--- a/src/query/epa/epa3.rs
+++ b/src/query/epa/epa3.rs
@@ -418,7 +418,9 @@ impl EPA {
 
             niter += 1;
             if niter > 100 {
-                return None;
+                // if we reached this point, our algorithm didn't converge to what precision we wanted.
+                // still return an intersection point, as it's probably close enough.
+                break;
             }
         }
 

--- a/src/query/gjk/gjk.rs
+++ b/src/query/gjk/gjk.rs
@@ -362,6 +362,9 @@ where
         }
 
         niter += 1;
+        if niter % 1000 == 0 {
+            eprintln!("Iteration {}: dir = {:?}, min_bound = {}, max_bound = {} old_max_bound = {}", niter, dir, max_bound, min_bound, old_max_bound);
+        }
         if niter == 10000 {
             return None;
         }

--- a/src/query/gjk/gjk.rs
+++ b/src/query/gjk/gjk.rs
@@ -161,7 +161,6 @@ where
         old_dir = dir;
         proj = simplex.project_origin_and_reduce();
 
-
         if simplex.dimension() == DIM {
             if min_bound >= _eps_tol {
                 if exact_dist {

--- a/src/query/gjk/gjk.rs
+++ b/src/query/gjk/gjk.rs
@@ -101,7 +101,7 @@ where
 
     let mut old_dir;
 
-    if let Some(proj_dir) = Unit::try_new(proj.coords, 0.0) {
+    if let Some(proj_dir) = Unit::try_new(proj.coords, _eps_tol) {
         old_dir = -proj_dir;
     } else {
         return GJKResult::Intersection;
@@ -160,7 +160,7 @@ where
 
         old_dir = dir;
         proj = simplex.project_origin_and_reduce();
-
+        eprintln!("Iteration {}: dir = {:?}, min_bound = {}, max_bound = {} old_max_bound = {}", niter, dir, max_bound, min_bound, old_max_bound);
         if simplex.dimension() == DIM {
             if min_bound >= _eps_tol {
                 if exact_dist {
@@ -175,7 +175,7 @@ where
             }
         }
         niter += 1;
-            eprintln!("Iteration {}: dir = {:?}, min_bound = {}, max_bound = {} old_max_bound = {}", niter, dir, max_bound, min_bound, old_max_bound);
+            
         if niter == 10000 {
             return GJKResult::NoIntersection(Vector::x_axis());
         }

--- a/src/query/gjk/gjk.rs
+++ b/src/query/gjk/gjk.rs
@@ -175,9 +175,7 @@ where
             }
         }
         niter += 1;
-        if niter % 1000 == 0 {
             eprintln!("Iteration {}: dir = {:?}, min_bound = {}, max_bound = {} old_max_bound = {}", niter, dir, max_bound, min_bound, old_max_bound);
-        }
         if niter == 10000 {
             return GJKResult::NoIntersection(Vector::x_axis());
         }
@@ -365,9 +363,7 @@ where
         }
 
         niter += 1;
-        if niter % 1000 == 0 {
             eprintln!("Iteration {}: dir = {:?}, min_bound = {}, max_bound = {} old_max_bound = {}", niter, dir, max_bound, min_bound, old_max_bound);
-        }
         if niter == 10000 {
             return None;
         }

--- a/src/query/gjk/gjk.rs
+++ b/src/query/gjk/gjk.rs
@@ -101,7 +101,7 @@ where
 
     let mut old_dir;
 
-    if let Some(proj_dir) = Unit::try_new(proj.coords, _eps_tol) {
+    if let Some(proj_dir) = Unit::try_new(proj.coords, 0.0) {
         old_dir = -proj_dir;
     } else {
         return GJKResult::Intersection;
@@ -160,7 +160,8 @@ where
 
         old_dir = dir;
         proj = simplex.project_origin_and_reduce();
-        eprintln!("Iteration {}: dir = {:?}, min_bound = {}, max_bound = {} old_max_bound = {}", niter, dir, max_bound, min_bound, old_max_bound);
+
+
         if simplex.dimension() == DIM {
             if min_bound >= _eps_tol {
                 if exact_dist {
@@ -175,8 +176,8 @@ where
             }
         }
         niter += 1;
-            
-        if niter == 10000 {
+
+        if niter == 100 {
             return GJKResult::NoIntersection(Vector::x_axis());
         }
     }
@@ -363,8 +364,7 @@ where
         }
 
         niter += 1;
-            eprintln!("Iteration {}: dir = {:?}, min_bound = {}, max_bound = {} old_max_bound = {}", niter, dir, max_bound, min_bound, old_max_bound);
-        if niter == 10000 {
+        if niter == 100 {
             return None;
         }
     }

--- a/src/query/gjk/gjk.rs
+++ b/src/query/gjk/gjk.rs
@@ -175,6 +175,9 @@ where
             }
         }
         niter += 1;
+        if niter % 1000 == 0 {
+            eprintln!("Iteration {}: dir = {:?}, min_bound = {}, max_bound = {} old_max_bound = {}", niter, dir, max_bound, min_bound, old_max_bound);
+        }
         if niter == 10000 {
             return GJKResult::NoIntersection(Vector::x_axis());
         }

--- a/src/query/gjk/voronoi_simplex2.rs
+++ b/src/query/gjk/voronoi_simplex2.rs
@@ -94,6 +94,7 @@ impl VoronoiSimplex {
     /// The state of the simplex before projection is saved, and can be retrieved using the methods prefixed
     /// by `prev_`.
     pub fn project_origin_and_reduce(&mut self) -> Point<Real> {
+        eprintln!("project_origin_and_reduce {}", self.dim);
         if self.dim == 0 {
             self.proj[0] = 1.0;
             self.vertices[0].point

--- a/src/query/gjk/voronoi_simplex2.rs
+++ b/src/query/gjk/voronoi_simplex2.rs
@@ -94,7 +94,6 @@ impl VoronoiSimplex {
     /// The state of the simplex before projection is saved, and can be retrieved using the methods prefixed
     /// by `prev_`.
     pub fn project_origin_and_reduce(&mut self) -> Point<Real> {
-        eprintln!("project_origin_and_reduce {}", self.dim);
         if self.dim == 0 {
             self.proj[0] = 1.0;
             self.vertices[0].point


### PR DESCRIPTION
Improves converges by checking if it's stuck. In such a case return a result, as a better solution will not be found, and most likely they are intersecting but not within the EPS.

Also decrease max iterations from 10000 to 100. It usually converges in 4-5 iterations, no need to ever do as many. Also we never really want a precision that big, we are ok with a lower precision most times.


- Fixes https://github.com/dimforge/parry/issues/205

Possibly fixes:
- https://github.com/dimforge/parry/issues/157