### PR TITLE
Derive `Copy` for `VHACDParameters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+- derive `Copy` for `VHACDParameters`.
+
 ## v0.18.0
 
 ### Added

--- a/src/transformation/vhacd/parameters.rs
+++ b/src/transformation/vhacd/parameters.rs
@@ -4,7 +4,7 @@ use crate::transformation::voxelization::FillMode;
 /// Parameters controlling the VHACD convex decomposition.
 ///
 /// See <https://github.com/Unity-Technologies/VHACD#parameters> for details.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct VHACDParameters {
     /// Maximum concavity.
     ///


### PR DESCRIPTION
This is to make something in Rapier be able to impl `Copy`.