### PR TITLE
Parry testbed exploration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/parry2d", "crates/parry3d", "crates/parry2d-f64", "crates/parry3d-f64"]
+members = ["crates/parry2d", "crates/parry3d", "crates/parry2d-f64", "crates/parry3d-f64", "crates/common_macroquad"]
 resolver = "2"
 
 [workspace.lints]

--- a/crates/common_macroquad/Cargo.toml
+++ b/crates/common_macroquad/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "common_macroquad"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+"dim2" = ["dep:parry2d"]
+"dim3" = ["dep:parry3d"]
+
+[dependencies]
+macroquad = "0.4.12"
+nalgebra = "*"
+parry3d = { optional = true, version = "*", path = "../parry3d"}
+parry2d = { optional = true, version = "*", path = "../parry2d"}
+
+[lints]
+workspace = true

--- a/crates/common_macroquad/src/dim2.rs
+++ b/crates/common_macroquad/src/dim2.rs
@@ -10,32 +10,17 @@ use nalgebra::Point2;
 use parry2d::math::Real;
 use parry2d::shape::TriMesh;
 
-/// As this file is used as a module from other examples,
-/// rustc warns about dead code:
-/// - `main()` is needed for this file to be included in examples
-/// - For other functions, they may be "dead code" for an example, but not for others.
-#[allow(dead_code)]
-fn main() {
-    println!(
-        "This module contains helper functions to use macroquad,
-    isolated from the rest of the examples for the sake of simplicity."
-    );
-}
-
 /// Converts a [`nalgebra::Point2`] to a [`Vec2`], which is used by [`macroquad`]
-#[allow(dead_code)]
 pub fn mquad_from_na(a: Point2<Real>) -> Vec2 {
     Vec2::new(a.x, a.y)
 }
 
 /// Converts a [`Vec2`] to a [`nalgebra::Point2`], which is used by [`parry3d`]
-#[allow(dead_code)]
 pub fn na_from_mquad(a: Vec2) -> Point2<Real> {
     Point2::new(a.x, a.y)
 }
 
 /// Uses [`macroquad`] to display the line passed as parameter.
