### PR TITLE
Fix infinite loop in `intersection_with_local_plane`

### DIFF
--- a/crates/parry3d/tests/geometry/trimesh_intersection.rs
+++ b/crates/parry3d/tests/geometry/trimesh_intersection.rs
@@ -121,3 +121,27 @@ fn trimesh_plane_below() {
 
     assert!(matches!(result, IntersectResult::Negative));
 }
+
+#[test]
+fn trimesh_plane_simple() {
+    let points = vec![
+        Point3::from([0.0, 0.0, 0.0]),
+        Point3::from([0.0, 0.0, 1.0]),
+        Point3::from([1.0, 0.0, 0.0]),
+        Point3::from([1.0, 0.0, 1.0]),
+    ];
+    let indices = vec![[0, 1, 2], [1, 3, 2]];
+    let trimesh = TriMesh::new(points, indices);
+    let colid = trimesh.intersection_with_local_plane(&Vector3::<Real>::x_axis(), 0.5, 0.0005);
+    match colid {
+        IntersectResult::Intersect(points) => {
+            println!("polyline {:#?}", points);
+        }
+        IntersectResult::Negative => {
+            println!("positif");
+        }
+        IntersectResult::Positive => {
+            println!("negatif");
+        }
+    }
+}


### PR DESCRIPTION
- Attempt to fix https://github.com/dimforge/parry/issues/215

Only failing test for now

the loop occurs within the `'traversal` labelled loop, the 2 `if` conditions are never true in our case.

![image](https://github.com/user-attachments/assets/fc5fdafa-4e4f-48a4-a726-05dff2e4db8b)


## Wild guess

It seems weird that we have twice the same index in the index_adjacencies list ? But I'm not sure there:

![image](https://github.com/user-attachments/assets/8d025154-d282-4862-9a36-a6852338b77e)
