### PR TITLE
Projection example reimagine

### DIFF
--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -22,11 +22,28 @@ workspace = true
 [features]
 default = ["required-features", "std"]
 required-features = ["dim2", "f32"]
-std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade", "thiserror"]
+std = [
+    "nalgebra/std",
+    "slab",
+    "rustc-hash",
+    "simba/std",
+    "arrayvec/std",
+    "spade",
+    "thiserror",
+]
 dim2 = []
 f32 = []
-serde-serialize = ["serde", "nalgebra/serde-serialize", "arrayvec/serde", "bitflags/serde"]
-rkyv-serialize = ["rkyv/validation", "nalgebra/rkyv-serialize", "simba/rkyv-serialize"]
+serde-serialize = [
+    "serde",
+    "nalgebra/serde-serialize",
+    "arrayvec/serde",
+    "bitflags/serde",
+]
+rkyv-serialize = [
+    "rkyv/validation",
+    "nalgebra/rkyv-serialize",
+    "simba/rkyv-serialize",
+]
 bytemuck-serialize = ["bytemuck", "nalgebra/convert-bytemuck"]
 simd-stable = ["simba/wide", "simd-is-enabled"]
 simd-nightly = ["simba/portable_simd", "simd-is-enabled"]
@@ -73,4 +90,4 @@ simba = { version = "0.9", default-features = false }
 oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }
-macroquad = "0.4"
+macroquad = { git = "https://github.com/not-fl3/macroquad.git", branch = "reimagine" }

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -88,4 +88,4 @@ obj = { version = "0.10.2", optional = true }
 oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }
-macroquad = "*"
+macroquad = { git = "https://github.com/not-fl3/macroquad.git", branch = "reimagine" }

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -22,11 +22,23 @@ workspace = true
 [features]
 default = ["required-features", "std"]
 required-features = ["dim3", "f32"]
-std = ["nalgebra/std", "slab", "rustc-hash", "simba/std", "arrayvec/std", "spade", "thiserror"]
+std = [
+    "nalgebra/std",
+    "slab",
+    "rustc-hash",
+    "simba/std",
+    "arrayvec/std",
+    "spade",
+    "thiserror",
+]
 dim3 = []
 f32 = []
 serde-serialize = ["serde", "nalgebra/serde-serialize", "bitflags/serde"]
-rkyv-serialize = ["rkyv/validation", "nalgebra/rkyv-serialize", "simba/rkyv-serialize"]
+rkyv-serialize = [
+    "rkyv/validation",
+    "nalgebra/rkyv-serialize",
+    "simba/rkyv-serialize",
+]
 bytemuck-serialize = ["bytemuck", "nalgebra/convert-bytemuck"]
 
 simd-stable = ["simba/wide", "simd-is-enabled"]
@@ -76,3 +88,4 @@ obj = { version = "0.10.2", optional = true }
 oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }
+macroquad = "*"

--- a/crates/parry3d/examples/project3d_animated.rs
+++ b/crates/parry3d/examples/project3d_animated.rs
@@ -1,20 +1,16 @@
 use std::f32::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_6};
 
 use macroquad::gizmos::{draw_gizmos, gizmos_add_line, init_gizmos};
-use macroquad::math::{vec2, vec3, Vec2, Vec3};
-use macroquad::miniquad;
+use macroquad::math::{vec2, vec3, Mat4, Vec2, Vec3};
 use macroquad::quad_gl::camera::{Camera, Projection};
 use macroquad::quad_gl::models::CpuMesh;
 use macroquad::quad_gl::QuadGl;
