### PR TITLE
clippy ci

### DIFF
--- a/.github/workflows/parry-ci-build.yml
+++ b/.github/workflows/parry-ci-build.yml
@@ -2,9 +2,9 @@ name: parry CI build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
@@ -18,6 +18,8 @@ jobs:
         run: cargo fmt -- --check
   clippy:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
       - name: Clippy
@@ -74,6 +76,6 @@ jobs:
       - name: install stable Rust
         uses: dtolnay/rust-toolchain@master
         with:
-            toolchain: stable
+          toolchain: stable
       - name: cargo doc
         run: cargo doc --workspace --features bytemuck-serialize,serde-serialize,rkyv-serialize,parallel --no-deps --document-private-items

--- a/src/mass_properties/mass_properties.rs
+++ b/src/mass_properties/mass_properties.rs
@@ -9,6 +9,7 @@ use {na::Matrix3, std::ops::MulAssign};
 #[cfg(feature = "rkyv")]
 use rkyv::{bytecheck, CheckBytes};
 
+#[cfg_attr(feature = "f32", expect(clippy::unnecessary_cast))]
 const EPSILON: Real = f32::EPSILON as Real;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq)]

--- a/src/query/sat/sat_cuboid_cuboid.rs
+++ b/src/query/sat/sat_cuboid_cuboid.rs
@@ -11,6 +11,7 @@ pub fn cuboid_cuboid_compute_separation_wrt_local_line(
     pos12: &Isometry<Real>,
     axis1: &Vector<Real>,
 ) -> (Real, Vector<Real>) {
+    #[expect(clippy::unnecessary_cast)]
     let signum = (1.0 as Real).copysign(pos12.translation.vector.dot(axis1));
     let axis1 = axis1 * signum;
     let axis2 = pos12.inverse_transform_vector(&-axis1);
@@ -87,6 +88,7 @@ pub fn cuboid_cuboid_find_local_separating_normal_oneway(
     let mut best_dir = Vector::zeros();
 
     for i in 0..DIM {
+        #[expect(clippy::unnecessary_cast)]
         let sign = (1.0 as Real).copysign(pos12.translation.vector[i]);
         let axis1 = Vector::ith(i, sign);
         let axis2 = pos12.inverse_transform_vector(&-axis1);

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -152,6 +152,7 @@ impl Cuboid {
         // to make this AoSoA friendly?
         let he = self.half_extents;
         let iamax = local_dir.iamax();
+        #[expect(clippy::unnecessary_cast)]
         let sign = (1.0 as Real).copysign(local_dir[iamax]);
 
         let vertices = match iamax {

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -1455,7 +1455,7 @@ impl Shape for HalfSpace {
 
     #[cfg(feature = "std")]
     fn scale_dyn(&self, scale: &Vector<Real>, _num_subdivisions: u32) -> Option<Box<dyn Shape>> {
-        Some(Box::new(self.clone().scaled(scale)?))
+        Some(Box::new(self.scaled(scale)?))
     }
 
     fn compute_local_aabb(&self) -> Aabb {
@@ -1475,7 +1475,10 @@ impl Shape for HalfSpace {
     }
 
     fn ccd_thickness(&self) -> Real {
-        f32::MAX as Real
+        #[cfg_attr(feature = "f32", expect(clippy::unnecessary_cast))]
+        let result = f32::MAX as Real;
+        #[cfg_attr(feature = "f64", expect(clippy::let_and_return))]
+        result
     }
 
     fn ccd_angular_thickness(&self) -> Real {

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -35,6 +35,7 @@ pub struct MeshIntersectionTolerances {
 impl Default for MeshIntersectionTolerances {
     fn default() -> Self {
         Self {
+            #[expect(clippy::unnecessary_cast)]
             angle_epsilon: (0.005 as Real).to_radians(), // 0.005 degrees
             global_insertion_epsilon: Real::EPSILON * 100.0,
             local_insertion_epsilon_scale: 10.,
@@ -179,8 +180,8 @@ pub fn intersect_meshes_with_tolerances(
     let mut constraints1 = BTreeMap::<_, Vec<_>>::new();
     let mut constraints2 = BTreeMap::<_, Vec<_>>::new();
     for (fid1, fid2) in &intersections {
-        let tri1 = mesh1.triangle(*fid1).transformed(&pos1);
-        let tri2 = mesh2.triangle(*fid2).transformed(&pos2);
+        let tri1 = mesh1.triangle(*fid1).transformed(pos1);
+        let tri2 = mesh2.triangle(*fid2).transformed(pos2);
 
         let list1 = constraints1.entry(fid1).or_default();
         let list2 = constraints2.entry(fid2).or_default();
@@ -216,8 +217,8 @@ pub fn intersect_meshes_with_tolerances(
         mesh1,
         mesh2,
         &constraints1,
-        &pos1,
-        &pos2,
+        pos1,
+        pos2,
         flip1,
         flip2,
         &meta_data,
@@ -229,8 +230,8 @@ pub fn intersect_meshes_with_tolerances(
         mesh2,
         mesh1,
         &constraints2,
-        &pos2,
-        &pos1,
+        pos2,
+        pos1,
         flip2,
         flip1,
         &meta_data,
@@ -601,7 +602,7 @@ fn merge_triangle_sets(
     // For each sub-triangle that is part of the intersection, add them to the
     // output mesh.
     for (triangle_id, constraints) in triangle_constraints.iter() {
-        let tri = mesh1.triangle(**triangle_id).transformed(&pos1);
+        let tri = mesh1.triangle(**triangle_id).transformed(pos1);
 
         let (delaunay, points) = triangulate_constraints_and_merge_duplicates(
             &tri,

--- a/src/transformation/polygon_intersection.rs
+++ b/src/transformation/polygon_intersection.rs
@@ -45,11 +45,11 @@ impl PolylinePointLocation {
     }
 
     /// Computes the point corresponding to this location.
-    pub fn to_point(&self, pts: &[Point2<Real>]) -> Point2<Real> {
+    pub fn to_point(self, pts: &[Point2<Real>]) -> Point2<Real> {
         match self {
-            PolylinePointLocation::OnVertex(i) => pts[*i],
+            PolylinePointLocation::OnVertex(i) => pts[i],
             PolylinePointLocation::OnEdge(i1, i2, bcoords) => {
-                pts[*i1] * bcoords[0] + pts[*i2].coords * bcoords[1]
+                pts[i1] * bcoords[0] + pts[i2].coords * bcoords[1]
             }
         }
     }


### PR DESCRIPTION
- Fixes clippy warnings
- forbid warnings within CI

<details><summary>Addressed doubts</summary>
<p>

I'm not too sure what to do about this error:
```rs
warning: methods with the following characteristics: (`to_*` and `self` type is `Copy`) usually take `self` by value
  --> crates/parry3d/../../src/transformation/polygon_intersection.rs:48:21
   |
48 |     pub fn to_point(&self, pts: &[Point2<Real>]) -> Point2<Real> {
   |                     ^^^^^
   |
   = help: consider choosing a less ambiguous name
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention
   = note: `#[warn(clippy::wrong_self_convention)]` on by default
```

Fixed by taking full ownership of `self` (It's not a big deal because they are `Copy`.

</p>
</details> 
