### PR TITLE
fix point_in_poly2d for self-intersecting polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+### Fix
+
+- Fix `utils::point_in_poly2d` for self-intersecting polygons.
+
 ### Added
 
-- `TriMesh` now implements `Shape::feature_normal_at_point` to retrieve the normal of a face, when passing a `FeatureId::Face`.
+- `TriMesh` now implements `Shape::feature_normal_at_point` to retrieve the normal of a face, when passing a
+  `FeatureId::Face`.
 
 ## v0.17.1
 
@@ -283,7 +288,8 @@ This version was yanked. See the release notes for 0.13.3 instead.
   for most shapes.
 - Add the `parallel` feature that enables methods for the parallel traversal of Qbvh
   trees: `Qbvh::traverse_bvtt_parallel`,
-  `Qbvh::traverse_bvtt_node_parallel`, `Qbvh::traverse_depth_first_parallel`, `Qbvh::traverse_depth_first_node_parallel`.
+  `Qbvh::traverse_bvtt_node_parallel`, `Qbvh::traverse_depth_first_parallel`,
+  `Qbvh::traverse_depth_first_node_parallel`.
 
 ### Fixed
 

--- a/src/utils/point_in_poly2d.rs
+++ b/src/utils/point_in_poly2d.rs
@@ -48,14 +48,15 @@ pub fn point_in_poly2d(pt: &Point2<Real>, poly: &[Point2<Real>]) -> bool {
         let seg_dir = b - a;
         let dpt = pt - a;
         let perp = dpt.perp(&seg_dir);
+
         winding += match (dpt.y >= 0.0, b.y > pt.y) {
             (true, true) if perp < 0.0 => 1,
-            (false, false) if perp > 0.0 => -1,
+            (false, false) if perp > 0.0 => 1,
             _ => 0,
         };
     }
 
-    winding != 0
+    winding % 2 == 1
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In some cases where the polygon loops on itself, the winding number was incorrect.