### PR TITLE
Create constructor for ConvexPolyline that does not remove any vertices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Derive `Copy` for `VHACDParameters`.
 - Add `spade` default feature for algorithms using Delaunay triangulation from `spade`.
+- Add `SharedShape::from_convex_polyline_unmodified` and `ConvexPolygon::from_convex_polyline_unmodified`
+  to initialize a polyline from a set of points assumed to be convex, and without modifying this set even
+  if some points are collinear.
 
 ### Modified
 

--- a/src/shape/convex_polygon.rs
+++ b/src/shape/convex_polygon.rs
@@ -31,6 +31,7 @@ impl ConvexPolygon {
     /// describe a counter-clockwise convex polyline.
     ///
     /// Convexity of the input polyline is not checked.
+    /// Removes some points if they are collinear with the previous one.
     /// Returns `None` if all points form an almost flat line.
     pub fn from_convex_polyline(mut points: Vec<Point<Real>>) -> Option<Self> {
         if points.is_empty() {
@@ -66,6 +67,29 @@ impl ConvexPolygon {
         let new_length = points.len() - nremoved;
         points.truncate(new_length);
         normals.truncate(new_length);
+
+        if points.len() > 2 {
+            Some(ConvexPolygon { points, normals })
+        } else {
+            None
+        }
+    }
+
+    /// Creates a new 2D convex polygon from a set of points assumed to
+    /// describe a counter-clockwise convex polyline.
+    ///
+    /// Convexity of the input polyline is not checked.
+    /// Does not remove any points.
+    pub fn from_points(points: Vec<Point<Real>>) -> Option<Self> {
+        if points.is_empty() {
+            return None;
+        }
+        let mut normals = Vec::with_capacity(points.len());
+        // First, compute all normals.
+        for i1 in 0..points.len() {
+            let i2 = (i1 + 1) % points.len();
+            normals.push(utils::ccw_face_normal([&points[i1], &points[i2]])?);
+        }
 
         if points.len() > 2 {
             Some(ConvexPolygon { points, normals })

--- a/src/shape/convex_polygon.rs
+++ b/src/shape/convex_polygon.rs
@@ -30,8 +30,14 @@ impl ConvexPolygon {
     /// Creates a new 2D convex polygon from a set of points assumed to
     /// describe a counter-clockwise convex polyline.
     ///
-    /// Convexity of the input polyline is not checked.
-    /// Removes some points if they are collinear with the previous one.
+    /// This does **not** compute the convex-hull of the input points: convexity of the input is
+    /// assumed and not checked. For a version that calculates the convex hull of the given points,
+    /// use [`ConvexPolygon::from_convex_hull`] instead.
+    ///
+    /// The generated [`ConvexPolygon`] will contain the given `points` with any point
+    /// collinear to the previous and next ones removed. For a version that leaves the input
+    /// `points` unmodified, use [`ConvexPolygon::from_convex_polyline_unmodified`].
+    ///
     /// Returns `None` if all points form an almost flat line.
     pub fn from_convex_polyline(mut points: Vec<Point<Real>>) -> Option<Self> {
         if points.is_empty() {
@@ -78,10 +84,12 @@ impl ConvexPolygon {
     /// Creates a new 2D convex polygon from a set of points assumed to
     /// describe a counter-clockwise convex polyline.
     ///
-    /// Convexity of the input polyline is not checked.
-    /// Does not remove any points.
-    pub fn from_points(points: Vec<Point<Real>>) -> Option<Self> {
-        if points.is_empty() {
+    /// This is the same as [`ConvexPolygon::from_convex_polyline`] but without removing any point
+    /// from the input even if some are coplanar.
+    ///
+    /// Returns `None` if `points` doesn’t contain at least three points.
+    pub fn from_convex_polyline_unmodified(points: Vec<Point<Real>>) -> Option<Self> {
+        if points.len() <= 2 {
             return None;
         }
         let mut normals = Vec::with_capacity(points.len());
@@ -91,11 +99,7 @@ impl ConvexPolygon {
             normals.push(utils::ccw_face_normal([&points[i1], &points[i2]])?);
         }
 
-        if points.len() > 2 {
-            Some(ConvexPolygon { points, normals })
-        } else {
-            None
-        }
+        Some(ConvexPolygon { points, normals })
     }
 
     /// The vertices of this convex polygon.

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -300,21 +300,33 @@ impl SharedShape {
         return ConvexPolyhedron::from_convex_hull(points).map(|ch| SharedShape(Arc::new(ch)));
     }
 
-    /// Creates a new shared shape that is a convex polygon formed by the
-    /// given set of points assumed to form a convex polyline (no convex-hull will be automatically
-    /// computed).
+    /// Creates a new shared shape that is a 2D convex polygon from a set of points assumed to
+    /// describe a counter-clockwise convex polyline.
+    ///
+    /// This does **not** compute the convex-hull of the input points: convexity of the input is
+    /// assumed and not checked. For a version that calculates the convex hull of the input points,
+    /// use [`SharedShape::convex_hull`] instead.
+    ///
+    /// The generated [`ConvexPolygon`] will contain the given `points` with any point
+    /// collinear to the previous and next ones removed. For a version that leaves the input
+    /// `points` unmodified, use [`SharedShape::convex_polyline_unmodified`].
+    ///
+    /// Returns `None` if all points form an almost flat line.
     #[cfg(feature = "dim2")]
     pub fn convex_polyline(points: Vec<Point<Real>>) -> Option<Self> {
         ConvexPolygon::from_convex_polyline(points).map(|ch| SharedShape(Arc::new(ch)))
     }
 
-    /// Creates a new shared shape that is a convex polygon formed by the
-    /// given set of points assumed to form a convex polyline (no convex-hull will be automatically
-    /// computed and no points will be removed).
-    /// Does not remove any points.
+    /// Creates a new shared shape that is a 2D convex polygon from a set of points assumed to
+    /// describe a counter-clockwise convex polyline.
+    ///
+    /// This is the same as [`SharedShape::convex_polyline`] but without removing any point
+    /// from the input even if some are coplanar.
+    ///
+    /// Returns `None` if `points` doesn’t contain at least three points.
     #[cfg(feature = "dim2")]
-    pub fn convex_polyline_from_points_raw(points: Vec<Point<Real>>) -> Option<Self> {
-        ConvexPolygon::from_points(points).map(|ch| SharedShape(Arc::new(ch)))
+    pub fn convex_polyline_unmodified(points: Vec<Point<Real>>) -> Option<Self> {
+        ConvexPolygon::from_convex_polyline_unmodified(points).map(|ch| SharedShape(Arc::new(ch)))
     }
 
     /// Creates a new shared shape that is a convex polyhedron formed by the

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -308,6 +308,15 @@ impl SharedShape {
         ConvexPolygon::from_convex_polyline(points).map(|ch| SharedShape(Arc::new(ch)))
     }
 
+    /// Creates a new shared shape that is a convex polygon formed by the
+    /// given set of points assumed to form a convex polyline (no convex-hull will be automatically
+    /// computed and no points will be removed).
+    /// Does not remove any points.
+    #[cfg(feature = "dim2")]
+    pub fn convex_polyline_from_points_raw(points: Vec<Point<Real>>) -> Option<Self> {
+        ConvexPolygon::from_points(points).map(|ch| SharedShape(Arc::new(ch)))
+    }
+
     /// Creates a new shared shape that is a convex polyhedron formed by the
     /// given set of points assumed to form a convex mesh (no convex-hull will be automatically
     /// computed).


### PR DESCRIPTION
- Fixes https://github.com/dimforge/parry/issues/277
In Godot Rapier, Godot sends vertices that it uses to draw the polygon. If Parry removes some vertices, then the physics will not work correct. We need the extra vertices even if collinear, and ideally have the collinearity check done in Godot at some point or sent as a warning to console. For now a function that accepts points and doesn't remove any is needed for this use case.