### PR TITLE
Parry benchmarks compilation

### DIFF
--- a/.github/workflows/parry-ci-build.yml
+++ b/.github/workflows/parry-ci-build.yml
@@ -2,9 +2,9 @@ name: parry CI build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
@@ -74,6 +74,16 @@ jobs:
       - name: install stable Rust
         uses: dtolnay/rust-toolchain@master
         with:
-            toolchain: stable
+          toolchain: stable
       - name: cargo doc
         run: cargo doc --workspace --features bytemuck-serialize,serde-serialize,rkyv-serialize,parallel --no-deps --document-private-items
+  check-benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+      - name: check benchmarks
+        run: cargo +nightly check --benches

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -89,10 +89,7 @@ oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }
 macroquad = "0.4.12"
-nalgebra = { version = "0.33", default-features = false, features = [
-    "libm",
-    "rand",
-] }
+nalgebra = { version = "0.33", default-features = false, features = ["rand"] }
 rand_isaac = "0.3"
 
 [package.metadata.docs.rs]

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -89,6 +89,11 @@ oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }
 macroquad = "0.4.12"
+nalgebra = { version = "0.33", default-features = false, features = [
+    "libm",
+    "rand",
+] }
+rand_isaac = "0.3"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]

--- a/crates/parry3d/benches/all.rs
+++ b/crates/parry3d/benches/all.rs
@@ -1,6 +1,8 @@
 #![feature(test)]
 #![allow(unused_macros)]
 
+use parry3d::math::{Point, Real};
+
 extern crate nalgebra as na;
 extern crate parry3d;
 extern crate rand;
@@ -10,3 +12,8 @@ mod bounding_volume;
 mod common;
 mod query;
 mod support_map;
+
+#[cfg(feature = "dim2")]
+type ConvexHull = Vec<Point<Real>>;
+#[cfg(feature = "dim3")]
+type ConvexHull = (Vec<Point<Real>>, Vec<[u32; 3]>);

--- a/crates/parry3d/benches/all.rs
+++ b/crates/parry3d/benches/all.rs
@@ -1,8 +1,6 @@
 #![feature(test)]
 #![allow(unused_macros)]
 
-use parry3d::math::{Point, Real};
-
 extern crate nalgebra as na;
 extern crate parry3d;
 extern crate rand;
@@ -12,8 +10,3 @@ mod bounding_volume;
 mod common;
 mod query;
 mod support_map;
-
-#[cfg(feature = "dim2")]
-type ConvexHull = Vec<Point<Real>>;
-#[cfg(feature = "dim3")]
-type ConvexHull = (Vec<Point<Real>>, Vec<[u32; 3]>);

--- a/crates/parry3d/benches/bounding_volume/mod.rs
+++ b/crates/parry3d/benches/bounding_volume/mod.rs
@@ -2,9 +2,7 @@ use crate::common::{generate, generate_trimesh_around_origin, unref};
 use na::Isometry3;
 use parry3d::bounding_volume::BoundingVolume;
 use parry3d::bounding_volume::{Aabb, BoundingSphere};
-use parry3d::shape::{
-    Ball, Capsule, Cone, ConvexHull, Cuboid, Cylinder, Segment, TriMesh, Triangle,
-};
+use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, TriMesh, Triangle};
 use rand::SeedableRng;
 use rand_isaac::IsaacRng;
 use test::Bencher;
@@ -132,6 +130,7 @@ bench_method!(
     m: Isometry3<f32>
 );
 
