### PR TITLE
Update `thiserror` to 2.x

### DIFF
--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -29,7 +29,7 @@ std = [
     "simba/std",
     "arrayvec/std",
     "spade",
-    "thiserror",
+    "thiserror/std",
     "ena"
 ]
 dim2 = []
@@ -84,7 +84,7 @@ rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
 ordered-float = { version = "4", default-features = false }
-thiserror = { version = "1", optional = true }
+thiserror = { version = "2", default-features = false }
 ena = { version = "0.14.3", optional = true }
 
 [dev-dependencies]

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -29,7 +29,7 @@ std = [
     "simba/std",
     "arrayvec/std",
     "spade",
-    "thiserror",
+    "thiserror/std",
     "ena"
 ]
 dim2 = []
@@ -84,7 +84,7 @@ rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 ordered-float = { version = "4", default-features = false }
 log = "0.4"
-thiserror = { version = "1", optional = true }
+thiserror = { version = "2", default-features = false }
 ena = { version = "0.14.3", optional = true }
 
 [dev-dependencies]

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -29,7 +29,7 @@ std = [
     "simba/std",
     "arrayvec/std",
     "spade",
-    "thiserror",
+    "thiserror/std",
     "ena"
 ]
 dim3 = []
@@ -85,7 +85,7 @@ ena = { version = "0.14.3", optional = true }
 
 log = "0.4"
 ordered-float = { version = "4", default-features = false }
-thiserror = { version = "1", optional = true }
+thiserror = { version = "2", default-features = false }
 
 [dev-dependencies]
 oorandom = "11"

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -29,7 +29,7 @@ std = [
     "simba/std",
     "arrayvec/std",
     "spade",
-    "thiserror",
+    "thiserror/std",
     "ena"
 ]
 dim3 = []
@@ -82,7 +82,7 @@ rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
 ordered-float = { version = "4", default-features = false }
-thiserror = { version = "1", optional = true }
+thiserror = { version = "2", default-features = false }
 rstar = "0.12.0"
 obj = { version = "0.10.2", optional = true }
 ena = { version = "0.14.3", optional = true }


### PR DESCRIPTION
This brings `no_std` support, so this is now able to be used in a `no_std` context, so always build it, but enable `std` support when building parry for `std`.