### PR TITLE
Use cuboid_cuboid contact implementation.

### DIFF
--- a/src/query/contact/contact_cuboid_cuboid.rs
+++ b/src/query/contact/contact_cuboid_cuboid.rs
@@ -132,3 +132,25 @@ pub fn contact_cuboid_cuboid(
 
     unreachable!()
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        math::{Isometry, Vector},
+        query,
+        shape::{Cuboid, Shape},
+    };
+
+    #[test]
+    pub fn compare_with_support() {
+        let shape1 = Cuboid::new(Vector::repeat(1.0));
+        let shape2 = Cuboid::new(Vector::repeat(1.0));
+        let pos12 = Isometry::new(Vector::repeat(0.5), na::zero());
+        let s1 = shape1.as_support_map().unwrap();
+        let s2 = shape2.as_support_map().unwrap();
+        let result_support = query::details::contact_support_map_support_map(&pos12, s1, s2, 1.0);
+        let result_cuboid = query::details::contact_cuboid_cuboid(&pos12, &shape1, &shape2, 1.0);
+        dbg!(result_support);
+        dbg!(result_cuboid);
+    }
+}


### PR DESCRIPTION
cuboid_cuboid contact implementation is [currently commented out](https://github.com/Vrixyz/parry/blob/c2686ceded77722235b0fc2be54f766ae1bd708f/src/query/default_query_dispatcher.rs#L152-L156), this PR investigates why and will attempt to bring it back.

** :warning: Currently in draft because current implementation is incorrect.**

## step 1: add test

Currently, contact fall back to using the more generic "as_support_shape" implementation. Let's compare both results and see if any is incorrect.

a simple test (see c2686ceded77722235b0fc2be54f766ae1bd708f) reveal differences betweens the 2 implementations:

<details><summary>test log</summary>
<p>

```
[crates/parry3d-f64/../../src/query/contact/contact_cuboid_cuboid.rs:153:9] result_support = Some(
    Contact {
        point1: [
            1.0,
            0.25,
            0.25,
        ],
        point2: [
            -1.0,
            -0.25,
            -0.25,
        ],
        normal1: [
            [
                1.0,
                0.0,
                -0.0,
            ],
        ],
        normal2: [
            [
                -1.0,
                0.0,
                0.0,
            ],
        ],
        dist: -1.5,
    },
)
[crates/parry3d-f64/../../src/query/contact/contact_cuboid_cuboid.rs:154:9] result_cuboid = Some(
    Contact {
        point1: [
            -0.5,
            1.0,
            1.0,
        ],
        point2: [
            -1.0,
            1.0,
            1.0,
        ],
        normal1: [
            [
                0.0,
                0.7071067811865475,
                0.7071067811865475,
            ],
        ],
        normal2: [
            [
                0.0,
                -0.7071067811865475,
                -0.7071067811865475,
            ],
        ],
        dist: 0.7071067811865476,
    },
}
```

</p>
</details> 

on cuboid_cuboid, `dist` being positive suggests there is no intersection, which is wrong here.