-#[allow(dead_code)]
 pub fn draw_polyline(polyline: Vec<(Vec2, Vec2)>, color: Color) {
     for line in polyline {
         let a = line.0;
@@ -44,25 +29,15 @@ pub fn draw_polyline(polyline: Vec<(Vec2, Vec2)>, color: Color) {
     }
 }
 
-/// Draws a text in the top left corner of the screen.
-///
-/// This uses a hardcoded position, size, color.
-#[allow(dead_code)]
-pub fn easy_draw_text(text: &str) {
-    macroquad::text::draw_text(text, 10.0, 48.0 + 18.0, 30.0, WHITE);
-}
-
 /// Returns [lissajous curve](https://en.wikipedia.org/wiki/Lissajous_curve) coordinates for time `t`.
 ///
 /// This uses hardcoded parameters to have an arbitrary pleasing trajectory.
-#[allow(dead_code)]
 pub fn lissajous_2d(t: f32) -> Vec2 {
     // Some hardcoded parameters to have a pleasing lissajous trajectory.
     lissajous_2d_with_params(t, 3.0, 2.0, FRAC_PI_2, FRAC_PI_4)
 }
 
 /// Returns [lissajous curve](https://en.wikipedia.org/wiki/Lissajous_curve) coordinates.
-#[allow(dead_code)]
 pub fn lissajous_2d_with_params(t: f32, a: f32, b: f32, delta_x: f32, delta_y: f32) -> Vec2 {
     // Some hardcoded parameters to have a pleasing lissajous trajectory.
 
@@ -72,13 +47,11 @@ pub fn lissajous_2d_with_params(t: f32, a: f32, b: f32, delta_x: f32, delta_y: f
 }
 
 /// Uses [`macroquad`] to display the line passed as parameter.
-#[allow(dead_code)]
 pub fn draw_line_2d(a: Vec2, b: Vec2, color: Color) {
     draw_line(a.x, a.y, b.x, b.y, 2f32, color);
 }
 
 /// Uses [`macroquad`] to display the line passed as parameter.
-#[allow(dead_code)]
 pub fn draw_trimesh2(trimesh: &TriMesh, offset: Vec2) {
     let vertices = trimesh.vertices();
     for v in trimesh.indices() {
@@ -93,7 +66,6 @@ pub fn draw_trimesh2(trimesh: &TriMesh, offset: Vec2) {
 }
 
 /// Uses [`macroquad`] to display a wireframe of the polygon.
-#[allow(dead_code)]
 pub fn draw_polygon(polygon: &[Point2<f32>], scale: f32, shift: Point2<f32>, color: Color) {
     for i in 0..polygon.len() {
         let a = polygon[i];
@@ -110,7 +82,6 @@ pub fn draw_polygon(polygon: &[Point2<f32>], scale: f32, shift: Point2<f32>, col
 }
 
 /// Uses [`macroquad`] to display the a cross, representing a point.
-#[allow(dead_code)]
 pub fn draw_point(point: Point2<f32>, scale: f32, shift: Point2<f32>, color: Color) {
     let edge_len = 0.15;
     draw_line(

--- a/crates/common_macroquad/src/dim3.rs
+++ b/crates/common_macroquad/src/dim3.rs
@@ -9,22 +9,12 @@ use macroquad::{
 use nalgebra::Point3;
 use parry3d::math::Real;
 
-#[allow(dead_code)]
-fn main() {
-    println!(
-        "This module contains helper functions to use macroquad,
-    isolated from the rest of the examples for the sake of simplicity."
-    );
-}
-
 /// Converts a [`nalgebra::Point3`] to a [`Vec3`], which is used by [`macroquad`]
-#[allow(dead_code)]
 pub fn mquad_from_na(a: Point3<Real>) -> Vec3 {
     Vec3::new(a.x, a.y, a.z)
 }
 
 /// Converts a [`Vec3`] to a [`nalgebra::Point3`], which is used by [`parry3d`]
-#[allow(dead_code)]
 pub fn na_from_mquad(a: Vec3) -> Point3<Real> {
     Point3::new(a.x, a.y, a.z)
 }
@@ -32,14 +22,13 @@ pub fn na_from_mquad(a: Vec3) -> Point3<Real> {
 /// Returns [lissajous curve](https://en.wikipedia.org/wiki/Lissajous_curve) coordinates for time `t`.
 ///
 /// This uses hardcoded parameters to have an arbitrary pleasing trajectory.
-#[allow(dead_code)]
+
 pub fn lissajous_3d(t: f32) -> Vec3 {
     // Some hardcoded parameters to have a pleasing lissajous trajectory.
     lissajous_3d_with_params(t, 3.0, 2.0, 1.0, FRAC_PI_2, FRAC_PI_4, FRAC_PI_6)
 }
 
 /// Returns [lissajous curve](https://en.wikipedia.org/wiki/Lissajous_curve) coordinates.
-#[allow(dead_code)]
 pub fn lissajous_3d_with_params(
     t: f32,
     a: f32,
@@ -56,7 +45,6 @@ pub fn lissajous_3d_with_params(
 }
 
 /// Uses [`macroquad`] to display the line passed as parameter.
-#[allow(dead_code)]
 pub fn draw_polyline(polyline: Vec<(Vec3, Vec3)>, color: Color) {
     for line in polyline {
         let a = line.0;
@@ -68,7 +56,6 @@ pub fn draw_polyline(polyline: Vec<(Vec3, Vec3)>, color: Color) {
 /// Draws a text in the top left corner of the screen.
 ///
 /// This uses a hardcoded position, size, color.
-#[allow(dead_code)]
 pub fn easy_draw_text(text: &str) {
     macroquad::text::draw_text(text, 10.0, 48.0 + 18.0, 30.0, WHITE);
 }
@@ -77,7 +64,6 @@ pub fn easy_draw_text(text: &str) {
 ///
 /// This duplicates the trimesh vertices, computes their normals,
 /// and bakes light into its vertices colors using [`mquad_compute_normals_and_bake_light`].
-#[allow(dead_code)]
 pub fn mquad_mesh_from_points(
     trimesh: &(Vec<Point3<Real>>, Vec<[u32; 3]>),
     light_pos: Vec3,
@@ -119,7 +105,6 @@ pub fn mquad_mesh_from_points(
 }
 
 /// Bakes light into vertices, using an hardcoded light strength.
-#[allow(dead_code)]
 pub fn mquad_compute_normals_and_bake_light(
     points: &Vec<Vertex>,
     indices: &Vec<u16>,

--- a/crates/common_macroquad/src/lib.rs
+++ b/crates/common_macroquad/src/lib.rs
@@ -1,0 +1,13 @@
+#[cfg(feature = "dim2")]
+pub mod dim2;
+#[cfg(feature = "dim3")]
+pub mod dim3;
+
+use macroquad::color::WHITE;
+
+/// Draws a text in the top left corner of the screen.
+///
+/// This uses a hardcoded position, size, color.
+pub fn easy_draw_text(text: &str) {
+    macroquad::text::draw_text(text, 10.0, 48.0 + 18.0, 30.0, WHITE);
+}

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -91,6 +91,9 @@ oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }
 macroquad = "0.4.12"
+common_macroquad = { version = "0.1", path = "../common_macroquad", features = [
+    "dim2",
+] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]

--- a/crates/parry2d/examples/aabb2d.rs
+++ b/crates/parry2d/examples/aabb2d.rs
@@ -1,8 +1,6 @@
-mod common_macroquad2d;
-
 extern crate nalgebra as na;
 
-use common_macroquad2d::{draw_polyline, lissajous_2d, mquad_from_na, na_from_mquad};
+use common_macroquad::dim2::{draw_polyline, lissajous_2d, mquad_from_na, na_from_mquad};
 use macroquad::prelude::*;
 use na::Isometry2;
 use parry2d::bounding_volume::{Aabb, BoundingVolume};

--- a/crates/parry2d/examples/bounding_sphere2d.rs
+++ b/crates/parry2d/examples/bounding_sphere2d.rs
@@ -1,8 +1,6 @@
-mod common_macroquad2d;
-
 extern crate nalgebra as na;
 
-use common_macroquad2d::{draw_polyline, lissajous_2d, mquad_from_na, na_from_mquad};
+use common_macroquad::dim2::{draw_polyline, lissajous_2d, mquad_from_na, na_from_mquad};
 use macroquad::prelude::*;
 use na::{Isometry2, Vector2};
 use parry2d::bounding_volume::{Aabb, BoundingVolume};

--- a/crates/parry2d/examples/common_macroquad2d.rs
+++ b/crates/parry2d/examples/common_macroquad2d.rs
@@ -22,36 +22,46 @@ fn main() {
     );
 }
 
+/// Converts a [`nalgebra::Point2`] to a [`Vec2`], which is used by [`macroquad`]
 #[allow(dead_code)]
 pub fn mquad_from_na(a: Point2<Real>) -> Vec2 {
     Vec2::new(a.x, a.y)
 }
 
+/// Converts a [`Vec2`] to a [`nalgebra::Point2`], which is used by [`parry3d`]
 #[allow(dead_code)]
 pub fn na_from_mquad(a: Vec2) -> Point2<Real> {
     Point2::new(a.x, a.y)
 }
 
+/// Uses [`macroquad`] to display the line passed as parameter.
 #[allow(dead_code)]
-pub fn draw_polyline(polygon: Vec<(Vec2, Vec2)>, color: Color) {
-    for i in 0..polygon.len() {
-        let a = polygon[i].0;
-        let b = polygon[i].1;
+pub fn draw_polyline(polyline: Vec<(Vec2, Vec2)>, color: Color) {
+    for line in polyline {
+        let a = line.0;
+        let b = line.1;
         draw_line_2d(a, b, color);
     }
 }
 
+/// Draws a text in the top left corner of the screen.
+///
+/// This uses a hardcoded position, size, color.
 #[allow(dead_code)]
 pub fn easy_draw_text(text: &str) {
     macroquad::text::draw_text(text, 10.0, 48.0 + 18.0, 30.0, WHITE);
 }
 
+/// Returns [lissajous curve](https://en.wikipedia.org/wiki/Lissajous_curve) coordinates for time `t`.
+///
+/// This uses hardcoded parameters to have an arbitrary pleasing trajectory.
 #[allow(dead_code)]
 pub fn lissajous_2d(t: f32) -> Vec2 {
     // Some hardcoded parameters to have a pleasing lissajous trajectory.
     lissajous_2d_with_params(t, 3.0, 2.0, FRAC_PI_2, FRAC_PI_4)
 }
 
+/// Returns [lissajous curve](https://en.wikipedia.org/wiki/Lissajous_curve) coordinates.
 #[allow(dead_code)]
 pub fn lissajous_2d_with_params(t: f32, a: f32, b: f32, delta_x: f32, delta_y: f32) -> Vec2 {
     // Some hardcoded parameters to have a pleasing lissajous trajectory.
@@ -61,11 +71,13 @@ pub fn lissajous_2d_with_params(t: f32, a: f32, b: f32, delta_x: f32, delta_y: f
     Vec2::new(x, y) * 0.75f32
 }
 
+/// Uses [`macroquad`] to display the line passed as parameter.
 #[allow(dead_code)]
 pub fn draw_line_2d(a: Vec2, b: Vec2, color: Color) {
     draw_line(a.x, a.y, b.x, b.y, 2f32, color);
 }
 
+/// Uses [`macroquad`] to display the line passed as parameter.
 #[allow(dead_code)]
 pub fn draw_trimesh2(trimesh: &TriMesh, offset: Vec2) {
     let vertices = trimesh.vertices();
@@ -80,6 +92,7 @@ pub fn draw_trimesh2(trimesh: &TriMesh, offset: Vec2) {
     }
 }
 
+/// Uses [`macroquad`] to display a wireframe of the polygon.
 #[allow(dead_code)]
 pub fn draw_polygon(polygon: &[Point2<f32>], scale: f32, shift: Point2<f32>, color: Color) {
     for i in 0..polygon.len() {
@@ -96,6 +109,7 @@ pub fn draw_polygon(polygon: &[Point2<f32>], scale: f32, shift: Point2<f32>, col
     }
 }
 
+/// Uses [`macroquad`] to display the a cross, representing a point.
 #[allow(dead_code)]
 pub fn draw_point(point: Point2<f32>, scale: f32, shift: Point2<f32>, color: Color) {
     let edge_len = 0.15;

--- a/crates/parry2d/examples/convex_hull2d.rs
+++ b/crates/parry2d/examples/convex_hull2d.rs
@@ -1,11 +1,8 @@
-mod common_macroquad2d;
-
-use std::f32::consts::{FRAC_PI_2, FRAC_PI_4};
-
-use common_macroquad2d::{draw_point, draw_polygon, lissajous_2d_with_params, na_from_mquad};
+use common_macroquad::dim2::{draw_point, draw_polygon, lissajous_2d_with_params, na_from_mquad};
 use macroquad::prelude::*;
 use nalgebra::Point2;
 use parry2d::transformation;
+use std::f32::consts::{FRAC_PI_2, FRAC_PI_4};
 
 const RENDER_SCALE: f32 = 30.0;
 

--- a/crates/parry2d/examples/point_in_poly2d.rs
+++ b/crates/parry2d/examples/point_in_poly2d.rs
@@ -1,6 +1,4 @@
-mod common_macroquad2d;
-
-use common_macroquad2d::{draw_point, draw_polygon};
+use common_macroquad::dim2::{draw_point, draw_polygon};
 use macroquad::prelude::*;
 use nalgebra::{Point2, UnitComplex, Vector2};
 use parry2d::utils::point_in_poly2d;

--- a/crates/parry2d/examples/polygons_intersection2d.rs
+++ b/crates/parry2d/examples/polygons_intersection2d.rs
@@ -1,6 +1,4 @@
-mod common_macroquad2d;
-
-use common_macroquad2d::draw_polygon;
+use common_macroquad::dim2::draw_polygon;
 use macroquad::prelude::*;
 use nalgebra::{Point2, UnitComplex, Vector2};
 use parry2d::shape::Ball;

--- a/crates/parry2d/examples/project_point2d.rs
+++ b/crates/parry2d/examples/project_point2d.rs
@@ -1,6 +1,4 @@
-mod common_macroquad2d;
-
-use common_macroquad2d::{draw_line_2d, draw_trimesh2, lissajous_2d, mquad_from_na, na_from_mquad};
+use common_macroquad::dim2::{draw_line_2d, draw_trimesh2, lissajous_2d, mquad_from_na, na_from_mquad};
 use macroquad::prelude::*;
 use nalgebra::{Point3, UnitComplex, Vector2};
 use parry2d::math::{Isometry, Translation};

--- a/crates/parry2d/examples/project_point2d.rs
+++ b/crates/parry2d/examples/project_point2d.rs
@@ -1,4 +1,6 @@
-use common_macroquad::dim2::{draw_line_2d, draw_trimesh2, lissajous_2d, mquad_from_na, na_from_mquad};
+use common_macroquad::dim2::{
+    draw_line_2d, draw_trimesh2, lissajous_2d, mquad_from_na, na_from_mquad,
+};
 use macroquad::prelude::*;
 use nalgebra::{Point3, UnitComplex, Vector2};
 use parry2d::math::{Isometry, Translation};

--- a/crates/parry2d/examples/raycasts_animated.rs
+++ b/crates/parry2d/examples/raycasts_animated.rs
@@ -1,6 +1,4 @@
-mod common_macroquad2d;
-
-use common_macroquad2d::draw_point;
+use common_macroquad::dim2::draw_point;
 use macroquad::prelude::*;
 use nalgebra::{Isometry2, Point2, UnitComplex, Vector2};
 use parry2d::math::Isometry;

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -92,6 +92,10 @@ rand = { version = "0.8" }
 macroquad = "0.4.12"
 nalgebra = { version = "0.33", default-features = false, features = ["rand"] }
 rand_isaac = "0.3"
+common_macroquad = { version = "0.1", path = "../common_macroquad", features = [
+    "dim3",
+] }
+fork = "*"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]

--- a/crates/parry3d/examples/aabb3d.rs
+++ b/crates/parry3d/examples/aabb3d.rs
@@ -1,8 +1,6 @@
-mod common_macroquad3d;
-
 extern crate nalgebra as na;
 
-use common_macroquad3d::{lissajous_3d, mquad_from_na, na_from_mquad};
+use common_macroquad::dim3::{lissajous_3d, mquad_from_na, na_from_mquad};
 use macroquad::prelude::*;
 use na::Isometry3;
 use parry3d::bounding_volume::{Aabb, BoundingVolume};

--- a/crates/parry3d/examples/bounding_sphere3d.rs
+++ b/crates/parry3d/examples/bounding_sphere3d.rs
@@ -1,10 +1,8 @@
-mod common_macroquad3d;
-
 extern crate nalgebra as na;
 
 use std::ops::Rem;
 
-use common_macroquad3d::{lissajous_3d, mquad_from_na, na_from_mquad};
+use common_macroquad::dim3::{lissajous_3d, mquad_from_na, na_from_mquad};
 use macroquad::prelude::*;
 use na::{Isometry3, Vector3};
 use parry3d::bounding_volume::BoundingVolume;

--- a/crates/parry3d/examples/common_macroquad3d.rs
+++ b/crates/parry3d/examples/common_macroquad3d.rs
@@ -17,22 +17,28 @@ fn main() {
     );
 }
 
+/// Converts a [`nalgebra::Point3`] to a [`Vec3`], which is used by [`macroquad`]
 #[allow(dead_code)]
 pub fn mquad_from_na(a: Point3<Real>) -> Vec3 {
     Vec3::new(a.x, a.y, a.z)
 }
 
+/// Converts a [`Vec3`] to a [`nalgebra::Point3`], which is used by [`parry3d`]
 #[allow(dead_code)]
 pub fn na_from_mquad(a: Vec3) -> Point3<Real> {
     Point3::new(a.x, a.y, a.z)
 }
 
+/// Returns [lissajous curve](https://en.wikipedia.org/wiki/Lissajous_curve) coordinates for time `t`.
+///
+/// This uses hardcoded parameters to have an arbitrary pleasing trajectory.
 #[allow(dead_code)]
 pub fn lissajous_3d(t: f32) -> Vec3 {
     // Some hardcoded parameters to have a pleasing lissajous trajectory.
     lissajous_3d_with_params(t, 3.0, 2.0, 1.0, FRAC_PI_2, FRAC_PI_4, FRAC_PI_6)
 }
 
+/// Returns [lissajous curve](https://en.wikipedia.org/wiki/Lissajous_curve) coordinates.
 #[allow(dead_code)]
 pub fn lissajous_3d_with_params(
     t: f32,
@@ -49,20 +55,28 @@ pub fn lissajous_3d_with_params(
     Vec3::new(x, y, z) * 0.75f32
 }
 
+/// Uses [`macroquad`] to display the line passed as parameter.
 #[allow(dead_code)]
-pub fn draw_polyline(polygon: Vec<(Vec3, Vec3)>, color: Color) {
-    for i in 0..polygon.len() {
-        let a = polygon[i].0;
-        let b = polygon[i].1;
+pub fn draw_polyline(polyline: Vec<(Vec3, Vec3)>, color: Color) {
+    for line in polyline {
+        let a = line.0;
+        let b = line.1;
         draw_line_3d(a, b, color);
     }
 }
 
+/// Draws a text in the top left corner of the screen.
+///
+/// This uses a hardcoded position, size, color.
 #[allow(dead_code)]
 pub fn easy_draw_text(text: &str) {
     macroquad::text::draw_text(text, 10.0, 48.0 + 18.0, 30.0, WHITE);
 }
 
+/// Create a usable mesh for [`macroquad`].
+///
+/// This duplicates the trimesh vertices, computes their normals,
+/// and bakes light into its vertices colors using [`mquad_compute_normals_and_bake_light`].
 #[allow(dead_code)]
 pub fn mquad_mesh_from_points(
     trimesh: &(Vec<Point3<Real>>, Vec<[u32; 3]>),
@@ -104,6 +118,7 @@ pub fn mquad_mesh_from_points(
     mesh
 }
 
+/// Bakes light into vertices, using an hardcoded light strength.
 #[allow(dead_code)]
 pub fn mquad_compute_normals_and_bake_light(
     points: &Vec<Vertex>,

--- a/crates/parry3d/examples/convex_hull3d.rs
+++ b/crates/parry3d/examples/convex_hull3d.rs
@@ -1,8 +1,6 @@
-mod common_macroquad3d;
-
 use std::f32::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_6};
 
-use common_macroquad3d::{
+use common_macroquad::dim3::{
     lissajous_3d_with_params, mquad_from_na, mquad_mesh_from_points, na_from_mquad,
 };
 use macroquad::prelude::*;

--- a/crates/parry3d/examples/plane_intersection.rs
+++ b/crates/parry3d/examples/plane_intersection.rs
@@ -3,11 +3,10 @@ use nalgebra::{UnitVector3, Vector3};
 use parry3d::query::IntersectResult;
 use parry3d::shape::{Cuboid, TriMesh};
 
-mod common_macroquad3d;
-use common_macroquad3d::*;
+use common_macroquad::dim3::*;
 
 #[macroquad::main("parry3d::query::PlaneIntersection")]
-async fn main() {
+pub async fn main() {
     let trimesh = Cuboid::new(Vector3::repeat(1.0)).to_trimesh();
 
     let light_pos = Vec3::new(-1f32, 3.5f32, -3f32);

--- a/crates/parry3d/examples/project_point3d.rs
+++ b/crates/parry3d/examples/project_point3d.rs
@@ -3,8 +3,7 @@ use nalgebra::Vector3;
 use parry3d::query::PointQuery;
 use parry3d::shape::{Cuboid, TriMesh, TriMeshFlags};
 
-mod common_macroquad3d;
-use common_macroquad3d::*;
+use common_macroquad::dim3::*;
 
 #[macroquad::main("parry3d::query::PlaneIntersection")]
 async fn main() {

--- a/crates/parry3d/examples/testbed.rs
+++ b/crates/parry3d/examples/testbed.rs
@@ -1,0 +1,24 @@
+mod plane_intersection;
+use fork::{fork, Fork};
+
+fn main() {
+    // NOTE: we can't use threads via macroquad: it supports only 1 window ; so I'm forking it.
+    // This will be problematic to support wasm...
+    // ...but! maybe not entirely difficult to make them target a specific canvas
+    // This would still need a custom communication layer between both windows/canvas,
+    // which would be different between web and native
+    match fork() {
+        Ok(Fork::Parent(child)) => {
+            plane_intersection::main();
+            println!(
+                "Continuing execution in parent process, new child has pid: {}",
+                child
+            );
+        }
+        Ok(Fork::Child) => {
+            plane_intersection::main();
+            println!("I'm a new child process")
+        }
+        Err(_) => println!("Fork failed"),
+    }
+}


### PR DESCRIPTION
- based on https://github.com/dimforge/parry/pull/275

- makes `common_macroquad` its own crate, it's the best solution to be able to use it from another example + reduces some warnings naturally. I think this changes is for the best and I can set this up in a different PR if need be.
- explores solution for a parry testbed, we have quite a lot of options, and an "RFC" might be best before starting to work on that, but c3cd122e8c7b6fc10b642c144f6ecbc742af120d starts to explore a "minimum effort testbed".

# Minimum effort testbed

Reuse code from examples as-is, with no modifications.

We can fork our process, have 1 controller and 1 demo ; the controller can kill the demo and spawn a new one.

- advantages:
  - no modification to existing examples :tada: ; that reduces a lot of cognitive load for the user.
  - simple to implement for native, not much code.
- disadvantages:
  - wasm compatibility is not totally trivial to make
  - result is 2 windows, which is arguably not as pretty as an integrated controller.

# Modular macroquad

With minimal changes to the examples, we could make them expose a function to draw their own frame, and probably pass them their own state.

Reusing egui to have something comparable to rapier / bevy_rapier seems possible through https://github.com/optozorax/egui-macroquad ; but will likely need maintenance/updating efforts.

- advantages:
  - easier wasm integration (only 1 canvas needed)
  - comparable experience to other rapier ecosystems testbeds.
- disadvantages
  - small modifications to examples needed
  - maintaining a egui / testbed using another dependency than the rest of rapier ecosystem.

# Using bevy

Using bevy can be interesting by isolating each example to their own plugin.

- advantages:
  - benefiting bevy ecosystem, easier to move camera, or use 3d features.
  - same dependencies as rapier testbed
- disadvantages
  - more complex examples ; see previous attempt: https://github.com/dimforge/parry/pull/219
  - longer compile times