### PR TITLE
Improve robustness of mesh/mesh intersection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,27 @@
 ### Added
 
 - Implement `::to_trimesh` in 2d for `Cuboid` and `Aabb`.
-- Implement `Shape::feature_normal_at_point` for `TriMesh` to retrieve the normal of a face, when passing a `FeatureId::Face`.
+- Implement `Shape::feature_normal_at_point` for `TriMesh` to retrieve the normal of a face, when passing a
+  `FeatureId::Face`.
+- Add `convex_polygons_intersection_points_with_tolerances`, `convex_polygons_intersection_with_tolerances`, and
+  `intersect_meshes_with_tolerances` that let the user specify tolerances value for the collinearity check.
 
 ### Modified
 
 - Propagate error information while creating a mesh and using functions making use of it (See #262):
-  - `TriMesh::new`
-  - `TriMesh::intersection_with_aabb`
-  - `SharedShape::trimesh`
-  - `SharedShape::trimesh_with_flags`
+    - `TriMesh::new`
+    - `TriMesh::intersection_with_aabb`
+    - `SharedShape::trimesh`
+    - `SharedShape::trimesh_with_flags`
 - `point_cloud_bounding_sphere_with_center` now returns a `BoundingSphere`.
+
+### Fixed
+
+- Fixed some robustness issues in mesh/mesh intersection when parts of both meshes overlap perfectly.
+- Improve robustness of convex polygons intersections when all the vertices of one polygon are located in either the
+  edges or vertices of the other polygon.
+- Fix incorrect orientation sometimes given to the polygon output by the convex polygon intersections when one of the
+  polygon is completely inside the other.
 
 ## v0.17.1
 
@@ -293,7 +304,8 @@ This version was yanked. See the release notes for 0.13.3 instead.
   for most shapes.
 - Add the `parallel` feature that enables methods for the parallel traversal of Qbvh
   trees: `Qbvh::traverse_bvtt_parallel`,
-  `Qbvh::traverse_bvtt_node_parallel`, `Qbvh::traverse_depth_first_parallel`, `Qbvh::traverse_depth_first_node_parallel`.
+  `Qbvh::traverse_bvtt_node_parallel`, `Qbvh::traverse_depth_first_parallel`,
+  `Qbvh::traverse_depth_first_node_parallel`.
 
 ### Fixed
 

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -8,7 +8,8 @@ use na::{Point3, Vector3};
 use rstar::RTree;
 use spade::{ConstrainedDelaunayTriangulation, InsertionError, Triangulation as _};
 use std::collections::BTreeMap;
-use std::collections::{hash_map::Entry, HashMap, HashSet};
+use crate::utils::hashmap::HashMap;
+use std::collections::{hash_map::Entry, HashSet};
 #[cfg(feature = "wavefront")]
 use std::path::PathBuf;
 
@@ -163,7 +164,7 @@ pub fn intersect_meshes_with_tolerances(
     // 4: Initialize a new mesh by inserting points into a set. Duplicate points should
     // hash to the same index.
     let mut point_set = RTree::<TreePoint, _>::new();
-    let mut topology_indices = HashMap::new();
+    let mut topology_indices = HashMap::default();
     {
         let mut insert_point = |position: Point3<Real>| {
             insert_into_set(

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -8,9 +8,23 @@ use na::{Point3, Vector3};
 use rstar::RTree;
 use spade::{ConstrainedDelaunayTriangulation, InsertionError, Triangulation as _};
 use std::collections::BTreeMap;
-use std::collections::HashSet;
+use std::collections::{hash_map::Entry, HashMap, HashSet};
 #[cfg(feature = "wavefront")]
 use std::path::PathBuf;
+
+/// A triangle with indices sorted in increasing order for deduplication in a hashmap.
+///
+/// Note that when converting a `[u32; 3]` into a `HashableTriangleIndices`, the result’s orientation
+/// might not match the input’s.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+struct HashableTriangleIndices([u32; 3]);
+
+impl From<[u32; 3]> for HashableTriangleIndices {
+    fn from([a, b, c]: [u32; 3]) -> Self {
+        let (sa, sb, sc) = crate::utils::sort3(&a, &b, &c);
+        HashableTriangleIndices([*sa, *sb, *sc])
+    }
+}
 
 /// Metadata that specifies thresholds to use when making construction choices
 /// in mesh intersections.
@@ -143,7 +157,7 @@ pub fn intersect_meshes_with_tolerances(
     // 4: Initialize a new mesh by inserting points into a set. Duplicate points should
     // hash to the same index.
     let mut point_set = RTree::<TreePoint, _>::new();
-    let mut topology_indices = Vec::new();
+    let mut topology_indices = HashMap::new();
     {
         let mut insert_point = |position: Point3<Real>| {
             insert_into_set(position, &mut point_set, meta_data.global_insertion_epsilon) as u32
@@ -153,11 +167,13 @@ pub fn intersect_meshes_with_tolerances(
             if flip1 {
                 face.swap(0, 1);
             }
-            topology_indices.push([
+
+            let idx = [
                 insert_point(pos1 * mesh1.vertices()[face[0] as usize]),
                 insert_point(pos1 * mesh1.vertices()[face[1] as usize]),
                 insert_point(pos1 * mesh1.vertices()[face[2] as usize]),
-            ]);
+            ];
+            let _ = topology_indices.insert(idx.into(), idx);
         }
 
         // Add the inside vertices and triangles from mesh2
@@ -165,11 +181,12 @@ pub fn intersect_meshes_with_tolerances(
             if flip2 {
                 face.swap(0, 1);
             }
-            topology_indices.push([
+            let idx = [
                 insert_point(pos2 * mesh2.vertices()[face[0] as usize]),
                 insert_point(pos2 * mesh2.vertices()[face[1] as usize]),
                 insert_point(pos2 * mesh2.vertices()[face[2] as usize]),
-            ]);
+            ];
+            let _ = topology_indices.insert(idx.into(), idx);
         }
     }
 
@@ -243,7 +260,10 @@ pub fn intersect_meshes_with_tolerances(
     let vertices: Vec<_> = vertices.iter().map(|p| Point3::from(p.point)).collect();
 
     if !topology_indices.is_empty() {
-        Ok(Some(TriMesh::new(vertices, topology_indices)?))
+        Ok(Some(TriMesh::new(
+            vertices,
+            topology_indices.into_values().collect(),
+        )?))
     } else {
         Ok(None)
     }
@@ -558,28 +578,20 @@ fn is_triangle_degenerate(
         return true;
     }
 
-    let mut shortest_side = Real::MAX;
     for i in 0..3 {
-        let p1 = triangle[i];
-        let p2 = triangle[(i + 1) % 3];
-
-        shortest_side = shortest_side.min((p1 - p2).norm());
-    }
-
-    let mut worse_projection_distance = Real::MAX;
-    for i in 0..3 {
-        let dir = triangle[(i + 1) % 3] - triangle[(i + 2) % 3];
-        if dir.norm() < epsilon_distance {
+        let mut dir = triangle[(i + 1) % 3] - triangle[(i + 2) % 3];
+        if dir.normalize_mut() < epsilon_distance {
             return true;
         }
 
-        let dir = dir.normalize();
         let proj = triangle[(i + 2) % 3] + (triangle[i] - triangle[(i + 2) % 3]).dot(&dir) * dir;
 
-        worse_projection_distance = worse_projection_distance.min((proj - triangle[i]).norm());
+        if (proj - triangle[i]).norm() < epsilon_distance {
+            return true;
+        }
     }
 
-    worse_projection_distance < epsilon_distance
+    false
 }
 
 fn merge_triangle_sets(
@@ -592,10 +604,10 @@ fn merge_triangle_sets(
     flip2: bool,
     metadata: &MeshIntersectionTolerances,
     point_set: &mut RTree<TreePoint>,
-    topology_indices: &mut Vec<[u32; 3]>,
+    topology_indices: &mut HashMap<HashableTriangleIndices, [u32; 3]>,
 ) -> Result<(), MeshIntersectionError> {
     // For each triangle, and each constraint edge associated to that triangle,
-    // make a triangulation of the face and sort whether or not each generated
+    // make a triangulation of the face and sort whether each generated
     // sub-triangle is part of the intersection.
     // For each sub-triangle that is part of the intersection, add them to the
     // output mesh.
@@ -638,23 +650,52 @@ fn merge_triangle_sets(
                 .0;
 
             if flip2 ^ (projection.is_inside_eps(&center, epsilon)) {
-                topology_indices.push([
+                let mut new_tri_idx = [
                     insert_into_set(p1, point_set, epsilon) as u32,
                     insert_into_set(p2, point_set, epsilon) as u32,
                     insert_into_set(p3, point_set, epsilon) as u32,
-                ]);
+                ];
 
                 if flip1 {
-                    topology_indices.last_mut().unwrap().swap(0, 1)
+                    new_tri_idx.swap(0, 1)
                 }
-
-                let [id1, id2, id3] = topology_indices.last().unwrap();
 
                 // This should *never* trigger. If it does
                 // it means the code has created a triangle with duplicate vertices,
                 // which means we encountered an unaccounted for edge case.
-                if id1 == id2 || id1 == id3 || id2 == id3 {
+                if new_tri_idx[0] == new_tri_idx[1]
+                    || new_tri_idx[0] == new_tri_idx[2]
+                    || new_tri_idx[1] == new_tri_idx[2]
+                {
                     return Err(MeshIntersectionError::DuplicateVertices);
+                }
+
+                // Insert in the hashmap with sorted indices to avoid adding duplicates.
+                // We also check if we don’t keep pairs of triangles that have the same
+                // set of indices but opposite orientations.
+                match topology_indices.entry(new_tri_idx.into()) {
+                    Entry::Vacant(e) => {
+                        let _ = e.insert(new_tri_idx);
+                    }
+                    Entry::Occupied(e) => {
+                        fn same_orientation(a: &[u32; 3], b: &[u32; 3]) -> bool {
+                            let ib = if a[0] == b[0] {
+                                0
+                            } else if a[0] == b[1] {
+                                1
+                            } else {
+                                2
+                            };
+                            a[1] == b[(ib + 1) % 3]
+                        }
+
+                        if !same_orientation(e.get(), &new_tri_idx) {
+                            // If we are inserting two identical triangles but with mismatching
+                            // orientations, we can just ignore both because they cover a degenerate
+                            // 2D plane.
+                            let _ = e.remove();
+                        }
+                    }
                 }
             }
         }

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -4,11 +4,11 @@ use crate::query::point::point_query::PointQueryWithLocation;
 use crate::query::{visitors::BoundingVolumeIntersectionsSimultaneousVisitor, PointQuery};
 use crate::shape::{TriMesh, Triangle};
 use crate::utils;
+use crate::utils::hashmap::HashMap;
 use na::{Point3, Vector3};
 use rstar::RTree;
 use spade::{ConstrainedDelaunayTriangulation, InsertionError, Triangulation as _};
 use std::collections::BTreeMap;
-use crate::utils::hashmap::HashMap;
 use std::collections::{hash_map::Entry, HashSet};
 #[cfg(feature = "wavefront")]
 use std::path::PathBuf;

--- a/src/transformation/mesh_intersection/mesh_intersection_error.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection_error.rs
@@ -1,13 +1,16 @@
 use crate::shape::TriMeshBuilderError;
 
+#[cfg(doc)]
+use crate::shape::{TriMesh, TriMeshFlags};
+
 /// Error indicating that a query is not supported between certain shapes
 #[derive(thiserror::Error, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MeshIntersectionError {
-    /// At least one of the meshes is missing its topology information. Call `mesh.compute_topology` on the mesh
-    #[error("at least one of the meshes is missing its topology information. Call `mesh.compute_topology` on the mesh")]
+    /// At least one of the meshes is missing its topology information. Ensure that the [`TriMeshFlags::ORIENTED`] flag is enabled on both meshes.
+    #[error("at least one of the meshes is missing its topology information. Ensure that the `TriMeshFlags::ORIENTED` flag is enabled on both meshes.")]
     MissingTopology,
-    /// At least one of the meshes is missing its pseudo-normals. Call `mesh.compute_pseudo_normals` on the mesh
-    #[error("at least one of the meshes is missing its pseudo-normals. Call `mesh.compute_pseudo_normals` on the mesh")]
+    /// At least one of the meshes is missing its pseudo-normals. Ensure that the [`TriMeshFlags::ORIENTED`] flag is enabled on both meshes.
+    #[error("at least one of the meshes is missing its pseudo-normals. Ensure that the `TriMeshFlags::ORIENTED` flag is enabled on both meshes.")]
     MissingPseudoNormals,
     /// Internal failure while intersecting two triangles
     #[error("internal failure while intersecting two triangles")]

--- a/src/transformation/mesh_intersection/mod.rs
+++ b/src/transformation/mesh_intersection/mod.rs
@@ -1,4 +1,6 @@
-pub use self::mesh_intersection::intersect_meshes;
+pub use self::mesh_intersection::{
+    intersect_meshes, intersect_meshes_with_tolerances, MeshIntersectionTolerances,
+};
 pub use self::mesh_intersection_error::MeshIntersectionError;
 use triangle_triangle_intersection::*;
 

--- a/src/transformation/mesh_intersection/triangle_triangle_intersection.rs
+++ b/src/transformation/mesh_intersection/triangle_triangle_intersection.rs
@@ -1,9 +1,13 @@
 use super::EPS;
 use crate::math::{Point, Real, Vector};
 use crate::query;
+use crate::query::PointQuery;
 use crate::shape::{FeatureId, Segment, Triangle};
-use crate::transformation::polygon_intersection::PolylinePointLocation;
+use crate::transformation::polygon_intersection::{
+    PolygonIntersectionTolerances, PolylinePointLocation,
+};
 use crate::utils::WBasis;
+use na::Point2;
 
 #[derive(Copy, Clone, Debug, Default)]
 pub struct TriangleTriangleIntersectionPoint {
@@ -28,9 +32,10 @@ impl Default for TriangleTriangleIntersection {
     }
 }
 
-pub fn triangle_triangle_intersection(
+pub(crate) fn triangle_triangle_intersection(
     tri1: &Triangle,
     tri2: &Triangle,
+    collinearity_epsilon: Real,
 ) -> Option<TriangleTriangleIntersection> {
     let normal1 = tri1.robust_normal();
     let normal2 = tri2.robust_normal();
@@ -113,8 +118,7 @@ pub fn triangle_triangle_intersection(
         let unit_normal2 = normal2.normalize();
         if (tri1.a - tri2.a).dot(&unit_normal2) < EPS {
             let basis = unit_normal2.orthonormal_basis();
-            let proj =
-                |vect: Vector<Real>| na::Point2::new(vect.dot(&basis[0]), vect.dot(&basis[1]));
+            let proj = |vect: Vector<Real>| Point2::new(vect.dot(&basis[0]), vect.dot(&basis[1]));
 
             let mut intersections = vec![];
 
@@ -144,25 +148,39 @@ pub fn triangle_triangle_intersection(
                 ),
             };
 
-            crate::transformation::convex_polygons_intersection(&poly1, &poly2, |pt1, pt2| {
-                let intersection = match (pt1, pt2) {
-                    (Some(loc1), Some(loc2)) => {
-                        let (_f1, p1) = convert_loc(loc1, pts1);
-                        let (_f2, _p2) = convert_loc(loc2, pts2);
-                        TriangleTriangleIntersectionPoint { p1 }
-                    }
-                    (Some(loc1), None) => {
-                        let (_f1, p1) = convert_loc(loc1, pts1);
-                        TriangleTriangleIntersectionPoint { p1 }
-                    }
-                    (None, Some(loc2)) => {
-                        let (_f2, p2) = convert_loc(loc2, pts2);
-                        TriangleTriangleIntersectionPoint { p1: p2 }
-                    }
-                    (None, None) => unreachable!(),
-                };
-                intersections.push(intersection);
-            });
+            crate::transformation::convex_polygons_intersection_with_tolerances(
+                &poly1,
+                &poly2,
+                PolygonIntersectionTolerances {
+                    collinearity_epsilon,
+                },
+                |pt1, pt2| {
+                    let intersection = match (pt1, pt2) {
+                        (Some(loc1), Some(loc2)) => {
+                            let (_f1, p1) = convert_loc(loc1, pts1);
+                            let (_f2, _p2) = convert_loc(loc2, pts2);
+                            TriangleTriangleIntersectionPoint { p1 }
+                        }
+                        (Some(loc1), None) => {
+                            let (_f1, p1) = convert_loc(loc1, pts1);
+                            TriangleTriangleIntersectionPoint { p1 }
+                        }
+                        (None, Some(loc2)) => {
+                            let (_f2, p2) = convert_loc(loc2, pts2);
+                            TriangleTriangleIntersectionPoint { p1: p2 }
+                        }
+                        (None, None) => unreachable!(),
+                    };
+                    intersections.push(intersection);
+                },
+            );
+
+            // NOTE: set this to `true` to automatically check if the computed intersection is
+            //       valid, and print debug infos if it is not.
+            const DEBUG_INTERSECTIONS: bool = false;
+            if DEBUG_INTERSECTIONS {
+                debug_check_intersections(tri1, tri2, &basis, &poly1, &poly2, &intersections);
+            }
 
             Some(TriangleTriangleIntersection::Polygon(intersections))
         } else {
@@ -193,5 +211,78 @@ fn segment_plane_intersection(
         Some((segment.b, FeatureId::Vertex(vids.1)))
     } else {
         Some((segment.a + dir * time_of_impact, FeatureId::Edge(eid)))
+    }
+}
+
+/// Prints debug information if the calulated intersection of two triangles is detected to be
+/// invalid.
+///
+/// If the intersection is valid, this prints nothing. If it isn’t valid, this will print a few
+/// lines to copy/paste into the Desmos online graphing tool (for visual debugging), as well as
+/// some rust code to add to the `tris` array in the `intersect_triangle_common_vertex` test for
+/// regression checking.
+fn debug_check_intersections(
+    tri1: &Triangle,
+    tri2: &Triangle,
+    basis: &[na::Vector3<Real>; 2],
+    poly1: &[Point2<Real>], // Projection of tri1 on the basis `basis1` with the origin at tri2.a.
+    poly2: &[Point2<Real>], // Projection of tri2 on the basis `basis2` with the origin at tri2.a.
+    intersections: &[TriangleTriangleIntersectionPoint],
+) {
+    let proj = |vect: Vector<Real>| Point2::new(vect.dot(&basis[0]), vect.dot(&basis[1]));
+    let mut incorrect = false;
+    for pt in intersections {
+        if !tri1
+            .project_local_point(&pt.p1, false)
+            .is_inside_eps(&pt.p1, 1.0e-5)
+        {
+            incorrect = true;
+            break;
+        }
+
+        if !tri2
+            .project_local_point(&pt.p1, false)
+            .is_inside_eps(&pt.p1, 1.0e-5)
+        {
+            incorrect = true;
+            break;
+        }
+    }
+
+    if incorrect {
+        let proj_inter: Vec<_> = intersections.iter().map(|p| proj(p.p1 - tri2.a)).collect();
+        println!("-------- (copy/paste the following on Desmos graphing)");
+        println!("A=({:.2},{:.2})", poly1[0].x, poly1[0].y);
+        println!("B=({:.2},{:.2})", poly1[1].x, poly1[1].y);
+        println!("C=({:.2},{:.2})", poly1[2].x, poly1[2].y);
+        println!("D=({:.2},{:.2})", poly2[0].x, poly2[0].y);
+        println!("E=({:.2},{:.2})", poly2[1].x, poly2[1].y);
+        println!("F=({:.2},{:.2})", poly2[2].x, poly2[2].y);
+
+        let lbls = ["G", "H", "I", "J", "K", "L", "M", "N", "O"];
+        for (i, inter) in proj_inter.iter().enumerate() {
+            println!("{}=({:.2},{:.2})", lbls[i], inter.x, inter.y);
+        }
+
+        // polygons
+        println!("X=polygon(A,B,C)");
+        println!("Y=polygon(D,E,F)");
+        print!("Z=polygon({}", lbls[0]);
+        for lbl in lbls.iter().skip(1) {
+            print!(",{}", lbl);
+        }
+        println!(")");
+
+        println!("~~~~~~~ (copy/paste the folliwing input in the `intersect_triangle_common_vertex` test)");
+        println!("(Triangle::new(");
+        for pt1 in poly1 {
+            println!("    Point2::new({},{}),", pt1.x, pt1.y);
+        }
+        println!("),");
+        println!("Triangle::new(");
+        for pt2 in poly2 {
+            println!("    Point2::new({},{}),", pt2.x, pt2.y);
+        }
+        println!("),),");
     }
 }

--- a/src/transformation/mod.rs
+++ b/src/transformation/mod.rs
@@ -12,7 +12,9 @@ pub use self::mesh_intersection::{
     MeshIntersectionTolerances,
 };
 pub use self::polygon_intersection::{
-    convex_polygons_intersection, convex_polygons_intersection_points, polygons_intersection,
+    convex_polygons_intersection, convex_polygons_intersection_points,
+    convex_polygons_intersection_points_with_tolerances,
+    convex_polygons_intersection_with_tolerances, polygons_intersection,
     polygons_intersection_points,
 };
 

--- a/src/transformation/mod.rs
+++ b/src/transformation/mod.rs
@@ -7,7 +7,10 @@ pub use self::convex_hull2::{convex_hull2 as convex_hull, convex_hull2_idx as co
 #[cfg(feature = "dim3")]
 pub use self::convex_hull3::{check_convex_hull, convex_hull, try_convex_hull, ConvexHullError};
 #[cfg(feature = "dim3")]
-pub use self::mesh_intersection::{intersect_meshes, MeshIntersectionError};
+pub use self::mesh_intersection::{
+    intersect_meshes, intersect_meshes_with_tolerances, MeshIntersectionError,
+    MeshIntersectionTolerances,
+};
 pub use self::polygon_intersection::{
     convex_polygons_intersection, convex_polygons_intersection_points, polygons_intersection,
     polygons_intersection_points,


### PR DESCRIPTION
This PR further improves the robustness the mesh/mesh intersection for a better handling of pars of meshes with coplanar triangles. This was motivated by the need to fix a case where the same mesh would be cut multiple times by the exact same second mesh. All cuts except for the first one result in degenerate cases where many triangles are coplanar.


This applies the following changes:
- Fix an issue where the orientation of a triangle output by the convex-polygons intersection algorithm, when given one triangle fully inside the other, is incorrect.
- Fix an issue where coplanar triangles could be output twice by the mesh/mesh intersection code.
- Improve robustness of convex-polygons intersection by avoiding the incorrect in-out state to be set when traversing an ambiguous configuration (when a point of one polygon lies exactly on an edge of the other polygon).
- Fix an issue where the vertices of both polygons might be output by the convex-polygons intersection algorithm if one triangle is fully inside the other but has its vertices exactly on the edges of the other polygon.

Tolerances can now be specified for the mesh/mesh intersection (the method has been made public), and for the convex-polygons intersection.

The variable names in convex-polygons intersection have be changed for better readability.
Note that this introduces a O(n²) complexity for the case where a polygon is fully inside the other one. This can be addressed in a future PR.