### PR TITLE
Fix shape-heightfield shape cast

### DIFF
--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -316,7 +316,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                     shape2,
                     options,
                 );
-            } else if let Some(heightfield2) = shape1.as_heightfield() {
+            } else if let Some(heightfield2) = shape2.as_heightfield() {
                 return query::details::cast_shapes_shape_heightfield(
                     self,
                     pos12,


### PR DESCRIPTION
This was causing shapecasts against heightfields to fall through to Unsupported, if and only if the heightfield was in the second position