### PR TITLE
Release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## v0.18.0
 
 ### Added
 

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.17.1"
+version = "0.18.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.17.1"
+version = "0.18.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.17.1"
+version = "0.18.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.17.1"
+version = "0.18.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."


### PR DESCRIPTION
## v0.18.0

### Added

- Implement `::to_trimesh` in 2d for `Cuboid` and `Aabb`.
- Fix some edge-cases in `point_in_poly2d` for self-intersecting polygons.
- Fix some edge-cases in mesh/mesh intersection that could result in degenerate triangles being generated.

### Modified

- Propagate error information while creating a mesh and using functions making use of it (See #262):
  - `TriMesh::new`
  - `TriMesh::intersection_with_aabb`
  - `SharedShape::trimesh`
  - `SharedShape::trimesh_with_flags`
- `point_cloud_bounding_sphere` and `point_cloud_bounding_sphere_with_center` now returns a `BoundingSphere`.
- Removed `IntersectionCompositeShapeShapeBestFirstVisitor` (which had been deprecated for a while):
  use `IntersectionCompositeShapeShapeVisitor` instead.