+/*
 bench_method!(
     bench_convex_aabb,
     aabb: Aabb,
@@ -143,7 +142,7 @@ bench_method!(
     bounding_sphere: BoundingSphere,
     c: ConvexHull,
     m: Isometry3<f32>
-);
+);*/
 
 bench_method_gen!(
     bench_mesh_aabb,

--- a/crates/parry3d/benches/bounding_volume/mod.rs
+++ b/crates/parry3d/benches/bounding_volume/mod.rs
@@ -2,7 +2,9 @@ use crate::common::{generate, generate_trimesh_around_origin, unref};
 use na::Isometry3;
 use parry3d::bounding_volume::BoundingVolume;
 use parry3d::bounding_volume::{Aabb, BoundingSphere};
-use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, TriMesh, Triangle};
+use parry3d::shape::{
+    Ball, Capsule, Cone, ConvexPolyhedron, Cuboid, Cylinder, Segment, TriMesh, Triangle,
+};
 use rand::SeedableRng;
 use rand_isaac::IsaacRng;
 use test::Bencher;
@@ -130,19 +132,18 @@ bench_method!(
     m: Isometry3<f32>
 );
 
-/*
 bench_method!(
     bench_convex_aabb,
     aabb: Aabb,
-    c: ConvexHull,
+    c: ConvexPolyhedron,
     m: Isometry3<f32>
 );
 bench_method!(
     bench_convex_bounding_sphere,
     bounding_sphere: BoundingSphere,
-    c: ConvexHull,
+    c: ConvexPolyhedron,
     m: Isometry3<f32>
-);*/
+);
 
 bench_method_gen!(
     bench_mesh_aabb,

--- a/crates/parry3d/benches/common/default_gen.rs
+++ b/crates/parry3d/benches/common/default_gen.rs
@@ -1,13 +1,15 @@
 use na::{
-    self, Isometry2, Isometry3, Matrix2, Matrix3, Matrix4, Point2, Point3, Point4, RealField,
-    Vector2, Vector3, Vector4,
+    self, Isometry2, Isometry3, Matrix2, Matrix3, Matrix4, Point2, Point3, Point4, Vector2,
+    Vector3, Vector4,
 };
 use parry3d::bounding_volume::{Aabb, BoundingSphere};
 use parry3d::math::{Point, Real, Vector};
 use parry3d::query::Ray;
-use parry3d::shape::{Ball, Capsule, Cone, ConvexHull, Cuboid, Cylinder, Segment, Triangle};
+use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
+
+use crate::ConvexHull;
 
 pub trait DefaultGen {
     fn generate<R: Rng>(rng: &mut R) -> Self;
@@ -76,7 +78,11 @@ where
     Standard: Distribution<Real>,
 {
     fn generate<R: Rng>(rng: &mut R) -> Capsule {
-        Capsule::new(rng.gen::<Real>().abs(), rng.gen::<Real>().abs())
+        Capsule::new(
+            rng.gen::<Point<Real>>(),
+            rng.gen::<Point<Real>>(),
+            rng.gen::<Real>().abs(),
+        )
     }
 }
 

--- a/crates/parry3d/benches/common/default_gen.rs
+++ b/crates/parry3d/benches/common/default_gen.rs
@@ -9,8 +9,6 @@ use parry3d::shape::{Ball, Capsule, Cone, ConvexPolyhedron, Cuboid, Cylinder, Se
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
-use crate::ConvexHull;
-
 pub trait DefaultGen {
     fn generate<R: Rng>(rng: &mut R) -> Self;
 }
@@ -119,20 +117,6 @@ where
 {
     fn generate<R: Rng>(rng: &mut R) -> Triangle {
         Triangle::new(rng.gen(), rng.gen(), rng.gen())
-    }
-}
-
-impl DefaultGen for ConvexHull
-where
-    Standard: Distribution<Point<Real>>,
-{
-    fn generate<R: Rng>(rng: &mut R) -> ConvexHull {
-        // It is recommended to have at most 100 points.
-        // Otherwise, a smarter structure like the DK hierarchy would be needed.
-        let pts: Vec<_> = (0..100).map(|_| rng.gen()).collect();
-        ConvexPolyhedron::from_convex_hull(&pts)
-            .unwrap()
-            .to_trimesh()
     }
 }
 

--- a/crates/parry3d/benches/common/default_gen.rs
+++ b/crates/parry3d/benches/common/default_gen.rs
@@ -5,7 +5,7 @@ use na::{
 use parry3d::bounding_volume::{Aabb, BoundingSphere};
 use parry3d::math::{Point, Real, Vector};
 use parry3d::query::Ray;
-use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
+use parry3d::shape::{Ball, Capsule, Cone, ConvexPolyhedron, Cuboid, Cylinder, Segment, Triangle};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
@@ -129,9 +129,22 @@ where
     fn generate<R: Rng>(rng: &mut R) -> ConvexHull {
         // It is recommended to have at most 100 points.
         // Otherwise, a smarter structure like the DK hierarchy would be needed.
-        // let pts: Vec<_> = (0..100).map(|_| rng.gen()).collect();
-        // ConvexHull::try_from_points(&pts).unwrap()
-        unimplemented!()
+        let pts: Vec<_> = (0..100).map(|_| rng.gen()).collect();
+        ConvexPolyhedron::from_convex_hull(&pts)
+            .unwrap()
+            .to_trimesh()
+    }
+}
+
+impl DefaultGen for ConvexPolyhedron
+where
+    Standard: Distribution<Real>,
+{
+    fn generate<R: Rng>(rng: &mut R) -> ConvexPolyhedron {
+        // It is recommended to have at most 100 points.
+        // Otherwise, a smarter structure like the DK hierarchy would be needed.
+        let pts: Vec<_> = (0..100).map(|_| rng.gen()).collect();
+        ConvexPolyhedron::from_convex_hull(&pts).unwrap()
     }
 }
 

--- a/crates/parry3d/benches/common/generators.rs
+++ b/crates/parry3d/benches/common/generators.rs
@@ -1,13 +1,10 @@
-use na::{Point2, Point3};
+use na::Point3;
 use parry3d::shape::TriMesh;
 use rand::Rng;
 
 pub fn generate_trimesh_around_origin<R: Rng>(rng: &mut R) -> TriMesh {
     let pts = (0..3000).map(|_| rng.gen::<Point3<f32>>() * 3.0).collect();
-    let uvs = (0..3000).map(|_| rng.gen::<Point2<f32>>() * 3.0).collect();
-    let indices = (0..1000)
-        .map(|i| Point3::new(i * 3, i * 3 + 1, i * 3 + 2))
-        .collect();
+    let indices = (0..1000).map(|i| [i * 3, i * 3 + 1, i * 3 + 2]).collect();
 
-    TriMesh::new(pts, indices, Some(uvs))
+    TriMesh::new(pts, indices)
 }

--- a/crates/parry3d/benches/common/macros.rs
+++ b/crates/parry3d/benches/common/macros.rs
@@ -72,7 +72,7 @@ macro_rules! bench_method_gen (
 
                 unsafe {
                     let val: $tres = test::black_box($arg.get_unchecked(i).$method($(unref($args.get_unchecked(i)),)*));
-                    drop(val);
+                    let _ = val;
                 }
             })
         }

--- a/crates/parry3d/benches/query/contacts.rs
+++ b/crates/parry3d/benches/query/contacts.rs
@@ -13,8 +13,9 @@ mod macros;
 bench_free_fn!(
     bench_ball_against_ball,
     query::contact,
-    pos12: Isometry3<f32>,
+    pos1: Isometry3<f32>,
     b1: Ball,
+    pos2: Isometry3<f32>,
     b2: Ball,
     prediction: f32
 );
@@ -22,8 +23,9 @@ bench_free_fn!(
 bench_free_fn!(
     bench_cuboid_against_cuboid,
     query::contact,
-    pos12: Isometry3<f32>,
+    pos1: Isometry3<f32>,
     b1: Cuboid,
+    pos2: Isometry3<f32>,
     b2: Cuboid,
     prediction: f32
 );
@@ -31,8 +33,9 @@ bench_free_fn!(
 bench_free_fn!(
     bench_capsule_against_capsule,
     query::contact,
-    pos12: Isometry3<f32>,
+    pos1: Isometry3<f32>,
     b1: Capsule,
+    pos2: Isometry3<f32>,
     b2: Capsule,
     prediction: f32
 );
@@ -40,8 +43,9 @@ bench_free_fn!(
 bench_free_fn!(
     bench_cone_against_cone,
     query::contact,
-    pos12: Isometry3<f32>,
+    pos1: Isometry3<f32>,
     b1: Cone,
+    pos2: Isometry3<f32>,
     b2: Cone,
     prediction: f32
 );
@@ -49,8 +53,9 @@ bench_free_fn!(
 bench_free_fn!(
     bench_cylinder_against_cylinder,
     query::contact,
-    pos12: Isometry3<f32>,
+    pos1: Isometry3<f32>,
     b1: Cylinder,
+    pos2: Isometry3<f32>,
     b2: Cylinder,
     prediction: f32
 );

--- a/crates/parry3d/benches/query/ray.rs
+++ b/crates/parry3d/benches/query/ray.rs
@@ -2,9 +2,7 @@ use crate::common::{generate, generate_trimesh_around_origin, unref};
 use na::Isometry3;
 use parry3d::bounding_volume::{Aabb, BoundingSphere};
 use parry3d::query::{Ray, RayCast};
-use parry3d::shape::{
-    Ball, Capsule, Cone, ConvexHull, Cuboid, Cylinder, Segment, TriMesh, Triangle,
-};
+use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, TriMesh, Triangle};
 use rand::SeedableRng;
 use rand_isaac::IsaacRng;
 use test::Bencher;
@@ -85,8 +83,8 @@ bench_method!(
 );
 
 bench_method!(
-    bench_ray_against_ball_with_normal_uv,
-    cast_ray_and_get_normal_and_uv,
+    bench_ray_against_ball_with_normal,
+    cast_ray_and_get_normal,
     b: Ball,
     pos: Isometry3<f32>,
     ray: Ray,
@@ -95,8 +93,8 @@ bench_method!(
 );
 
 bench_method!(
-    bench_ray_against_cuboid_with_normal_uv,
-    cast_ray_and_get_normal_and_uv,
+    bench_ray_against_cuboid_with_normal,
+    cast_ray_and_get_normal,
     c: Cuboid,
     pos: Isometry3<f32>,
     ray: Ray,
@@ -105,8 +103,8 @@ bench_method!(
 );
 
 bench_method!(
-    bench_ray_against_capsule_with_normal_uv,
-    cast_ray_and_get_normal_and_uv,
+    bench_ray_against_capsule_with_normal,
+    cast_ray_and_get_normal,
     c: Capsule,
     pos: Isometry3<f32>,
     ray: Ray,
@@ -115,8 +113,8 @@ bench_method!(
 );
 
 bench_method!(
-    bench_ray_against_cone_with_normal_uv,
-    cast_ray_and_get_normal_and_uv,
+    bench_ray_against_cone_with_normal,
+    cast_ray_and_get_normal,
     c: Cone,
     pos: Isometry3<f32>,
     ray: Ray,
@@ -125,8 +123,8 @@ bench_method!(
 );
 
 bench_method!(
-    bench_ray_against_cylinder_with_normal_uv,
-    cast_ray_and_get_normal_and_uv,
+    bench_ray_against_cylinder_with_normal,
+    cast_ray_and_get_normal,
     c: Cylinder,
     pos: Isometry3<f32>,
     ray: Ray,
@@ -135,8 +133,8 @@ bench_method!(
 );
 
 bench_method!(
-    bench_ray_against_segment_with_normal_uv,
-    cast_ray_and_get_normal_and_uv,
+    bench_ray_against_segment_with_normal,
+    cast_ray_and_get_normal,
     c: Segment,
     pos: Isometry3<f32>,
     ray: Ray,
@@ -145,8 +143,8 @@ bench_method!(
 );
 
 bench_method!(
-    bench_ray_against_triangle_with_normal_uv,
-    cast_ray_and_get_normal_and_uv,
+    bench_ray_against_triangle_with_normal,
+    cast_ray_and_get_normal,
     c: Triangle,
     pos: Isometry3<f32>,
     ray: Ray,
@@ -154,19 +152,21 @@ bench_method!(
     solid: bool
 );
 
+/*
 bench_method!(
-    bench_ray_against_convex_with_normal_uv,
-    cast_ray_and_get_normal_and_uv,
+    bench_ray_against_convex_with_normal,
+    cast_ray_and_get_normal,
     c: ConvexHull,
     pos: Isometry3<f32>,
     ray: Ray,
     max_time_of_impact: f32,
     solid: bool
 );
+*/
 
 bench_method_gen!(
-    bench_ray_against_trimesh_with_normal_uv,
-    cast_ray_and_get_normal_and_uv,
+    bench_ray_against_trimesh_with_normal,
+    cast_ray_and_get_normal,
     m: TriMesh = generate_trimesh_around_origin,
     pos: Isometry3<f32> = generate,
     ray: Ray = generate,

--- a/crates/parry3d/benches/query/ray.rs
+++ b/crates/parry3d/benches/query/ray.rs
@@ -2,7 +2,9 @@ use crate::common::{generate, generate_trimesh_around_origin, unref};
 use na::Isometry3;
 use parry3d::bounding_volume::{Aabb, BoundingSphere};
 use parry3d::query::{Ray, RayCast};
-use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, TriMesh, Triangle};
+use parry3d::shape::{
+    Ball, Capsule, Cone, ConvexPolyhedron, Cuboid, Cylinder, Segment, TriMesh, Triangle,
+};
 use rand::SeedableRng;
 use rand_isaac::IsaacRng;
 use test::Bencher;
@@ -152,17 +154,15 @@ bench_method!(
     solid: bool
 );
 
-/*
 bench_method!(
     bench_ray_against_convex_with_normal,
     cast_ray_and_get_normal,
-    c: ConvexHull,
+    c: ConvexPolyhedron,
     pos: Isometry3<f32>,
     ray: Ray,
     max_time_of_impact: f32,
     solid: bool
 );
-*/
 
 bench_method_gen!(
     bench_ray_against_trimesh_with_normal,

--- a/crates/parry3d/benches/support_map/mod.rs
+++ b/crates/parry3d/benches/support_map/mod.rs
@@ -1,7 +1,7 @@
 use crate::common::{generate, unref};
 use na::{Isometry3, Vector3};
-use parry3d::shape::SupportMap;
 use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
+use parry3d::shape::{ConvexPolyhedron, SupportMap};
 use rand::SeedableRng;
 use rand_isaac::IsaacRng;
 use test::Bencher;
@@ -59,12 +59,11 @@ bench_method!(
     m: Isometry3<f32>,
     dir: Vector3<f32>
 );
-/*
+
 bench_method!(
     bench_convex_support_map,
     support_point,
-    c: ConvexHull,
+    c: ConvexPolyhedron,
     m: Isometry3<f32>,
     dir: Vector3<f32>
 );
-*/

--- a/crates/parry3d/benches/support_map/mod.rs
+++ b/crates/parry3d/benches/support_map/mod.rs
@@ -1,7 +1,7 @@
 use crate::common::{generate, unref};
 use na::{Isometry3, Vector3};
 use parry3d::shape::SupportMap;
-use parry3d::shape::{Ball, Capsule, Cone, ConvexHull, Cuboid, Cylinder, Segment, Triangle};
+use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
 use rand::SeedableRng;
 use rand_isaac::IsaacRng;
 use test::Bencher;
@@ -59,6 +59,7 @@ bench_method!(
     m: Isometry3<f32>,
     dir: Vector3<f32>
 );
+/*
 bench_method!(
     bench_convex_support_map,
     support_point,
@@ -66,3 +67,4 @@ bench_method!(
     m: Isometry3<f32>,
     dir: Vector3<f32>
 );
+*/


### PR DESCRIPTION
Fixes compiling for parry benchmarks

There has been a few API changes since their creation, especially around `ConvexHull`, and in a lesser amount `Capsule`.