### PR TITLE
Add mutable accessor for a VoxelSet's voxels.

### DIFF
--- a/src/transformation/voxelization/voxel_set.rs
+++ b/src/transformation/voxelization/voxel_set.rs
@@ -165,6 +165,11 @@ impl VoxelSet {
         &self.voxels
     }
 
+    /// A mutable reference to the set of voxels.
+    pub fn voxels_mut(&mut self) -> &mut Vec<Voxel> {
+        &mut self.voxels
+    }
+
     /// Update the bounding box of this voxel set.
     pub fn compute_bb(&mut self) {
         let num_voxels = self.voxels.len();


### PR DESCRIPTION
This is to allow external code to call into VHACD with a set of voxels that it computes without forcing it to generate a bunch of geometry to then get revoxelized.