-use macroquad::{
-    quad_gl::{
-        camera::Environment,
-        color::{self, Color},
-        scene::Shader,
-        ui::{hash, widgets},
-    },
-    window::next_frame,
+use macroquad::quad_gl::{
+    camera::Environment,
+    color::{self},
+    scene::Shader,
 };
+use macroquad::window::{next_frame, screen_height, screen_width};
 
 use nalgebra::{Point3, Vector3};
 use parry3d::math::{Isometry, Real};
@@ -23,12 +19,12 @@ use parry3d::shape::{Cuboid, TriMesh, TriMeshFlags};
 
 fn lissajous_3d(t: f32) -> Vec3 {
     // Some hardcoded parameters to have a pleasing lissajous trajectory.
-    let (a, b, c, delta_x, delta_y, delta_z) = (3.0, 2.0, 1.0, FRAC_PI_2, FRAC_PI_4, FRAC_PI_6);
+    let (a, b, c, delta_x, delta_y, delta_z) = (1.0, 3.0, 2.0, FRAC_PI_4, FRAC_PI_2, FRAC_PI_4);
 
     let x = (a * t + delta_x).sin();
     let y = (b * t + delta_y).sin();
     let z = (c * t + delta_z).sin();
-    Vec3::new(x, y, z) * 0.75f32
+    Vec3::new(x, y, z) * 0.8f32
 }
 
 fn main() {
@@ -38,21 +34,13 @@ fn main() {
 async fn main_loop(ctx: macroquad::Context) {
     init_gizmos(&ctx);
 
-    let (points, indices) = Cuboid::new(Vector3::new(0.2, 0.5, 1.0)).to_trimesh();
+    let (points, indices) = Cuboid::new(Vector3::new(0.5, 0.5, 0.8)).to_trimesh();
 
     let mut scene = ctx.new_scene();
 
     let quad_gl = QuadGl::new(ctx.quad_ctx.clone());
 
-    let mut cpu_mesh = mquad_mesh_from_parry(&indices, &points);
-
-    // No clone on CpuMesh :'(
-    let cpu_mesh2 = CpuMesh(
-        cpu_mesh.0.clone(),
-        cpu_mesh.1.clone(),
-        cpu_mesh.2.clone(),
-        cpu_mesh.3.clone(),
-    );
+    let cpu_mesh = mquad_mesh_from_parry(&indices, &points);
 
     let mut mesh = quad_gl.mesh(cpu_mesh, None);
 
@@ -109,24 +97,34 @@ async fn main_loop(ctx: macroquad::Context) {
          *
          */
 
-        /*
         let color = if projected_point.is_inside {
             color::RED
         } else {
             color::YELLOW
         };
 
-        draw_line_3d(
+        gizmos_add_line(
+            false,
             point_to_project,
             mquad_from_na(projected_point.point),
-            color,
         );
-        draw_sphere(point_to_project, 0.1, None, color);
+        // not working
+        //let point = camera
+        //    .proj_view()
+        //    .0
+        //    .project_point3(point_to_project.xy);
+        //let point = vec2(
+        //    (point.x / 2. + 0.5) * screen_width(),
+        //    (0.5 - point.y / 2.) * screen_height(),
+        //);
 
-        draw_line_3d(
+        //canvas.draw_circle(point.x, point.y, 10.0, color);
+        //draw_sphere(point_to_project, 0.1, None, color);
+
+        gizmos_add_line(
+            false,
             point_to_project,
             mquad_from_na(projected_point.point),
-            color,
         );
 
         // fixed point inside
@@ -141,13 +139,13 @@ async fn main_loop(ctx: macroquad::Context) {
         } else {
             color::YELLOW
         };
-        draw_sphere(point_to_project, 0.1, None, color);
+        //draw_sphere(point_to_project, 0.1, None, color);
 
-        draw_line_3d(
+        gizmos_add_line(
+            false,
             point_to_project,
             mquad_from_na(projected_point.point),
-            color,
-        );*/
+        );
 
         ctx.root_ui().draw(&mut canvas);
 
@@ -229,6 +227,6 @@ void main() {
     float diff = max(dot(norm, lightDir), 0.0);
     vec3 diffuse = diff * vec3(1.0) + vec3(0.3);
 
-    gl_FragColor = vec4(diffuse,1.);
+    gl_FragColor = vec4(diffuse,0.5);
 }
 "#;

--- a/crates/parry3d/examples/project3d_animated.rs
+++ b/crates/parry3d/examples/project3d_animated.rs
@@ -1,0 +1,157 @@
+use macroquad::models::Vertex;
+use macroquad::prelude::*;
+use nalgebra::{Point3, UnitVector3, Vector3};
+use parry3d::math::{Isometry, Real};
+use parry3d::query::{IntersectResult, PointQuery};
+use parry3d::shape::TriMesh;
+
+fn build_diamond(position: &Isometry<Real>) -> (Vec<Point3<Real>>, Vec<[u32; 3]>) {
+    // Two tetrahedrons sharing a face
+    let points = vec![
+        position * Point3::new(0.0, 2.0, 0.0),
+        position * Point3::new(-2.0, -1.0, 0.0),
+        position * Point3::new(0.0, 0.0, 2.0),
+        position * Point3::new(2.0, -1.0, 0.0),
+        position * Point3::new(0.0, 0.0, -2.0),
+    ];
+
+    let indices = vec![
+        [0u32, 1, 2],
+        [0, 2, 3],
+        [1, 2, 3],
+        [0, 1, 4],
+        [0, 4, 3],
+        [1, 4, 3],
+    ];
+
+    (points, indices)
+}
+
+#[macroquad::main("parry3d::query::PlaneIntersection")]
+async fn main() {
+    //
+    // This is useful to test for https://github.com/dimforge/parry/pull/248
+    let _points = vec![
+        Point3::from([0.0, 0.0, 0.0]),
+        Point3::from([0.0, 0.0, 1.0]),
+        Point3::from([1.0, 0.0, 0.0]),
+        Point3::from([1.0, 0.0, 1.0]),
+    ];
+    let _indices: Vec<[u32; 3]> = vec![[0, 1, 2], [1, 3, 2]];
+    //
+    //
+
+    let (points, indices) = build_diamond(&Isometry::identity());
+
+    let mesh = Mesh {
+        vertices: points
+            .iter()
+            .map(|p| Vertex {
+                position: mquad_from_na(*p),
+                uv: Vec2::new(p.x, p.y),
+                color: Color::new(0.9, 0.9, 0.9, 0.7),
+            })
+            .collect(),
+        indices: indices.iter().flatten().map(|v| *v as u16).collect(),
+        texture: None,
+    };
+    let trimesh = TriMesh::new(points, indices);
+
+    for _i in 1.. {
+        clear_background(BLACK);
+
+        let elapsed_time = get_time() as f32;
+        let slow_elapsed_time = elapsed_time / 3.0;
+
+        let sin = (elapsed_time / 3f32).sin();
+        let bias = 1.5 * sin.abs();
+        let rotation = Quat::from_axis_angle(
+            Vec3::new(slow_elapsed_time.sin(), slow_elapsed_time.cos(), 1f32),
+            (elapsed_time * 50f32).to_radians(),
+        );
+        let up_plane_vector = rotation * Vec3::Y;
+        let point_to_project = up_plane_vector * bias;
+        let projected_point = trimesh.project_point(
+            &Isometry::identity(),
+            &na_from_mquad(point_to_project),
+            true,
+        );
+
+        let slow_elapsed_time = slow_elapsed_time / 2.0;
+        // Going 3d!
+        set_camera(&Camera3D {
+            position: Vec3::new(
+                slow_elapsed_time.sin() * 5.0,
+                slow_elapsed_time.sin(),
+                slow_elapsed_time.cos() * 5.0,
+            ),
+            up: Vec3::new(0f32, 1f32, 0f32),
+            target: Vec3::new(0.5f32, 0f32, 0.5f32),
+            ..Default::default()
+        });
+
+        /*
+         *
+         * Render the projection
+         *
+         */
+        let color = if projected_point.is_inside {
+            RED
+        } else {
+            YELLOW
+        };
+
+        draw_line_3d(
+            point_to_project,
+            mquad_from_na(projected_point.point),
+            color,
+        );
+        draw_sphere(point_to_project, 0.1, None, color);
+
+        draw_line_3d(
+            point_to_project,
+            mquad_from_na(projected_point.point),
+            color,
+        );
+
+        // fixed point inside
+        let point_to_project = Vec3::ZERO;
+        let projected_point = trimesh.project_point(
+            &Isometry::identity(),
+            &na_from_mquad(point_to_project),
+            true,
+        );
+        let color = if projected_point.is_inside {
+            RED
+        } else {
+            YELLOW
+        };
+        draw_line_3d(
+            point_to_project,
+            mquad_from_na(projected_point.point),
+            color,
+        );
+        draw_sphere(point_to_project, 0.1, None, color);
+
+        // Mesh is rendered in the back.
+        draw_mesh(&mesh);
+
+        next_frame().await
+    }
+}
+
+fn draw_polyline(polygon: Vec<(Vec3, Vec3)>, color: Color) {
+    for i in 0..polygon.len() {
+        let a = polygon[i].0;
+        let b = polygon[i].1;
+        draw_line_3d(a, b, color);
+    }
+}
+
+fn mquad_from_na(a: Point3<Real>) -> Vec3 {
+    Vec3::new(a.x, a.y, a.z)
+}
+
+fn na_from_mquad(a: Vec3) -> Point3<Real> {
+    Point3::new(a.x, a.y, a.z)
+}

--- a/crates/parry3d/examples/project3d_animated.rs
+++ b/crates/parry3d/examples/project3d_animated.rs
@@ -1,31 +1,9 @@
 use macroquad::models::Vertex;
 use macroquad::prelude::*;
-use nalgebra::{Point3, UnitVector3, Vector3};
+use nalgebra::{Point3, Vector3};
 use parry3d::math::{Isometry, Real};
-use parry3d::query::{IntersectResult, PointQuery};
-use parry3d::shape::TriMesh;
-
-fn build_diamond(position: &Isometry<Real>) -> (Vec<Point3<Real>>, Vec<[u32; 3]>) {
-    // Two tetrahedrons sharing a face
-    let points = vec![
-        position * Point3::new(0.0, 2.0, 0.0),
-        position * Point3::new(-2.0, -1.0, 0.0),
-        position * Point3::new(0.0, 0.0, 2.0),
-        position * Point3::new(2.0, -1.0, 0.0),
-        position * Point3::new(0.0, 0.0, -2.0),
-    ];
-
-    let indices = vec![
-        [0u32, 1, 2],
-        [0, 2, 3],
-        [1, 2, 3],
-        [0, 1, 4],
-        [0, 4, 3],
-        [1, 4, 3],
-    ];
-
-    (points, indices)
-}
+use parry3d::query::PointQuery;
+use parry3d::shape::{Cuboid, TriMesh, TriMeshFlags};
 
 #[macroquad::main("parry3d::query::PlaneIntersection")]
 async fn main() {
@@ -38,10 +16,8 @@ async fn main() {
         Point3::from([1.0, 0.0, 1.0]),
     ];
     let _indices: Vec<[u32; 3]> = vec![[0, 1, 2], [1, 3, 2]];
-    //
-    //
 
-    let (points, indices) = build_diamond(&Isometry::identity());
+    let (points, indices) = Cuboid::new(Vector3::new(0.2, 0.5, 1.0)).to_trimesh();
 
     let mesh = Mesh {
         vertices: points
@@ -55,22 +31,24 @@ async fn main() {
         indices: indices.iter().flatten().map(|v| *v as u16).collect(),
         texture: None,
     };
-    let trimesh = TriMesh::new(points, indices);
-
+    let trimesh = TriMesh::with_flags(
+        points.clone(),
+        indices.clone(),
+        TriMeshFlags::ORIENTED
+            | TriMeshFlags::DELETE_BAD_TOPOLOGY_TRIANGLES
+            | TriMeshFlags::FIX_INTERNAL_EDGES,
+    );
     for _i in 1.. {
         clear_background(BLACK);
 
         let elapsed_time = get_time() as f32;
         let slow_elapsed_time = elapsed_time / 3.0;
 
-        let sin = (elapsed_time / 3f32).sin();
-        let bias = 1.5 * sin.abs();
-        let rotation = Quat::from_axis_angle(
-            Vec3::new(slow_elapsed_time.sin(), slow_elapsed_time.cos(), 1f32),
-            (elapsed_time * 50f32).to_radians(),
-        );
-        let up_plane_vector = rotation * Vec3::Y;
-        let point_to_project = up_plane_vector * bias;
+        let point_to_project = Vec3::new(
+            slow_elapsed_time.sin(),
+            slow_elapsed_time.cos() * 1.5,
+            (elapsed_time - slow_elapsed_time).cos(),
+        ) * slow_elapsed_time.sin().abs();
         let projected_point = trimesh.project_point(
             &Isometry::identity(),
             &na_from_mquad(point_to_project),
@@ -126,25 +104,17 @@ async fn main() {
         } else {
             YELLOW
         };
+        draw_sphere(point_to_project, 0.1, None, color);
+
         draw_line_3d(
             point_to_project,
             mquad_from_na(projected_point.point),
             color,
         );
-        draw_sphere(point_to_project, 0.1, None, color);
-
         // Mesh is rendered in the back.
         draw_mesh(&mesh);
 
         next_frame().await
-    }
-}
-
-fn draw_polyline(polygon: Vec<(Vec3, Vec3)>, color: Color) {
-    for i in 0..polygon.len() {
-        let a = polygon[i].0;
-        let b = polygon[i].1;
-        draw_line_3d(a, b, color);
     }
 }
 


### PR DESCRIPTION
This builds on top of https://github.com/dimforge/parry/pull/250 to use macroquad next version on branch `reimagine`

:warning: sphere/point gizmos are not yet supported in the new branch, 2 options are:
- get screen coordinate and render a point, it's not too great to get a feeling of exact position of the point being projected. cheating with distance feels off (It would probably need to take fov into account..)
- create a sphere mesh + tweak the rendering
  - I can see that work, but it needs some boilerplate (create the mesh, shader adaptation)
- Also, I think macroquad needs to expose `PipelineParams` in `Shader::new` to be able to tweak `depth_test` and see when line and sphere are inside the shape.

- I investigated those options in my branch `projection_example_reimagine_more` at https://github.com/Vrixyz/parry/pull/3.

[projection.webm](https://github.com/user-attachments/assets/c735a844-ce8c-4a98-827b-97d498b08046)