### PR TITLE
Improve `no_std` compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@
 
 ### Added
 
-- derive `Copy` for `VHACDParameters`.
+- Derive `Copy` for `VHACDParameters`.
+- Add `spade` default feature for algorithms using Delaunay triangulation from `spade`.
+
+### Modified
+
+- Improve `no_std` compatibility.
+  - Everything is now compatible, except `mesh_intersections`, `split_trimesh`,
+    convex hull validation, and computation of connected components for `TriMesh`.
+  - Add the `alloc_instead_of_core`, `std_instead_of_alloc`, and `std_instead_of_core` Clippy lints to the workspace.
+  - Use `core` and `alloc` directly rather than using an `std` alias.
+  - Use `hashbrown` instead of `rustc-hash` when `enhanced-determinism` is not enabled.
+  - Make `spade` optional.
 
 ## v0.18.0
 
@@ -158,7 +169,7 @@ This version modifies many names related to shape-casting:
   now prefixed with `cast_shapes_` (e.g. `cast_shapes_ball_ball`).
 - Rename `QueryDispatcher::time_of_impact` to `QueryDispatcher::cast_shapes`.
 - The (linear) shape-casting functions like `query::cast_shapes` (previously named
-  `query::time_of_impact) now take a `ShapeCastOptions` instead of the `max_toi` and
+  `query::time_of_impact`) now take a `ShapeCastOptions` instead of the `max_toi` and
   `stop_at_penetration` arguments.
 - Rename `query::nonlinear_time_of_impact` to `query::cast_shapes_nonlinear`.
 - Rename `QueryDispatcher::nonlinear_time_of_impact` to `QueryDispatcher::cast_shapes_nonlinear`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["crates/parry2d", "crates/parry3d", "crates/parry2d-f64", "crates/parry3d-f64"]
+members = [
+    "crates/parry2d",
+    "crates/parry3d",
+    "crates/parry2d-f64",
+    "crates/parry3d-f64",
+]
 resolver = "2"
 
 [workspace.lints]
@@ -8,6 +13,11 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
     # "wavefront" is only used for 3D crates.
     'cfg(feature, values("wavefront"))',
 ] }
+
+[workspace.lints.clippy]
+alloc_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"
 
 [patch.crates-io]
 parry2d = { path = "crates/parry2d" }

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -20,17 +20,17 @@ maintenance = { status = "actively-developed" }
 workspace = true
 
 [features]
-default = ["required-features", "std"]
+default = ["required-features", "alloc"]
 required-features = ["dim2", "f64"]
 std = [
     "nalgebra/std",
     "slab",
-    "rustc-hash",
     "simba/std",
     "arrayvec/std",
     "spade",
     "thiserror/std",
-    "ena"
+    "ena",
+    "spade/std",
 ]
 dim2 = []
 f64 = []
@@ -39,6 +39,7 @@ serde-serialize = [
     "nalgebra/serde-serialize",
     "arrayvec/serde",
     "bitflags/serde",
+    "spade/serde",
 ]
 rkyv-serialize = [
     "rkyv/validation",
@@ -50,7 +51,7 @@ simd-stable = ["simba/wide", "simd-is-enabled"]
 simd-nightly = ["simba/portable_simd", "simd-is-enabled"]
 enhanced-determinism = ["simba/libm_force", "indexmap"]
 parallel = ["rayon"]
-alloc = []
+alloc = ["nalgebra/alloc", "hashbrown"]
 improved_fixed_point_support = []
 
 # Do not enable this feature directly. It is automatically
@@ -76,17 +77,24 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 rkyv = { version = "0.7.41", optional = true }
 num-derive = "0.4"
 indexmap = { version = "2", features = ["serde"], optional = true }
-rustc-hash = { version = "2", optional = true }
+hashbrown = { version = "0.15", optional = true, default-features = false, features = [
+    "default-hasher",
+] }
 cust_core = { version = "0.1", optional = true }
-spade = { version = "2", optional = true } # Make this optional?
+spade = { version = "2", optional = true, default-features = false } # Make this optional?
+robust = { version = "1.1", optional = true, default-features = false, features = [
+    # Force `no_std` for `robust`, which is used by `spade`.
+    "no_std",
+] }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
 ordered-float = { version = "5", default-features = false }
 thiserror = { version = "2", default-features = false }
-ena = { version = "0.14.3", optional = true }
+ena = { version = "0.14.3", optional = true, default-features = false }
 
 [dev-dependencies]
+parry2d-f64 = { path = ".", features = ["std"] }
 simba = { version = "0.9", default-features = false }
 oorandom = "11"
 ptree = "0.4.0"

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -82,11 +82,7 @@ hashbrown = { version = "0.15", optional = true, default-features = false, featu
     "default-hasher",
 ] }
 cust_core = { version = "0.1", optional = true }
-spade = { version = "2", optional = true, default-features = false } # Make this optional?
-robust = { version = "1.1", optional = true, default-features = false, features = [
-    # Force `no_std` for `robust`, which is used by `spade`.
-    "no_std",
-] }
+spade = { version = "2", optional = true, default-features = false }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "actively-developed" }
 workspace = true
 
 [features]
-default = ["required-features", "std"]
+default = ["required-features", "std", "spade"]
 required-features = ["dim2", "f64"]
 std = [
     "nalgebra/std",
@@ -30,7 +30,7 @@ std = [
     "spade",
     "thiserror/std",
     "ena",
-    "spade/std",
+    "spade?/std",
 ]
 dim2 = []
 f64 = []
@@ -39,7 +39,7 @@ serde-serialize = [
     "nalgebra/serde-serialize",
     "arrayvec/serde",
     "bitflags/serde",
-    "spade/serde",
+    "spade?/serde",
 ]
 rkyv-serialize = [
     "rkyv/validation",
@@ -52,6 +52,7 @@ simd-nightly = ["simba/portable_simd", "simd-is-enabled"]
 enhanced-determinism = ["simba/libm_force", "indexmap"]
 parallel = ["rayon"]
 alloc = ["nalgebra/alloc", "hashbrown"]
+spade = ["dep:spade", "alloc"]
 improved_fixed_point_support = []
 
 # Do not enable this feature directly. It is automatically

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -92,7 +92,6 @@ thiserror = { version = "2", default-features = false }
 ena = { version = "0.14.3", optional = true, default-features = false }
 
 [dev-dependencies]
-parry2d-f64 = { path = ".", features = ["std"] }
 simba = { version = "0.9", default-features = false }
 oorandom = "11"
 ptree = "0.4.0"

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "actively-developed" }
 workspace = true
 
 [features]
-default = ["required-features", "alloc"]
+default = ["required-features", "std"]
 required-features = ["dim2", "f64"]
 std = [
     "nalgebra/std",

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -39,6 +39,7 @@ serde-serialize = [
     "nalgebra/serde-serialize",
     "arrayvec/serde",
     "bitflags/serde",
+    "hashbrown?/serde",
     "spade?/serde",
 ]
 rkyv-serialize = [

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -83,10 +83,6 @@ hashbrown = { version = "0.15", optional = true, default-features = false, featu
 ] }
 cust_core = { version = "0.1", optional = true }
 spade = { version = "2", optional = true, default-features = false }
-robust = { version = "1.1", optional = true, default-features = false, features = [
-    # Force `no_std` for `robust`, which is used by `spade`.
-    "no_std",
-] }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 ordered-float = { version = "5", default-features = false }

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -92,7 +92,6 @@ thiserror = { version = "2", default-features = false }
 ena = { version = "0.14.3", optional = true, default-features = false }
 
 [dev-dependencies]
-parry2d = { path = ".", features = ["std"] }
 simba = { version = "0.9", default-features = false }
 oorandom = "11"
 ptree = "0.4.0"

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -20,17 +20,17 @@ maintenance = { status = "actively-developed" }
 workspace = true
 
 [features]
-default = ["required-features", "std"]
+default = ["required-features", "alloc"]
 required-features = ["dim2", "f32"]
 std = [
+    "alloc",
     "nalgebra/std",
     "slab",
-    "rustc-hash",
     "simba/std",
     "arrayvec/std",
-    "spade",
+    "spade/std",
     "thiserror/std",
-    "ena"
+    "ena",
 ]
 dim2 = []
 f32 = []
@@ -39,6 +39,7 @@ serde-serialize = [
     "nalgebra/serde-serialize",
     "arrayvec/serde",
     "bitflags/serde",
+    "spade/serde",
 ]
 rkyv-serialize = [
     "rkyv/validation",
@@ -50,7 +51,7 @@ simd-stable = ["simba/wide", "simd-is-enabled"]
 simd-nightly = ["simba/portable_simd", "simd-is-enabled"]
 enhanced-determinism = ["simba/libm_force", "indexmap"]
 parallel = ["rayon"]
-alloc = []
+alloc = ["nalgebra/alloc", "hashbrown"]
 improved_fixed_point_support = []
 
 # Do not enable this feature directly. It is automatically
@@ -76,17 +77,24 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 rkyv = { version = "0.7.41", optional = true }
 num-derive = "0.4"
 indexmap = { version = "2", features = ["serde"], optional = true }
-rustc-hash = { version = "2", optional = true }
+hashbrown = { version = "0.15", optional = true, default-features = false, features = [
+    "default-hasher",
+] }
 cust_core = { version = "0.1", optional = true }
-spade = { version = "2", optional = true }
+spade = { version = "2", optional = true, default-features = false }
+robust = { version = "1.1", optional = true, default-features = false, features = [
+    # Force `no_std` for `robust`, which is used by `spade`.
+    "no_std",
+] }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 ordered-float = { version = "5", default-features = false }
 log = "0.4"
 thiserror = { version = "2", default-features = false }
-ena = { version = "0.14.3", optional = true }
+ena = { version = "0.14.3", optional = true, default-features = false }
 
 [dev-dependencies]
+parry2d = { path = ".", features = ["std"] }
 simba = { version = "0.9", default-features = false }
 oorandom = "11"
 ptree = "0.4.0"

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "actively-developed" }
 workspace = true
 
 [features]
-default = ["required-features", "alloc"]
+default = ["required-features", "std"]
 required-features = ["dim2", "f32"]
 std = [
     "alloc",

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -39,6 +39,7 @@ serde-serialize = [
     "nalgebra/serde-serialize",
     "arrayvec/serde",
     "bitflags/serde",
+    "hashbrown?/serde",
     "spade?/serde",
 ]
 rkyv-serialize = [

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "actively-developed" }
 workspace = true
 
 [features]
-default = ["required-features", "std"]
+default = ["required-features", "std", "spade"]
 required-features = ["dim2", "f32"]
 std = [
     "alloc",
@@ -28,7 +28,7 @@ std = [
     "slab",
     "simba/std",
     "arrayvec/std",
-    "spade/std",
+    "spade?/std",
     "thiserror/std",
     "ena",
 ]
@@ -39,7 +39,7 @@ serde-serialize = [
     "nalgebra/serde-serialize",
     "arrayvec/serde",
     "bitflags/serde",
-    "spade/serde",
+    "spade?/serde",
 ]
 rkyv-serialize = [
     "rkyv/validation",
@@ -52,6 +52,7 @@ simd-nightly = ["simba/portable_simd", "simd-is-enabled"]
 enhanced-determinism = ["simba/libm_force", "indexmap"]
 parallel = ["rayon"]
 alloc = ["nalgebra/alloc", "hashbrown"]
+spade = ["dep:spade", "alloc"]
 improved_fixed_point_support = []
 
 # Do not enable this feature directly. It is automatically

--- a/crates/parry2d/examples/common_macroquad2d.rs
+++ b/crates/parry2d/examples/common_macroquad2d.rs
@@ -1,4 +1,4 @@
-use std::f32::consts::{FRAC_PI_2, FRAC_PI_4};
+use core::f32::consts::{FRAC_PI_2, FRAC_PI_4};
 
 use macroquad::prelude::*;
 use macroquad::{

--- a/crates/parry2d/examples/convex_hull2d.rs
+++ b/crates/parry2d/examples/convex_hull2d.rs
@@ -1,6 +1,6 @@
 mod common_macroquad2d;
 
-use std::f32::consts::{FRAC_PI_2, FRAC_PI_4};
+use core::f32::consts::{FRAC_PI_2, FRAC_PI_4};
 
 use common_macroquad2d::{draw_point, draw_polygon, lissajous_2d_with_params, na_from_mquad};
 use macroquad::prelude::*;

--- a/crates/parry2d/examples/raycasts_animated.rs
+++ b/crates/parry2d/examples/raycasts_animated.rs
@@ -35,7 +35,7 @@ async fn main() {
             Point2::new(2.0, 2.0),
             UnitComplex::new(animation_rotation * i as f32) * -Vector2::x(),
         );
-        let toi = cube.cast_ray(&cube_pose, &ray, std::f32::MAX, true);
+        let toi = cube.cast_ray(&cube_pose, &ray, f32::MAX, true);
 
         /*
          *

--- a/crates/parry2d/examples/solid_ray_cast2d.rs
+++ b/crates/parry2d/examples/solid_ray_cast2d.rs
@@ -12,7 +12,7 @@ fn main() {
     // Solid cast.
     assert_eq!(
         cuboid
-            .cast_ray(&Isometry2::identity(), &ray_inside, std::f32::MAX, true)
+            .cast_ray(&Isometry2::identity(), &ray_inside, f32::MAX, true)
             .unwrap(),
         0.0
     );
@@ -20,16 +20,16 @@ fn main() {
     // Non-solid cast.
     assert_eq!(
         cuboid
-            .cast_ray(&Isometry2::identity(), &ray_inside, std::f32::MAX, false)
+            .cast_ray(&Isometry2::identity(), &ray_inside, f32::MAX, false)
             .unwrap(),
         2.0
     );
 
     // The other ray does not intersect this shape.
     assert!(cuboid
-        .cast_ray(&Isometry2::identity(), &ray_miss, std::f32::MAX, false)
+        .cast_ray(&Isometry2::identity(), &ray_miss, f32::MAX, false)
         .is_none());
     assert!(cuboid
-        .cast_ray(&Isometry2::identity(), &ray_miss, std::f32::MAX, true)
+        .cast_ray(&Isometry2::identity(), &ray_miss, f32::MAX, true)
         .is_none());
 }

--- a/crates/parry2d/tests/geometry/ray_cast.rs
+++ b/crates/parry2d/tests/geometry/ray_cast.rs
@@ -9,7 +9,7 @@ fn issue_178_parallel_raycast() {
     let ray = Ray::new(Point2::new(0.0, 0.0), Vector2::new(0.0, 1.0));
     let seg = Segment::new(Point2::new(2.0, 1.0), Point2::new(2.0, 0.0));
 
-    let cast = seg.cast_ray(&m1, &ray, std::f32::MAX, true);
+    let cast = seg.cast_ray(&m1, &ray, f32::MAX, true);
     assert!(cast.is_none());
 }
 
@@ -19,7 +19,7 @@ fn parallel_raycast() {
     let ray = Ray::new(Point2::new(0.0, 0.0), Vector2::new(0.0, 1.0));
     let seg = Segment::new(Point2::new(2.0, 1.0), Point2::new(2.0, -1.0));
 
-    let cast = seg.cast_ray(&m1, &ray, std::f32::MAX, true);
+    let cast = seg.cast_ray(&m1, &ray, f32::MAX, true);
     assert!(cast.is_none());
 }
 
@@ -29,7 +29,7 @@ fn collinear_raycast_starting_on_segment() {
     let ray = Ray::new(Point2::new(0.0, 0.0), Vector2::new(0.0, 1.0));
     let seg = Segment::new(Point2::new(0.0, 1.0), Point2::new(0.0, -1.0));
 
-    let cast = seg.cast_ray(&m1, &ray, std::f32::MAX, true);
+    let cast = seg.cast_ray(&m1, &ray, f32::MAX, true);
     assert_eq!(cast, Some(0.0));
 }
 
@@ -39,7 +39,7 @@ fn collinear_raycast_starting_below_segment() {
     let ray = Ray::new(Point2::new(0.0, -2.0), Vector2::new(0.0, 1.0));
     let seg = Segment::new(Point2::new(0.0, 1.0), Point2::new(0.0, -1.0));
 
-    let cast = seg.cast_ray(&m1, &ray, std::f32::MAX, true);
+    let cast = seg.cast_ray(&m1, &ray, f32::MAX, true);
     assert_eq!(cast, Some(1.0));
 }
 
@@ -49,7 +49,7 @@ fn collinear_raycast_starting_above_segment() {
     let ray = Ray::new(Point2::new(0.0, 2.0), Vector2::new(0.0, 1.0));
     let seg = Segment::new(Point2::new(0.0, 1.0), Point2::new(0.0, -1.0));
 
-    let cast = seg.cast_ray(&m1, &ray, std::f32::MAX, true);
+    let cast = seg.cast_ray(&m1, &ray, f32::MAX, true);
     assert_eq!(cast, None);
 }
 
@@ -57,14 +57,14 @@ fn collinear_raycast_starting_above_segment() {
 fn perpendicular_raycast_starting_behind_segment() {
     let segment = Segment::new(Point2::new(0.0f32, -10.0), Point2::new(0.0, 10.0));
     let ray = Ray::new(Point2::new(-1.0, 0.0), Vector2::new(1.0, 0.0));
-    assert!(segment.intersects_local_ray(&ray, std::f32::MAX));
+    assert!(segment.intersects_local_ray(&ray, f32::MAX));
 }
 
 #[test]
 fn perpendicular_raycast_starting_in_front_of_segment() {
     let segment = Segment::new(Point2::new(0.0f32, -10.0), Point2::new(0.0, 10.0));
     let ray = Ray::new(Point2::new(1.0, 0.0), Vector2::new(1.0, 0.0));
-    assert!(!segment.intersects_local_ray(&ray, std::f32::MAX));
+    assert!(!segment.intersects_local_ray(&ray, f32::MAX));
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn perpendicular_raycast_starting_on_segment() {
     let segment = Segment::new(Point2::new(0.0f32, -10.0), Point2::new(0.0, 10.0));
     let ray = Ray::new(Point2::new(0.0, 3.0), Vector2::new(1.0, 0.0));
 
-    let cast = segment.cast_local_ray(&ray, std::f32::MAX, true);
+    let cast = segment.cast_local_ray(&ray, f32::MAX, true);
     assert_eq!(cast, Some(0.0));
 }
 
@@ -80,14 +80,14 @@ fn perpendicular_raycast_starting_on_segment() {
 fn perpendicular_raycast_starting_above_segment() {
     let segment = Segment::new(Point2::new(0.0f32, -10.0), Point2::new(0.0, 10.0));
     let ray = Ray::new(Point2::new(0.0, 11.0), Vector2::new(1.0, 0.0));
-    assert!(!segment.intersects_local_ray(&ray, std::f32::MAX));
+    assert!(!segment.intersects_local_ray(&ray, f32::MAX));
 }
 
 #[test]
 fn perpendicular_raycast_starting_below_segment() {
     let segment = Segment::new(Point2::new(0.0f32, -10.0), Point2::new(0.0, 10.0));
     let ray = Ray::new(Point2::new(0.0, -11.0), Vector2::new(1.0, 0.0));
-    assert!(!segment.intersects_local_ray(&ray, std::f32::MAX));
+    assert!(!segment.intersects_local_ray(&ray, f32::MAX));
 }
 
 #[test]
@@ -99,7 +99,7 @@ fn raycast_starting_outside_of_triangle() {
     );
     let ray = Ray::new(Point2::new(-10.0, 0.0), Vector2::new(1.0, 0.0));
     let intersect = triangle
-        .cast_local_ray_and_get_normal(&ray, std::f32::MAX, true)
+        .cast_local_ray_and_get_normal(&ray, f32::MAX, true)
         .expect("No intersection");
 
     assert_ne!(intersect.time_of_impact, 0.0);
@@ -114,7 +114,7 @@ fn raycast_starting_inside_of_triangle() {
     );
     let ray = Ray::new(Point2::new(2.0, 0.0), Vector2::new(1.0, 0.0));
     let intersect = triangle
-        .cast_local_ray_and_get_normal(&ray, std::f32::MAX, true)
+        .cast_local_ray_and_get_normal(&ray, f32::MAX, true)
         .expect("No intersection");
 
     assert_eq!(intersect.time_of_impact, 0.0);
@@ -129,7 +129,7 @@ fn raycast_starting_on_edge_of_triangle() {
     );
     let ray = Ray::new(Point2::new(0.0, 0.0), Vector2::new(1.0, 0.0));
     let intersect = triangle
-        .cast_local_ray_and_get_normal(&ray, std::f32::MAX, true)
+        .cast_local_ray_and_get_normal(&ray, f32::MAX, true)
         .expect("No intersection");
 
     assert_eq!(intersect.time_of_impact, 0.0);

--- a/crates/parry2d/tests/geometry/time_of_impact2.rs
+++ b/crates/parry2d/tests/geometry/time_of_impact2.rs
@@ -152,7 +152,7 @@ fn cast_shapes_should_return_toi_for_ball_and_rotated_polyline() {
     let ball_isometry = Isometry2::identity();
     let ball_velocity = Vector2::new(1.0, 0.0);
     let ball = Ball::new(0.5);
-    let polyline_isometry = Isometry2::rotation(-std::f32::consts::FRAC_PI_2);
+    let polyline_isometry = Isometry2::rotation(-core::f32::consts::FRAC_PI_2);
     let polyline_velocity = Vector2::zeros();
     let polyline = Polyline::new(vec![Point2::new(1.0, 1.0), Point2::new(-1.0, 1.0)], None);
 
@@ -184,7 +184,7 @@ fn cast_shapes_should_return_toi_for_ball_and_rotated_segment() {
     let ball_isometry = Isometry2::identity();
     let ball_velocity = Vector2::new(1.0, 0.0);
     let ball = Ball::new(0.5);
-    let segment_isometry = Isometry2::rotation(-std::f32::consts::FRAC_PI_2);
+    let segment_isometry = Isometry2::rotation(-core::f32::consts::FRAC_PI_2);
     let segment_velocity = Vector2::zeros();
     let segment = Segment::new(Point2::new(1.0, 1.0), Point2::new(-1.0, 1.0));
 
@@ -216,7 +216,7 @@ fn cast_shapes_should_return_toi_for_rotated_segment_and_ball() {
     let ball_isometry = Isometry2::identity();
     let ball_velocity = Vector2::new(1.0, 0.0);
     let ball = Ball::new(0.5);
-    let segment_isometry = Isometry2::rotation(-std::f32::consts::FRAC_PI_2);
+    let segment_isometry = Isometry2::rotation(-core::f32::consts::FRAC_PI_2);
     let segment_velocity = Vector2::zeros();
     let segment = Segment::new(Point2::new(1.0, 1.0), Point2::new(-1.0, 1.0));
 

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -83,11 +83,7 @@ hashbrown = { version = "0.15", optional = true, default-features = false, featu
 ] }
 foldhash = { version = "0.1", optional = true, default-features = false }
 cust_core = { version = "0.1", optional = true }
-spade = { version = "2.9", optional = true, default-features = false } # Make this optional?
-robust = { version = "1.1", optional = true, default-features = false, features = [
-    # Force `no_std` for `robust`, which is used by `spade`.
-    "no_std",
-] }
+spade = { version = "2.9", optional = true, default-features = false }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 rstar = "0.12.0"

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -37,6 +37,7 @@ serde-serialize = [
     "serde",
     "nalgebra/serde-serialize",
     "bitflags/serde",
+    "hashbrown?/serde",
     "spade?/serde",
 ]
 rkyv-serialize = [

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -96,7 +96,6 @@ ordered-float = { version = "5", default-features = false }
 thiserror = { version = "2", default-features = false }
 
 [dev-dependencies]
-parry3d-f64 = { path = ".", features = ["std"] }
 oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "actively-developed" }
 workspace = true
 
 [features]
-default = ["required-features", "alloc"]
+default = ["required-features", "std"]
 required-features = ["dim3", "f64"]
 std = [
     "nalgebra/std",

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -20,21 +20,25 @@ maintenance = { status = "actively-developed" }
 workspace = true
 
 [features]
-default = ["required-features", "std"]
+default = ["required-features", "alloc"]
 required-features = ["dim3", "f64"]
 std = [
     "nalgebra/std",
     "slab",
-    "rustc-hash",
     "simba/std",
     "arrayvec/std",
-    "spade",
+    "spade/std",
     "thiserror/std",
-    "ena"
+    "ena",
 ]
 dim3 = []
 f64 = []
-serde-serialize = ["serde", "nalgebra/serde-serialize", "bitflags/serde"]
+serde-serialize = [
+    "serde",
+    "nalgebra/serde-serialize",
+    "bitflags/serde",
+    "spade/serde",
+]
 rkyv-serialize = [
     "rkyv/validation",
     "nalgebra/rkyv-serialize",
@@ -47,7 +51,7 @@ enhanced-determinism = ["simba/libm_force", "indexmap"]
 parallel = ["rayon"]
 # Adds `TriMesh:to_obj_file` function.
 wavefront = ["obj"]
-alloc = []
+alloc = ["nalgebra/alloc", "hashbrown"]
 improved_fixed_point_support = []
 
 # Do not enable this feature directly. It is automatically
@@ -73,20 +77,28 @@ serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 rkyv = { version = "0.7.41", optional = true }
 num-derive = "0.4"
 indexmap = { version = "2", features = ["serde"], optional = true }
-rustc-hash = { version = "2", optional = true }
+hashbrown = { version = "0.15", optional = true, default-features = false, features = [
+    "default-hasher",
+] }
+foldhash = { version = "0.1", optional = true, default-features = false }
 cust_core = { version = "0.1", optional = true }
-spade = { version = "2.9", optional = true } # Make this optional?
+spade = { version = "2.9", optional = true, default-features = false } # Make this optional?
+robust = { version = "1.1", optional = true, default-features = false, features = [
+    # Force `no_std` for `robust`, which is used by `spade`.
+    "no_std",
+] }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 rstar = "0.12.0"
 obj = { version = "0.10.2", optional = true }
-ena = { version = "0.14.3", optional = true }
+ena = { version = "0.14.3", optional = true, default-features = false }
 
 log = "0.4"
 ordered-float = { version = "5", default-features = false }
 thiserror = { version = "2", default-features = false }
 
 [dev-dependencies]
+parry3d-f64 = { path = ".", features = ["std"] }
 oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -20,14 +20,14 @@ maintenance = { status = "actively-developed" }
 workspace = true
 
 [features]
-default = ["required-features", "std"]
+default = ["required-features", "std", "spade"]
 required-features = ["dim3", "f64"]
 std = [
     "nalgebra/std",
     "slab",
     "simba/std",
     "arrayvec/std",
-    "spade/std",
+    "spade?/std",
     "thiserror/std",
     "ena",
 ]
@@ -37,7 +37,7 @@ serde-serialize = [
     "serde",
     "nalgebra/serde-serialize",
     "bitflags/serde",
-    "spade/serde",
+    "spade?/serde",
 ]
 rkyv-serialize = [
     "rkyv/validation",
@@ -52,6 +52,7 @@ parallel = ["rayon"]
 # Adds `TriMesh:to_obj_file` function.
 wavefront = ["obj"]
 alloc = ["nalgebra/alloc", "hashbrown"]
+spade = ["dep:spade", "alloc"]
 improved_fixed_point_support = []
 
 # Do not enable this feature directly. It is automatically

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -37,6 +37,7 @@ serde-serialize = [
     "serde",
     "nalgebra/serde-serialize",
     "bitflags/serde",
+    "hashbrown?/serde",
     "spade?/serde",
 ]
 rkyv-serialize = [

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -20,21 +20,25 @@ maintenance = { status = "actively-developed" }
 workspace = true
 
 [features]
-default = ["required-features", "std"]
+default = ["required-features", "alloc"]
 required-features = ["dim3", "f32"]
 std = [
     "nalgebra/std",
     "slab",
-    "rustc-hash",
     "simba/std",
     "arrayvec/std",
-    "spade",
+    "spade/std",
     "thiserror/std",
-    "ena"
+    "ena",
 ]
 dim3 = []
 f32 = []
-serde-serialize = ["serde", "nalgebra/serde-serialize", "bitflags/serde"]
+serde-serialize = [
+    "serde",
+    "nalgebra/serde-serialize",
+    "bitflags/serde",
+    "spade/serde",
+]
 rkyv-serialize = [
     "rkyv/validation",
     "nalgebra/rkyv-serialize",
@@ -48,7 +52,7 @@ enhanced-determinism = ["simba/libm_force", "indexmap"]
 parallel = ["rayon"]
 # Adds `TriMesh:to_obj_file` function.
 wavefront = ["obj"]
-alloc = []
+alloc = ["nalgebra/alloc", "hashbrown"]
 improved_fixed_point_support = []
 
 # Do not enable this feature directly. It is automatically
@@ -74,9 +78,15 @@ serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 rkyv = { version = "0.7.41", optional = true }
 num-derive = "0.4"
 indexmap = { version = "2", features = ["serde"], optional = true }
-rustc-hash = { version = "2", optional = true }
+hashbrown = { version = "0.15", optional = true, default-features = false, features = [
+    "default-hasher",
+] }
 cust_core = { version = "0.1", optional = true }
-spade = { version = "2.9", optional = true } # Make this optional?
+spade = { version = "2.9", optional = true, default-features = false } # Make this optional?
+robust = { version = "1.1", optional = true, default-features = false, features = [
+    # Force `no_std` for `robust`, which is used by `spade`.
+    "no_std",
+] }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
@@ -84,9 +94,10 @@ ordered-float = { version = "5", default-features = false }
 thiserror = { version = "2", default-features = false }
 rstar = "0.12.0"
 obj = { version = "0.10.2", optional = true }
-ena = { version = "0.14.3", optional = true }
+ena = { version = "0.14.3", optional = true, default-features = false }
 
 [dev-dependencies]
+parry3d = { path = ".", features = ["std"] }
 oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }
@@ -136,16 +147,19 @@ doc-scrape-examples = true
 [[example]]
 name = "convex3d"
 path = "examples/convex3d.rs"
+required-features = ["alloc"]
 doc-scrape-examples = true
 
 [[example]]
 name = "convex_hull3d"
 path = "examples/convex_hull3d.rs"
+required-features = ["alloc"]
 doc-scrape-examples = true
 
 [[example]]
 name = "convex_try_new3d"
 path = "examples/convex_try_new3d.rs"
+required-features = ["alloc"]
 doc-scrape-examples = true
 
 [[example]]
@@ -171,6 +185,7 @@ doc-scrape-examples = true
 [[example]]
 name = "mesh3d"
 path = "examples/mesh3d.rs"
+required-features = ["alloc"]
 doc-scrape-examples = true
 
 [[example]]
@@ -181,16 +196,24 @@ doc-scrape-examples = true
 [[example]]
 name = "plane_intersection"
 path = "examples/plane_intersection.rs"
+required-features = ["alloc"]
 doc-scrape-examples = true
 
 [[example]]
 name = "polyline3d"
 path = "examples/polyline3d.rs"
+required-features = ["alloc"]
 doc-scrape-examples = true
 
 [[example]]
 name = "proximity_query3d"
 path = "examples/proximity_query3d.rs"
+doc-scrape-examples = true
+
+[[example]]
+name = "project_point3d"
+path = "examples/project_point3d.rs"
+required-features = ["alloc"]
 doc-scrape-examples = true
 
 [[example]]

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -83,11 +83,7 @@ hashbrown = { version = "0.15", optional = true, default-features = false, featu
     "default-hasher",
 ] }
 cust_core = { version = "0.1", optional = true }
-spade = { version = "2.9", optional = true, default-features = false } # Make this optional?
-robust = { version = "1.1", optional = true, default-features = false, features = [
-    # Force `no_std` for `robust`, which is used by `spade`.
-    "no_std",
-] }
+spade = { version = "2.9", optional = true, default-features = false }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "actively-developed" }
 workspace = true
 
 [features]
-default = ["required-features", "alloc"]
+default = ["required-features", "std"]
 required-features = ["dim3", "f32"]
 std = [
     "nalgebra/std",

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -20,14 +20,14 @@ maintenance = { status = "actively-developed" }
 workspace = true
 
 [features]
-default = ["required-features", "std"]
+default = ["required-features", "std", "spade"]
 required-features = ["dim3", "f32"]
 std = [
     "nalgebra/std",
     "slab",
     "simba/std",
     "arrayvec/std",
-    "spade/std",
+    "spade?/std",
     "thiserror/std",
     "ena",
 ]
@@ -37,7 +37,7 @@ serde-serialize = [
     "serde",
     "nalgebra/serde-serialize",
     "bitflags/serde",
-    "spade/serde",
+    "spade?/serde",
 ]
 rkyv-serialize = [
     "rkyv/validation",
@@ -53,6 +53,7 @@ parallel = ["rayon"]
 # Adds `TriMesh:to_obj_file` function.
 wavefront = ["obj"]
 alloc = ["nalgebra/alloc", "hashbrown"]
+spade = ["dep:spade", "alloc"]
 improved_fixed_point_support = []
 
 # Do not enable this feature directly. It is automatically

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -95,7 +95,6 @@ obj = { version = "0.10.2", optional = true }
 ena = { version = "0.14.3", optional = true, default-features = false }
 
 [dev-dependencies]
-parry3d = { path = ".", features = ["std"] }
 oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.8" }

--- a/crates/parry3d/benches/bounding_volume/mod.rs
+++ b/crates/parry3d/benches/bounding_volume/mod.rs
@@ -1,10 +1,12 @@
-use crate::common::{generate, generate_trimesh_around_origin, unref};
+#[cfg(feature = "alloc")]
+use crate::common::generate_trimesh_around_origin;
+use crate::common::{generate, unref};
 use na::Isometry3;
 use parry3d::bounding_volume::BoundingVolume;
 use parry3d::bounding_volume::{Aabb, BoundingSphere};
-use parry3d::shape::{
-    Ball, Capsule, Cone, ConvexPolyhedron, Cuboid, Cylinder, Segment, TriMesh, Triangle,
-};
+use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
+#[cfg(feature = "alloc")]
+use parry3d::shape::{ConvexPolyhedron, TriMesh};
 use rand::SeedableRng;
 use rand_isaac::IsaacRng;
 use test::Bencher;
@@ -132,12 +134,14 @@ bench_method!(
     m: Isometry3<f32>
 );
 
+#[cfg(feature = "alloc")]
 bench_method!(
     bench_convex_aabb,
     aabb: Aabb,
     c: ConvexPolyhedron,
     m: Isometry3<f32>
 );
+#[cfg(feature = "alloc")]
 bench_method!(
     bench_convex_bounding_sphere,
     bounding_sphere: BoundingSphere,
@@ -145,12 +149,14 @@ bench_method!(
     m: Isometry3<f32>
 );
 
+#[cfg(feature = "alloc")]
 bench_method_gen!(
     bench_mesh_aabb,
     aabb: Aabb,
     mesh: TriMesh = generate_trimesh_around_origin,
     m: Isometry3<f32> = generate
 );
+#[cfg(feature = "alloc")]
 bench_method_gen!(
     bench_mesh_bounding_sphere,
     bounding_sphere: BoundingSphere,

--- a/crates/parry3d/benches/bounding_volume/mod.rs
+++ b/crates/parry3d/benches/bounding_volume/mod.rs
@@ -1,11 +1,9 @@
-#[cfg(feature = "alloc")]
 use crate::common::generate_trimesh_around_origin;
 use crate::common::{generate, unref};
 use na::Isometry3;
 use parry3d::bounding_volume::BoundingVolume;
 use parry3d::bounding_volume::{Aabb, BoundingSphere};
 use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
-#[cfg(feature = "alloc")]
 use parry3d::shape::{ConvexPolyhedron, TriMesh};
 use rand::SeedableRng;
 use rand_isaac::IsaacRng;
@@ -134,14 +132,12 @@ bench_method!(
     m: Isometry3<f32>
 );
 
-#[cfg(feature = "alloc")]
 bench_method!(
     bench_convex_aabb,
     aabb: Aabb,
     c: ConvexPolyhedron,
     m: Isometry3<f32>
 );
-#[cfg(feature = "alloc")]
 bench_method!(
     bench_convex_bounding_sphere,
     bounding_sphere: BoundingSphere,
@@ -149,14 +145,12 @@ bench_method!(
     m: Isometry3<f32>
 );
 
-#[cfg(feature = "alloc")]
 bench_method_gen!(
     bench_mesh_aabb,
     aabb: Aabb,
     mesh: TriMesh = generate_trimesh_around_origin,
     m: Isometry3<f32> = generate
 );
-#[cfg(feature = "alloc")]
 bench_method_gen!(
     bench_mesh_bounding_sphere,
     bounding_sphere: BoundingSphere,

--- a/crates/parry3d/benches/common/default_gen.rs
+++ b/crates/parry3d/benches/common/default_gen.rs
@@ -5,7 +5,9 @@ use na::{
 use parry3d::bounding_volume::{Aabb, BoundingSphere};
 use parry3d::math::{Point, Real, Vector};
 use parry3d::query::Ray;
-use parry3d::shape::{Ball, Capsule, Cone, ConvexPolyhedron, Cuboid, Cylinder, Segment, Triangle};
+#[cfg(feature = "alloc")]
+use parry3d::shape::ConvexPolyhedron;
+use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
@@ -120,6 +122,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl DefaultGen for ConvexPolyhedron
 where
     Standard: Distribution<Real>,

--- a/crates/parry3d/benches/common/default_gen.rs
+++ b/crates/parry3d/benches/common/default_gen.rs
@@ -5,7 +5,6 @@ use na::{
 use parry3d::bounding_volume::{Aabb, BoundingSphere};
 use parry3d::math::{Point, Real, Vector};
 use parry3d::query::Ray;
-#[cfg(feature = "alloc")]
 use parry3d::shape::ConvexPolyhedron;
 use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
 use rand::distributions::{Distribution, Standard};
@@ -122,7 +121,6 @@ where
     }
 }
 
-#[cfg(feature = "alloc")]
 impl DefaultGen for ConvexPolyhedron
 where
     Standard: Distribution<Real>,

--- a/crates/parry3d/benches/common/mod.rs
+++ b/crates/parry3d/benches/common/mod.rs
@@ -1,7 +1,9 @@
 pub use self::default_gen::generate;
+#[cfg(feature = "alloc")]
 pub use self::generators::generate_trimesh_around_origin;
 pub use self::unref::unref;
 
 mod default_gen;
+#[cfg(feature = "alloc")]
 mod generators;
 mod unref;

--- a/crates/parry3d/benches/common/mod.rs
+++ b/crates/parry3d/benches/common/mod.rs
@@ -1,9 +1,7 @@
 pub use self::default_gen::generate;
-#[cfg(feature = "alloc")]
 pub use self::generators::generate_trimesh_around_origin;
 pub use self::unref::unref;
 
 mod default_gen;
-#[cfg(feature = "alloc")]
 mod generators;
 mod unref;

--- a/crates/parry3d/benches/query/ray.rs
+++ b/crates/parry3d/benches/query/ray.rs
@@ -1,10 +1,12 @@
-use crate::common::{generate, generate_trimesh_around_origin, unref};
+#[cfg(feature = "alloc")]
+use crate::common::generate_trimesh_around_origin;
+use crate::common::{generate, unref};
 use na::Isometry3;
 use parry3d::bounding_volume::{Aabb, BoundingSphere};
 use parry3d::query::{Ray, RayCast};
-use parry3d::shape::{
-    Ball, Capsule, Cone, ConvexPolyhedron, Cuboid, Cylinder, Segment, TriMesh, Triangle,
-};
+use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
+#[cfg(feature = "alloc")]
+use parry3d::shape::{ConvexPolyhedron, TriMesh};
 use rand::SeedableRng;
 use rand_isaac::IsaacRng;
 use test::Bencher;
@@ -154,6 +156,7 @@ bench_method!(
     solid: bool
 );
 
+#[cfg(feature = "alloc")]
 bench_method!(
     bench_ray_against_convex_with_normal,
     cast_ray_and_get_normal,
@@ -164,6 +167,7 @@ bench_method!(
     solid: bool
 );
 
+#[cfg(feature = "alloc")]
 bench_method_gen!(
     bench_ray_against_trimesh_with_normal,
     cast_ray_and_get_normal,

--- a/crates/parry3d/benches/query/ray.rs
+++ b/crates/parry3d/benches/query/ray.rs
@@ -1,11 +1,9 @@
-#[cfg(feature = "alloc")]
 use crate::common::generate_trimesh_around_origin;
 use crate::common::{generate, unref};
 use na::Isometry3;
 use parry3d::bounding_volume::{Aabb, BoundingSphere};
 use parry3d::query::{Ray, RayCast};
 use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
-#[cfg(feature = "alloc")]
 use parry3d::shape::{ConvexPolyhedron, TriMesh};
 use rand::SeedableRng;
 use rand_isaac::IsaacRng;
@@ -156,7 +154,6 @@ bench_method!(
     solid: bool
 );
 
-#[cfg(feature = "alloc")]
 bench_method!(
     bench_ray_against_convex_with_normal,
     cast_ray_and_get_normal,
@@ -167,7 +164,6 @@ bench_method!(
     solid: bool
 );
 
-#[cfg(feature = "alloc")]
 bench_method_gen!(
     bench_ray_against_trimesh_with_normal,
     cast_ray_and_get_normal,

--- a/crates/parry3d/benches/support_map/mod.rs
+++ b/crates/parry3d/benches/support_map/mod.rs
@@ -1,7 +1,9 @@
 use crate::common::{generate, unref};
 use na::{Isometry3, Vector3};
+#[cfg(feature = "alloc")]
+use parry3d::shape::ConvexPolyhedron;
+use parry3d::shape::SupportMap;
 use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
-use parry3d::shape::{ConvexPolyhedron, SupportMap};
 use rand::SeedableRng;
 use rand_isaac::IsaacRng;
 use test::Bencher;
@@ -59,7 +61,7 @@ bench_method!(
     m: Isometry3<f32>,
     dir: Vector3<f32>
 );
-
+#[cfg(feature = "alloc")]
 bench_method!(
     bench_convex_support_map,
     support_point,

--- a/crates/parry3d/benches/support_map/mod.rs
+++ b/crates/parry3d/benches/support_map/mod.rs
@@ -1,6 +1,5 @@
 use crate::common::{generate, unref};
 use na::{Isometry3, Vector3};
-#[cfg(feature = "alloc")]
 use parry3d::shape::ConvexPolyhedron;
 use parry3d::shape::SupportMap;
 use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
@@ -61,7 +60,6 @@ bench_method!(
     m: Isometry3<f32>,
     dir: Vector3<f32>
 );
-#[cfg(feature = "alloc")]
 bench_method!(
     bench_convex_support_map,
     support_point,

--- a/crates/parry3d/examples/bounding_sphere3d.rs
+++ b/crates/parry3d/examples/bounding_sphere3d.rs
@@ -2,7 +2,7 @@ mod common_macroquad3d;
 
 extern crate nalgebra as na;
 
-use std::ops::Rem;
+use core::ops::Rem;
 
 use common_macroquad3d::{lissajous_3d, mquad_from_na, na_from_mquad};
 use macroquad::prelude::*;

--- a/crates/parry3d/examples/common_macroquad3d.rs
+++ b/crates/parry3d/examples/common_macroquad3d.rs
@@ -1,4 +1,4 @@
-use std::f32::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_6};
+use core::f32::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_6};
 
 use macroquad::{
     color::{Color, WHITE},
@@ -36,9 +36,9 @@ pub fn hue_to_rgb(h: f32) -> (f32, f32, f32) {
     let kg = (3.0 + h * 6.0).rem_euclid(6.0);
     let kb = (1.0 + h * 6.0).rem_euclid(6.0);
 
-    let r = 1.0 - kr.min(4.0 - kr).min(1.0).max(0.0);
-    let g = 1.0 - kg.min(4.0 - kg).min(1.0).max(0.0);
-    let b = 1.0 - kb.min(4.0 - kb).min(1.0).max(0.0);
+    let r = 1.0 - kr.min(4.0 - kr).clamp(0.0, 1.0);
+    let g = 1.0 - kg.min(4.0 - kg).clamp(0.0, 1.0);
+    let b = 1.0 - kb.min(4.0 - kb).clamp(0.0, 1.0);
 
     (r, g, b)
 }
@@ -120,10 +120,7 @@ pub fn mquad_mesh_from_points(
     let vertices: Vec<Vertex> =
         mquad_compute_normals_and_bake_light(&mquad_points, &mquad_indices, light_pos);
     // Regenerate the index for each vertex.
-    let indices: Vec<u16> = (0..vertices.len() * 3)
-        .into_iter()
-        .map(|i| i as u16)
-        .collect();
+    let indices: Vec<u16> = (0..vertices.len() * 3).map(|i| i as u16).collect();
     let mesh = Mesh {
         vertices,
         indices,

--- a/crates/parry3d/examples/convex_hull3d.rs
+++ b/crates/parry3d/examples/convex_hull3d.rs
@@ -1,6 +1,6 @@
 mod common_macroquad3d;
 
-use std::f32::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_6};
+use core::f32::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_6};
 
 use common_macroquad3d::{
     lissajous_3d_with_params, mquad_from_na, mquad_mesh_from_points, na_from_mquad,

--- a/crates/parry3d/examples/getting_started.rs
+++ b/crates/parry3d/examples/getting_started.rs
@@ -8,5 +8,5 @@ fn main() {
     let cube = Cuboid::new(Vector3::new(1.0f32, 1.0, 1.0));
     let ray = Ray::new(Point3::new(0.0f32, 0.0, -1.0), Vector3::z());
 
-    assert!(cube.intersects_ray(&Isometry3::identity(), &ray, std::f32::MAX));
+    assert!(cube.intersects_ray(&Isometry3::identity(), &ray, f32::MAX));
 }

--- a/crates/parry3d/examples/solid_ray_cast3d.rs
+++ b/crates/parry3d/examples/solid_ray_cast3d.rs
@@ -12,7 +12,7 @@ fn main() {
     // Solid cast.
     assert_eq!(
         cuboid
-            .cast_ray(&Isometry3::identity(), &ray_inside, std::f32::MAX, true)
+            .cast_ray(&Isometry3::identity(), &ray_inside, f32::MAX, true)
             .unwrap(),
         0.0
     );
@@ -20,16 +20,16 @@ fn main() {
     // Non-solid cast.
     assert_eq!(
         cuboid
-            .cast_ray(&Isometry3::identity(), &ray_inside, std::f32::MAX, false)
+            .cast_ray(&Isometry3::identity(), &ray_inside, f32::MAX, false)
             .unwrap(),
         2.0
     );
 
     // The other ray does not intersect this shape.
     assert!(cuboid
-        .cast_ray(&Isometry3::identity(), &ray_miss, std::f32::MAX, false)
+        .cast_ray(&Isometry3::identity(), &ray_miss, f32::MAX, false)
         .is_none());
     assert!(cuboid
-        .cast_ray(&Isometry3::identity(), &ray_miss, std::f32::MAX, true)
+        .cast_ray(&Isometry3::identity(), &ray_miss, f32::MAX, true)
         .is_none());
 }

--- a/crates/parry3d/tests/geometry/cuboid_ray_cast.rs
+++ b/crates/parry3d/tests/geometry/cuboid_ray_cast.rs
@@ -31,7 +31,7 @@ where
         let position = Isometry3::from_parts(Translation3::identity(), rotation);
 
         let intersection = shape
-            .cast_ray_and_get_normal(&position, &ray, std::f32::MAX, true)
+            .cast_ray_and_get_normal(&position, &ray, f32::MAX, true)
             .expect(&format!(
                 "Ray {:?} did not hit Shape {} rotated with {:?}",
                 ray, name, rotation
@@ -61,14 +61,14 @@ where
 
         assert!(
             shape
-                .cast_ray_and_get_normal(&position, &new_ray, std::f32::MAX, true)
+                .cast_ray_and_get_normal(&position, &new_ray, f32::MAX, true)
                 .is_none(),
             "Ray {:#?} from outside Shape {} rotated with {:#?} did hit at t={}",
             ray,
             name,
             rotation,
             shape
-                .cast_ray_and_get_normal(&position, &new_ray, std::f32::MAX, true)
+                .cast_ray_and_get_normal(&position, &new_ray, f32::MAX, true)
                 .expect("recurring ray cast produced a different answer")
                 .time_of_impact
         );

--- a/crates/parry3d/tests/geometry/mod.rs
+++ b/crates/parry3d/tests/geometry/mod.rs
@@ -1,18 +1,12 @@
 mod aabb_scale;
 mod ball_ball_toi;
 mod ball_triangle_toi;
-#[cfg(feature = "alloc")]
 mod convex_hull;
 mod cuboid_ray_cast;
-#[cfg(feature = "alloc")]
 mod cylinder_cuboid_contact;
-#[cfg(feature = "alloc")]
 mod epa3;
 mod still_objects_toi;
 mod time_of_impact3;
-#[cfg(feature = "alloc")]
 mod trimesh_connected_components;
-#[cfg(feature = "alloc")]
 mod trimesh_intersection;
-#[cfg(feature = "alloc")]
 mod trimesh_trimesh_toi;

--- a/crates/parry3d/tests/geometry/mod.rs
+++ b/crates/parry3d/tests/geometry/mod.rs
@@ -1,12 +1,18 @@
 mod aabb_scale;
 mod ball_ball_toi;
 mod ball_triangle_toi;
+#[cfg(feature = "alloc")]
 mod convex_hull;
 mod cuboid_ray_cast;
+#[cfg(feature = "alloc")]
 mod cylinder_cuboid_contact;
+#[cfg(feature = "alloc")]
 mod epa3;
 mod still_objects_toi;
 mod time_of_impact3;
+#[cfg(feature = "alloc")]
 mod trimesh_connected_components;
+#[cfg(feature = "alloc")]
 mod trimesh_intersection;
+#[cfg(feature = "alloc")]
 mod trimesh_trimesh_toi;

--- a/crates/parry3d/tests/geometry/trimesh_intersection.rs
+++ b/crates/parry3d/tests/geometry/trimesh_intersection.rs
@@ -29,7 +29,7 @@ fn build_diamond(position: &Isometry<Real>) -> TriMesh {
 fn trimesh_plane_edge_intersection() {
     let mesh = build_diamond(&Isometry::identity());
 
-    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 0.5, std::f32::EPSILON);
+    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 0.5, core::f32::EPSILON);
 
     assert!(matches!(result, IntersectResult::Intersect(_)));
 
@@ -47,7 +47,7 @@ fn trimesh_plane_edge_intersection() {
 fn trimesh_plane_vertex_intersection() {
     let mesh = build_diamond(&Isometry::identity());
 
-    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 0.0, std::f32::EPSILON);
+    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 0.0, core::f32::EPSILON);
 
     assert!(matches!(result, IntersectResult::Intersect(_)));
 
@@ -65,7 +65,7 @@ fn trimesh_plane_vertex_intersection() {
 fn trimesh_plane_mixed_intersection() {
     let mesh = build_diamond(&Isometry::identity());
 
-    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(0), 0.0, std::f32::EPSILON);
+    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(0), 0.0, core::f32::EPSILON);
 
     assert!(matches!(result, IntersectResult::Intersect(_)));
 
@@ -85,7 +85,7 @@ fn trimesh_plane_multi_intersection() {
     let mut mesh = build_diamond(&Isometry::identity());
     mesh.append(&build_diamond(&Isometry::translation(-5.0, 0.0, 0.0)));
 
-    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 0.5, std::f32::EPSILON);
+    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 0.5, core::f32::EPSILON);
 
     assert!(matches!(result, IntersectResult::Intersect(_)));
 
@@ -108,7 +108,8 @@ fn trimesh_plane_multi_intersection() {
 fn trimesh_plane_above() {
     let mesh = build_diamond(&Isometry::identity());
 
-    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), -5.0, std::f32::EPSILON);
+    let result =
+        mesh.intersection_with_local_plane(&Vector3::ith_axis(2), -5.0, core::f32::EPSILON);
 
     assert!(matches!(result, IntersectResult::Positive));
 }
@@ -117,7 +118,7 @@ fn trimesh_plane_above() {
 fn trimesh_plane_below() {
     let mesh = build_diamond(&Isometry::identity());
 
-    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 5.0, std::f32::EPSILON);
+    let result = mesh.intersection_with_local_plane(&Vector3::ith_axis(2), 5.0, core::f32::EPSILON);
 
     assert!(matches!(result, IntersectResult::Negative));
 }

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -411,7 +411,7 @@ impl Aabb {
     }
 
     #[cfg(feature = "dim3")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn intersects_spiral(
         &self,
         point: &Point<Real>,
@@ -422,6 +422,7 @@ impl Aabb {
     ) -> bool {
         use crate::utils::WBasis;
         use crate::utils::{Interval, IntervalFunction};
+        use alloc::vec;
 
         struct SpiralPlaneDistance {
             center: Point<Real>,

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -8,8 +8,8 @@ use arrayvec::ArrayVec;
 use na;
 use num::Bounded;
 
-#[cfg(not(feature = "std"))]
-use na::ComplexField; // for .abs()
+#[cfg(all(feature = "dim3", not(feature = "std")))]
+use na::ComplexField; // for .sin_cos()
 
 use crate::query::{Ray, RayCast};
 #[cfg(feature = "rkyv")]

--- a/src/bounding_volume/aabb_utils.rs
+++ b/src/bounding_volume/aabb_utils.rs
@@ -1,4 +1,4 @@
-use std::iter::IntoIterator;
+use core::iter::IntoIterator;
 
 use crate::bounding_volume::Aabb;
 use crate::math::{Isometry, Point, Real, Vector, DIM};

--- a/src/bounding_volume/mod.rs
+++ b/src/bounding_volume/mod.rs
@@ -16,14 +16,14 @@ pub mod bounding_volume;
 pub mod aabb;
 mod aabb_ball;
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod aabb_convex_polygon;
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod aabb_convex_polyhedron;
 mod aabb_cuboid;
 mod aabb_halfspace;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod aabb_heightfield;
 mod aabb_support_map;
 mod aabb_triangle;
@@ -37,22 +37,22 @@ mod bounding_sphere_capsule;
 #[cfg(feature = "dim3")]
 mod bounding_sphere_cone;
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod bounding_sphere_convex;
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod bounding_sphere_convex_polygon;
 mod bounding_sphere_cuboid;
 #[cfg(feature = "dim3")]
 mod bounding_sphere_cylinder;
 mod bounding_sphere_halfspace;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod bounding_sphere_heightfield;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod bounding_sphere_polyline;
 mod bounding_sphere_segment;
 mod bounding_sphere_triangle;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod bounding_sphere_trimesh;
 mod bounding_sphere_utils;
 mod simd_aabb;

--- a/src/bounding_volume/simd_aabb.rs
+++ b/src/bounding_volume/simd_aabb.rs
@@ -62,7 +62,7 @@ impl<'de> serde::Deserialize<'de> for SimdAabb {
 
         impl<'de> serde::de::Visitor<'de> for Visitor {
             type Value = SimdAabb;
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(
                     formatter,
                     "two arrays containing at least {} floats",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ the rust programming language.
 #![deny(unused_parens)]
 #![deny(non_upper_case_globals)]
 #![deny(unused_results)]
+#![deny(unused_qualifications)]
 #![warn(missing_docs)]
 #![warn(unused_imports)]
 #![allow(missing_copy_implementations)]
@@ -19,8 +20,7 @@ the rust programming language.
 #![allow(clippy::manual_range_contains)] // This usually makes it way more verbose that it could be.
 #![allow(clippy::type_complexity)] // Complains about closures that are fairly simple.
 #![doc(html_root_url = "http://docs.rs/parry/0.1.1")]
-#![cfg_attr(not(feature = "std"), no_std)]
-#![deny(unused_qualifications)]
+#![no_std]
 
 #[cfg(all(
     feature = "simd-is-enabled",
@@ -47,12 +47,12 @@ macro_rules! array(
     }
 );
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "alloc")]
 #[cfg_attr(test, macro_use)]
 extern crate alloc;
-
-#[cfg(not(feature = "std"))]
-extern crate core as std;
 
 #[cfg(feature = "serde")]
 #[macro_use]
@@ -70,7 +70,7 @@ pub mod mass_properties;
 pub mod partitioning;
 pub mod query;
 pub mod shape;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub mod transformation;
 pub mod utils;
 

--- a/src/mass_properties/mass_properties.rs
+++ b/src/mass_properties/mass_properties.rs
@@ -1,10 +1,10 @@
 use crate::math::{AngVector, AngularInertia, Isometry, Point, Real, Rotation, Vector};
 use crate::utils;
+use core::ops::{Add, AddAssign, Sub, SubAssign};
 use na::ComplexField;
 use num::Zero;
-use std::ops::{Add, AddAssign, Sub, SubAssign};
 #[cfg(feature = "dim3")]
-use {na::Matrix3, std::ops::MulAssign};
+use {core::ops::MulAssign, na::Matrix3};
 
 #[cfg(feature = "rkyv")]
 use rkyv::{bytecheck, CheckBytes};
@@ -380,13 +380,15 @@ impl AddAssign<MassProperties> for MassProperties {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::iter::Sum<MassProperties> for MassProperties {
+#[cfg(feature = "alloc")]
+impl core::iter::Sum<MassProperties> for MassProperties {
     #[cfg(feature = "dim2")]
     fn sum<I>(iter: I) -> Self
     where
         I: Iterator<Item = Self>,
     {
+        use alloc::vec::Vec;
+
         let mut total_mass = 0.0;
         let mut total_com = Point::origin();
         let mut total_inertia = 0.0;
@@ -421,6 +423,8 @@ impl std::iter::Sum<MassProperties> for MassProperties {
     where
         I: Iterator<Item = Self>,
     {
+        use alloc::vec::Vec;
+
         let mut total_mass = 0.0;
         let mut total_com = Point::origin();
         let mut total_inertia = Matrix3::zeros();
@@ -587,6 +591,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn mass_properties_sum_no_nan() {
         let mp: MassProperties = [MassProperties::zero()].iter().map(|v| *v).sum();
         assert!(!mp.local_com.x.is_nan() && !mp.local_com.y.is_nan());

--- a/src/mass_properties/mass_properties_trimesh3d.rs
+++ b/src/mass_properties/mass_properties_trimesh3d.rs
@@ -182,6 +182,8 @@ pub fn trimesh_signed_volume_and_center_of_mass(
 
 #[cfg(test)]
 mod test {
+    use std::dbg;
+
     use crate::math::Vector;
     use crate::{
         mass_properties::MassProperties,

--- a/src/mass_properties/mod.rs
+++ b/src/mass_properties/mod.rs
@@ -5,37 +5,37 @@ pub use self::mass_properties::MassProperties;
 mod mass_properties;
 mod mass_properties_ball;
 mod mass_properties_capsule;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod mass_properties_compound;
 #[cfg(feature = "dim3")]
 mod mass_properties_cone;
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod mass_properties_convex_polygon;
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod mass_properties_convex_polyhedron;
 mod mass_properties_cuboid;
 mod mass_properties_cylinder;
 #[cfg(feature = "dim2")]
 mod mass_properties_triangle;
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod mass_properties_trimesh2d;
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod mass_properties_trimesh3d;
 
 /// Free functions for some special-cases of mass-properties computation.
 pub mod details {
     #[cfg(feature = "dim2")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub use super::mass_properties_convex_polygon::convex_polygon_area_and_center_of_mass;
     #[cfg(feature = "dim2")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub use super::mass_properties_trimesh2d::trimesh_area_and_center_of_mass;
     #[cfg(feature = "dim3")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub use super::mass_properties_trimesh3d::{
         tetrahedron_unit_inertia_tensor_wrt_point, trimesh_signed_volume_and_center_of_mass,
     };

--- a/src/partitioning/mod.rs
+++ b/src/partitioning/mod.rs
@@ -1,6 +1,6 @@
 //! Spatial partitioning tools.
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::qbvh::{
     CenterDataSplitter, IndexedData, NodeIndex, Qbvh, QbvhDataGenerator, QbvhNode,
     QbvhNonOverlappingDataSplitter, QbvhProxy, QbvhUpdateWorkspace, SimdNodeIndex,
@@ -14,9 +14,9 @@ pub use self::visitor::{
 
 /// A quaternary bounding-volume-hierarchy.
 #[deprecated(note = "Renamed to Qbvh")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub type SimdQbvh<T> = Qbvh<T>;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod qbvh;
 mod visitor;

--- a/src/partitioning/qbvh/build.rs
+++ b/src/partitioning/qbvh/build.rs
@@ -3,6 +3,7 @@ use crate::math::Vector;
 use crate::math::{Point, Real};
 use crate::query::SplitResult;
 use crate::simd::SimdReal;
+use alloc::{vec, vec::Vec};
 use simba::simd::SimdValue;
 
 use super::utils::split_indices_wrt_dim;

--- a/src/partitioning/qbvh/qbvh.rs
+++ b/src/partitioning/qbvh/qbvh.rs
@@ -1,5 +1,6 @@
 use crate::bounding_volume::{Aabb, SimdAabb};
 use crate::math::{Real, Vector};
+use alloc::vec::Vec;
 
 use na::SimdValue;
 

--- a/src/partitioning/qbvh/traversal.rs
+++ b/src/partitioning/qbvh/traversal.rs
@@ -9,9 +9,9 @@ use crate::partitioning::{
 };
 use crate::simd::SIMD_WIDTH;
 use crate::utils::WeightedValue;
+use alloc::{collections::BinaryHeap, vec, vec::Vec};
 use num::Bounded;
 use simba::simd::SimdBool;
-use std::collections::BinaryHeap;
 #[cfg(feature = "parallel")]
 use {
     crate::partitioning::{ParallelSimdSimultaneousVisitor, ParallelSimdVisitor},

--- a/src/partitioning/qbvh/update.rs
+++ b/src/partitioning/qbvh/update.rs
@@ -4,6 +4,7 @@ use crate::math::Vector;
 use crate::math::{Point, Real};
 use crate::partitioning::{CenterDataSplitter, QbvhProxy};
 use crate::simd::{SimdReal, SIMD_WIDTH};
+use alloc::{vec, vec::Vec};
 use simba::simd::{SimdBool, SimdValue};
 
 use super::{IndexedData, NodeIndex, Qbvh, QbvhNode, QbvhNodeFlags};
@@ -320,7 +321,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
             }
 
             first_iter = false;
-            std::mem::swap(&mut self.dirty_nodes, &mut workspace.dirty_parent_nodes);
+            core::mem::swap(&mut self.dirty_nodes, &mut workspace.dirty_parent_nodes);
         }
 
         num_changed
@@ -403,7 +404,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
         workspace.to_sort.extend(0..workspace.orig_ids.len());
         let root_id = NodeIndex::new(0, 0);
 
-        let mut indices = std::mem::take(&mut workspace.to_sort);
+        let mut indices = core::mem::take(&mut workspace.to_sort);
         let (id, aabb) = self.do_recurse_rebalance(&mut indices, workspace, root_id, margin);
         workspace.to_sort = indices;
 

--- a/src/partitioning/qbvh/update/tests.rs
+++ b/src/partitioning/qbvh/update/tests.rs
@@ -1,5 +1,6 @@
+use alloc::{borrow::Cow, string::String};
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use std::borrow::Cow;
+use std::println;
 
 use crate::{
     bounding_volume::Aabb,
@@ -213,7 +214,7 @@ impl QbvhTester {
         let mut qbvh = Qbvh::new();
         let workspace = QbvhUpdateWorkspace::default();
         let aabbs = self.aabbs.clone();
-        qbvh.clear_and_rebuild(aabbs.iter().map(|(index, aabb)| (index, aabb.clone())), 0.0);
+        qbvh.clear_and_rebuild(aabbs.iter().map(|(index, aabb)| (index, *aabb)), 0.0);
         QbvhTester {
             qbvh,
             workspace,

--- a/src/partitioning/visitor.rs
+++ b/src/partitioning/visitor.rs
@@ -1,6 +1,6 @@
 use crate::math::{Real, SimdBool, SimdReal, SIMD_WIDTH};
 
-#[cfg(all(feature = "std", feature = "parallel"))]
+#[cfg(all(feature = "alloc", feature = "parallel"))]
 use crate::partitioning::{qbvh::QbvhNode, SimdNodeIndex};
 
 /// The next action to be taken by a BVH traversal algorithm after having visited a node with some data.
@@ -117,7 +117,7 @@ pub trait SimdSimultaneousVisitor<T1, T2, SimdBV> {
  */
 
 /// Trait implemented by visitor called during the parallel traversal of a spatial partitioning data structure.
-#[cfg(all(feature = "std", feature = "parallel"))]
+#[cfg(all(feature = "alloc", feature = "parallel"))]
 pub trait ParallelSimdVisitor<LeafData>: Sync {
     /// Execute an operation on the content of a node of the spatial partitioning structure.
     ///
@@ -131,7 +131,7 @@ pub trait ParallelSimdVisitor<LeafData>: Sync {
     ) -> SimdVisitStatus;
 }
 
-#[cfg(all(feature = "std", feature = "parallel"))]
+#[cfg(all(feature = "alloc", feature = "parallel"))]
 impl<F, LeafData> ParallelSimdVisitor<LeafData> for F
 where
     F: Sync + Fn(&QbvhNode, Option<[Option<&LeafData>; SIMD_WIDTH]>) -> SimdVisitStatus,
@@ -148,7 +148,7 @@ where
 
 /// Trait implemented by visitor called during a parallel simultaneous spatial partitioning
 /// data structure traversal.
-#[cfg(all(feature = "std", feature = "parallel"))]
+#[cfg(all(feature = "alloc", feature = "parallel"))]
 pub trait ParallelSimdSimultaneousVisitor<LeafData1, LeafData2>: Sync {
     /// Visitor state data that will be passed down the recursion.
     type Data: Copy + Sync + Default;

--- a/src/query/clip/clip_aabb_line.rs
+++ b/src/query/clip/clip_aabb_line.rs
@@ -92,7 +92,7 @@ pub fn clip_aabb_line(
 
             if inter_with_near_halfspace > inter_with_far_halfspace {
                 flip_sides = true;
-                std::mem::swap(
+                core::mem::swap(
                     &mut inter_with_near_halfspace,
                     &mut inter_with_far_halfspace,
                 )

--- a/src/query/clip/clip_aabb_polygon.rs
+++ b/src/query/clip/clip_aabb_polygon.rs
@@ -1,5 +1,6 @@
 use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
+use alloc::vec::Vec;
 
 impl Aabb {
     /// Computes the intersections between this Aabb and the given polygon.

--- a/src/query/clip/clip_halfspace_polygon.rs
+++ b/src/query/clip/clip_halfspace_polygon.rs
@@ -1,5 +1,6 @@
 use crate::math::{Point, Real, Vector};
 use crate::query::{self, Ray};
+use alloc::vec::Vec;
 
 /// Cuts a polygon with the given half-space.
 ///

--- a/src/query/clip/clip_segment_segment.rs
+++ b/src/query/clip/clip_segment_segment.rs
@@ -27,13 +27,13 @@ pub fn clip_segment_segment_with_normal(
     if range1[1] < range1[0] {
         range1.swap(0, 1);
         features1.swap(0, 1);
-        std::mem::swap(&mut seg1.0, &mut seg1.1);
+        core::mem::swap(&mut seg1.0, &mut seg1.1);
     }
 
     if range2[1] < range2[0] {
         range2.swap(0, 1);
         features2.swap(0, 1);
-        std::mem::swap(&mut seg2.0, &mut seg2.1);
+        core::mem::swap(&mut seg2.0, &mut seg2.1);
     }
 
     if range2[0] > range1[1] || range1[0] > range2[1] {
@@ -92,13 +92,13 @@ pub fn clip_segment_segment(
     if range1[1] < range1[0] {
         range1.swap(0, 1);
         features1.swap(0, 1);
-        std::mem::swap(&mut seg1.0, &mut seg1.1);
+        core::mem::swap(&mut seg1.0, &mut seg1.1);
     }
 
     if range2[1] < range2[0] {
         range2.swap(0, 1);
         features2.swap(0, 1);
-        std::mem::swap(&mut seg2.0, &mut seg2.1);
+        core::mem::swap(&mut seg2.0, &mut seg2.1);
     }
 
     if range2[0] > range1[1] || range1[0] > range2[1] {

--- a/src/query/clip/mod.rs
+++ b/src/query/clip/mod.rs
@@ -1,13 +1,13 @@
 pub use self::clip_aabb_line::clip_aabb_line;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::clip_halfspace_polygon::clip_halfspace_polygon;
 pub use self::clip_segment_segment::clip_segment_segment;
 #[cfg(feature = "dim2")]
 pub use self::clip_segment_segment::clip_segment_segment_with_normal;
 
 mod clip_aabb_line;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod clip_aabb_polygon;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod clip_halfspace_polygon;
 mod clip_segment_segment;

--- a/src/query/closest_points/closest_points.rs
+++ b/src/query/closest_points/closest_points.rs
@@ -1,6 +1,6 @@
 use crate::math::{Isometry, Point, Real};
 
-use std::mem;
+use core::mem;
 
 /// Closest points information.
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/src/query/closest_points/mod.rs
+++ b/src/query/closest_points/mod.rs
@@ -5,7 +5,7 @@ pub use self::closest_points_ball_ball::closest_points_ball_ball;
 pub use self::closest_points_ball_convex_polyhedron::{
     closest_points_ball_convex_polyhedron, closest_points_convex_polyhedron_ball,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::closest_points_composite_shape_shape::{
     closest_points_composite_shape_shape, closest_points_shape_composite_shape,
     CompositeShapeAgainstShapeClosestPointsVisitor,
@@ -32,7 +32,7 @@ pub use self::closest_points_support_map_support_map::closest_points_support_map
 mod closest_points;
 mod closest_points_ball_ball;
 mod closest_points_ball_convex_polyhedron;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod closest_points_composite_shape_shape;
 mod closest_points_cuboid_cuboid;
 mod closest_points_cuboid_triangle;

--- a/src/query/contact/contact.rs
+++ b/src/query/contact/contact.rs
@@ -1,6 +1,6 @@
 use crate::math::{Isometry, Point, Real, Vector};
 use na::{self, Unit};
-use std::mem;
+use core::mem;
 
 #[cfg(feature = "rkyv")]
 use rkyv::{bytecheck, CheckBytes};

--- a/src/query/contact/contact.rs
+++ b/src/query/contact/contact.rs
@@ -1,6 +1,6 @@
 use crate::math::{Isometry, Point, Real, Vector};
-use na::{self, Unit};
 use core::mem;
+use na::{self, Unit};
 
 #[cfg(feature = "rkyv")]
 use rkyv::{bytecheck, CheckBytes};

--- a/src/query/contact/mod.rs
+++ b/src/query/contact/mod.rs
@@ -5,7 +5,7 @@ pub use self::contact_ball_ball::contact_ball_ball;
 pub use self::contact_ball_convex_polyhedron::{
     contact_ball_convex_polyhedron, contact_convex_polyhedron_ball,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::contact_composite_shape_shape::{
     contact_composite_shape_shape, contact_shape_composite_shape,
 };
@@ -14,7 +14,7 @@ pub use self::contact_halfspace_support_map::{
     contact_halfspace_support_map, contact_support_map_halfspace,
 };
 pub use self::contact_shape_shape::contact;
-#[cfg(feature = "std")] // TODO: doesn’t work without std because of EPA
+#[cfg(feature = "alloc")]
 pub use self::contact_support_map_support_map::{
     contact_support_map_support_map, contact_support_map_support_map_with_params,
 };
@@ -22,10 +22,10 @@ pub use self::contact_support_map_support_map::{
 mod contact;
 mod contact_ball_ball;
 mod contact_ball_convex_polyhedron;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod contact_composite_shape_shape;
 mod contact_cuboid_cuboid;
 mod contact_halfspace_support_map;
 mod contact_shape_shape;
-#[cfg(feature = "std")] // TODO: doesn’t work without std because of EPA
+#[cfg(feature = "alloc")]
 mod contact_support_map_support_map;

--- a/src/query/contact_manifolds/contact_manifold.rs
+++ b/src/query/contact_manifolds/contact_manifold.rs
@@ -1,5 +1,7 @@
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::shape::PackedFeatureId;
+#[cfg(feature = "dim3")]
+use alloc::vec::Vec;
 
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -141,7 +143,7 @@ impl<ManifoldData, ContactData: Default + Copy> ContactManifold<ManifoldData, Co
         #[cfg(feature = "dim2")]
         let points = self.points.clone();
         #[cfg(feature = "dim3")]
-        let points = std::mem::take(&mut self.points);
+        let points = core::mem::take(&mut self.points);
         self.points.clear();
 
         ContactManifold {

--- a/src/query/contact_manifolds/contact_manifolds_capsule_capsule.rs
+++ b/src/query/contact_manifolds/contact_manifolds_capsule_capsule.rs
@@ -6,9 +6,6 @@ use crate::shape::{Capsule, PackedFeatureId, Shape};
 use approx::AbsDiffEq;
 use na::Unit;
 
-#[cfg(not(feature = "alloc"))]
-use na::ComplexField; // for .abs()
-
 /// Computes the contact manifold between two capsules given as `Shape` trait-objects.
 pub fn contact_manifold_capsule_capsule_shapes<ManifoldData, ContactData>(
     pos12: &Isometry<Real>,

--- a/src/query/contact_manifolds/contact_manifolds_capsule_capsule.rs
+++ b/src/query/contact_manifolds/contact_manifolds_capsule_capsule.rs
@@ -6,7 +6,7 @@ use crate::shape::{Capsule, PackedFeatureId, Shape};
 use approx::AbsDiffEq;
 use na::Unit;
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::ComplexField; // for .abs()
 
 /// Computes the contact manifold between two capsules given as `Shape` trait-objects.

--- a/src/query/contact_manifolds/contact_manifolds_composite_shape_composite_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_composite_shape_composite_shape.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
 use crate::bounding_volume::BoundingVolume;
 use crate::math::{Isometry, Real};
 use crate::query::contact_manifolds::contact_manifolds_workspace::{
@@ -87,15 +90,15 @@ pub fn contact_manifolds_composite_shape_composite_shape<'a, ManifoldData, Conta
     let flipped = ls_aabb1.half_extents().norm_squared() < ls_aabb2.half_extents().norm_squared();
 
     if flipped {
-        std::mem::swap(&mut composite1, &mut composite2);
-        std::mem::swap(&mut qbvh1, &mut qbvh2);
-        std::mem::swap(&mut pos12, &mut pos21);
-        std::mem::swap(&mut ls_aabb1, &mut ls_aabb2);
+        core::mem::swap(&mut composite1, &mut composite2);
+        core::mem::swap(&mut qbvh1, &mut qbvh2);
+        core::mem::swap(&mut pos12, &mut pos21);
+        core::mem::swap(&mut ls_aabb1, &mut ls_aabb2);
     }
 
     // Traverse qbvh1 first.
     let ls_aabb2_1 = ls_aabb2.transform_by(&pos12).loosened(prediction);
-    let mut old_manifolds = std::mem::take(manifolds);
+    let mut old_manifolds = core::mem::take(manifolds);
 
     let mut leaf_fn1 = |leaf1: &u32| {
         composite1.map_part_at(

--- a/src/query/contact_manifolds/contact_manifolds_composite_shape_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_composite_shape_shape.rs
@@ -1,3 +1,5 @@
+use alloc::{boxed::Box, vec::Vec};
+
 use crate::bounding_volume::BoundingVolume;
 use crate::math::{Isometry, Real};
 use crate::query::contact_manifolds::contact_manifolds_workspace::{
@@ -81,7 +83,7 @@ pub fn contact_manifolds_composite_shape_shape<ManifoldData, ContactData>(
 
     // Traverse qbvh1 first.
     let ls_aabb2_1 = shape2.compute_aabb(&pos12).loosened(prediction);
-    let mut old_manifolds = std::mem::take(manifolds);
+    let mut old_manifolds = core::mem::take(manifolds);
 
     let mut leaf1_fn = |leaf1: &u32| {
         composite1.map_part_at(

--- a/src/query/contact_manifolds/contact_manifolds_halfspace_pfm.rs
+++ b/src/query/contact_manifolds/contact_manifolds_halfspace_pfm.rs
@@ -58,7 +58,7 @@ pub fn contact_manifold_halfspace_pfm<'a, ManifoldData, ContactData, S2>(
 
     // We do this clone to perform contact tracking and transfer impulses.
     // TODO: find a more efficient way of doing this.
-    let old_manifold_points = std::mem::take(&mut manifold.points);
+    let old_manifold_points = core::mem::take(&mut manifold.points);
 
     for i in 0..feature2.num_vertices {
         let vtx2 = feature2.vertices[i];

--- a/src/query/contact_manifolds/contact_manifolds_heightfield_composite_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_heightfield_composite_shape.rs
@@ -1,3 +1,5 @@
+use alloc::{boxed::Box, vec::Vec};
+
 use crate::bounding_volume::BoundingVolume;
 use crate::math::{Isometry, Real};
 use crate::query::contact_manifolds::contact_manifolds_workspace::{
@@ -81,7 +83,7 @@ pub fn contact_manifolds_heightfield_composite_shape<ManifoldData, ContactData>(
     let qbvh2 = composite2.qbvh();
     let mut stack2 = Vec::new();
     let ls_aabb2_1 = qbvh2.root_aabb().transform_by(pos12).loosened(prediction);
-    let mut old_manifolds = std::mem::take(manifolds);
+    let mut old_manifolds = core::mem::take(manifolds);
 
     heightfield1.map_elements_in_local_aabb(&ls_aabb2_1, &mut |leaf1, part1| {
         #[cfg(feature = "dim2")]

--- a/src/query/contact_manifolds/contact_manifolds_heightfield_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_heightfield_shape.rs
@@ -1,3 +1,5 @@
+use alloc::{boxed::Box, vec::Vec};
+
 use crate::bounding_volume::BoundingVolume;
 use crate::math::{Isometry, Real};
 use crate::query::contact_manifolds::contact_manifolds_workspace::{
@@ -115,7 +117,7 @@ pub fn contact_manifolds_heightfield_shape<ManifoldData, ContactData>(
      */
     // TODO: somehow precompute the Aabb and reuse it?
     let ls_aabb2 = shape2.compute_aabb(pos12).loosened(prediction);
-    let mut old_manifolds = std::mem::take(manifolds);
+    let mut old_manifolds = core::mem::take(manifolds);
 
     heightfield1.map_elements_in_local_aabb(&ls_aabb2, &mut |i, part1| {
         #[cfg(feature = "dim2")]

--- a/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
@@ -1,3 +1,5 @@
+use alloc::{boxed::Box, vec::Vec};
+
 use crate::bounding_volume::{Aabb, BoundingVolume};
 use crate::math::{Isometry, Real};
 use crate::query::contact_manifolds::contact_manifolds_workspace::{
@@ -116,12 +118,12 @@ pub fn contact_manifolds_trimesh_shape<ManifoldData, ContactData>(
         new_local_aabb2.maxs += extra_margin;
 
         let local_aabb2 = new_local_aabb2; // .loosened(prediction * 2.0); // TODO: what would be the best value?
-        std::mem::swap(
+        core::mem::swap(
             &mut workspace.old_interferences,
             &mut workspace.interferences,
         );
 
-        std::mem::swap(manifolds, &mut old_manifolds);
+        core::mem::swap(manifolds, &mut old_manifolds);
 
         // This assertion may fire due to the invalid triangle_ids that the
         // near-phase may return (due to SIMD sentinels).

--- a/src/query/contact_manifolds/contact_manifolds_workspace.rs
+++ b/src/query/contact_manifolds/contact_manifolds_workspace.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::multiple_bound_locations)] // for impl_downcast
 
+use alloc::boxed::Box;
 use downcast_rs::{impl_downcast, DowncastSync};
 
 use crate::query::contact_manifolds::{

--- a/src/query/contact_manifolds/polygon_polygon_contact_generator.rs
+++ b/src/query/contact_manifolds/polygon_polygon_contact_generator.rs
@@ -52,10 +52,10 @@ fn generate_contacts<'a>(
 
     let mut swapped = false;
     if sep2.0 > sep1.0 {
-        std::mem::swap(&mut sep1, &mut sep2);
-        std::mem::swap(&mut m1, &mut m2);
-        std::mem::swap(&mut p1, &mut p2);
-        std::mem::swap(&mut m12, &mut m21);
+        core::mem::swap(&mut sep1, &mut sep2);
+        core::mem::swap(&mut m1, &mut m2);
+        core::mem::swap(&mut p1, &mut p2);
+        core::mem::swap(&mut m12, &mut m21);
         manifold.swap_identifiers();
         swapped = true;
     }

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -4,13 +4,14 @@ use crate::query::{
     self, details::NonlinearShapeCastMode, ClosestPoints, Contact, NonlinearRigidMotion,
     QueryDispatcher, ShapeCastHit, Unsupported,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use crate::query::{
     contact_manifolds::{ContactManifoldsWorkspace, NormalConstraints},
     query_dispatcher::PersistentQueryDispatcher,
     ContactManifold,
 };
 use crate::shape::{HalfSpace, Segment, Shape, ShapeType};
+use alloc::vec::Vec;
 
 /// A dispatcher that exposes built-in queries
 #[derive(Debug, Clone)]
@@ -63,7 +64,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 pos12, s1, s2,
             ))
         } else {
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             if let Some(c1) = shape1.as_composite_shape() {
                 return Ok(query::details::intersection_test_composite_shape_shape(
                     self, pos12, c1, shape2,
@@ -122,7 +123,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 pos12, s1, s2,
             ))
         } else {
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             if let Some(c1) = shape1.as_composite_shape() {
                 return Ok(query::details::distance_composite_shape_shape(
                     self, pos12, c1, shape2,
@@ -174,7 +175,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 pos12, shape1, b2, prediction,
             ))
         } else {
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             if let (Some(s1), Some(s2)) = (shape1.as_support_map(), shape2.as_support_map()) {
                 return Ok(query::details::contact_support_map_support_map(
                     pos12, s1, s2, prediction,
@@ -254,7 +255,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 pos12, s1, s2, max_dist,
             ))
         } else {
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             if let Some(c1) = shape1.as_composite_shape() {
                 return Ok(query::details::closest_points_composite_shape_shape(
                     self, pos12, c1, shape2, max_dist,
@@ -306,7 +307,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 options,
             ))
         } else {
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             if let Some(heightfield1) = shape1.as_heightfield() {
                 return query::details::cast_shapes_heightfield_shape(
                     self,
@@ -381,7 +382,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 ),
             )
         } else {
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             if let Some(c1) = shape1.as_composite_shape() {
                 return Ok(query::details::cast_shapes_nonlinear_composite_shape_shape(
                     self,
@@ -417,7 +418,7 @@ impl QueryDispatcher for DefaultQueryDispatcher {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<ManifoldData, ContactData> PersistentQueryDispatcher<ManifoldData, ContactData>
     for DefaultQueryDispatcher
 where

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -11,6 +11,7 @@ use crate::query::{
     ContactManifold,
 };
 use crate::shape::{HalfSpace, Segment, Shape, ShapeType};
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 /// A dispatcher that exposes built-in queries

--- a/src/query/distance/mod.rs
+++ b/src/query/distance/mod.rs
@@ -5,7 +5,7 @@ pub use self::distance_ball_ball::distance_ball_ball;
 pub use self::distance_ball_convex_polyhedron::{
     distance_ball_convex_polyhedron, distance_convex_polyhedron_ball,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::distance_composite_shape_shape::{
     distance_composite_shape_shape, distance_shape_composite_shape,
     CompositeShapeAgainstAnyDistanceVisitor,
@@ -22,7 +22,7 @@ pub use self::distance_support_map_support_map::{
 mod distance;
 mod distance_ball_ball;
 mod distance_ball_convex_polyhedron;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod distance_composite_shape_shape;
 mod distance_cuboid_cuboid;
 mod distance_halfspace_support_map;

--- a/src/query/epa/epa2.rs
+++ b/src/query/epa/epa2.rs
@@ -1,7 +1,7 @@
 //! Two-dimensional penetration depth queries using the Expanding Polytope Algorithm.
 
-use std::cmp::Ordering;
-use std::collections::BinaryHeap;
+use alloc::{collections::BinaryHeap, vec::Vec};
+use core::cmp::Ordering;
 
 use na::{self, Unit};
 use num::Bounded;

--- a/src/query/epa/epa3.rs
+++ b/src/query/epa/epa3.rs
@@ -5,10 +5,11 @@ use crate::query::gjk::{self, CSOPoint, ConstantOrigin, VoronoiSimplex};
 use crate::query::PointQueryWithLocation;
 use crate::shape::{SupportMap, Triangle, TrianglePointLocation};
 use crate::utils;
+use alloc::collections::BinaryHeap;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
 use na::{self, Unit};
 use num::Bounded;
-use std::cmp::Ordering;
-use std::collections::BinaryHeap;
 
 #[derive(Copy, Clone, PartialEq)]
 struct FaceId {
@@ -467,7 +468,10 @@ impl EPA {
     }
 
     #[allow(dead_code)]
+    #[cfg(feature = "std")]
     fn print_silhouette(&self) {
+        use std::{print, println};
+
         print!("Silhouette points: ");
         for i in 0..self.silhouette.len() {
             let edge = &self.silhouette[i];

--- a/src/query/error.rs
+++ b/src/query/error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 /// Error indicating that a query is not supported between certain shapes
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -10,5 +10,5 @@ impl fmt::Display for Unsupported {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Unsupported {}
+#[cfg(feature = "alloc")]
+impl core::error::Error for Unsupported {}

--- a/src/query/gjk/cso_point.rs
+++ b/src/query/gjk/cso_point.rs
@@ -1,7 +1,7 @@
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::shape::SupportMap;
 use na::Unit;
-use std::ops::Sub;
+use core::ops::Sub;
 
 /// A point of a Configuration-Space Obstacle.
 ///

--- a/src/query/gjk/cso_point.rs
+++ b/src/query/gjk/cso_point.rs
@@ -1,7 +1,7 @@
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::shape::SupportMap;
-use na::Unit;
 use core::ops::Sub;
+use na::Unit;
 
 /// A point of a Configuration-Space Obstacle.
 ///

--- a/src/query/gjk/voronoi_simplex3.rs
+++ b/src/query/gjk/voronoi_simplex3.rs
@@ -6,7 +6,7 @@ use crate::shape::{
     TrianglePointLocation,
 };
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::ComplexField; // for .abs()
 
 /// A simplex of dimension up to 3 that uses Voronoï regions for computing point projections.

--- a/src/query/intersection_test/mod.rs
+++ b/src/query/intersection_test/mod.rs
@@ -5,7 +5,7 @@ pub use self::intersection_test_ball_ball::intersection_test_ball_ball;
 pub use self::intersection_test_ball_point_query::{
     intersection_test_ball_point_query, intersection_test_point_query_ball,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::intersection_test_composite_shape_shape::{
     intersection_test_composite_shape_shape, intersection_test_shape_composite_shape,
     IntersectionCompositeShapeShapeVisitor,
@@ -28,7 +28,7 @@ pub use self::intersection_test_support_map_support_map::intersection_test_suppo
 mod intersection_test;
 mod intersection_test_ball_ball;
 mod intersection_test_ball_point_query;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod intersection_test_composite_shape_shape;
 mod intersection_test_cuboid_cuboid;
 mod intersection_test_cuboid_segment;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -27,7 +27,7 @@
 
 pub use self::closest_points::{closest_points, ClosestPoints};
 pub use self::contact::{contact, Contact};
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::contact_manifolds::{
     ContactManifold, ContactManifoldsWorkspace, TrackedContact, TypedWorkspaceData, WorkspaceData,
 };
@@ -37,7 +37,7 @@ pub use self::error::Unsupported;
 pub use self::intersection_test::intersection_test;
 pub use self::nonlinear_shape_cast::{cast_shapes_nonlinear, NonlinearRigidMotion};
 pub use self::point::{PointProjection, PointQuery, PointQueryWithLocation};
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::query_dispatcher::PersistentQueryDispatcher;
 pub use self::query_dispatcher::{QueryDispatcher, QueryDispatcherChain};
 pub use self::ray::{Ray, RayCast, RayIntersection, SimdRay};
@@ -47,11 +47,11 @@ pub use self::split::{IntersectResult, SplitResult};
 mod clip;
 pub mod closest_points;
 pub mod contact;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod contact_manifolds;
 mod default_query_dispatcher;
 mod distance;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub mod epa;
 mod error;
 pub mod gjk;
@@ -63,7 +63,7 @@ mod ray;
 pub mod sat;
 mod shape_cast;
 mod split;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub mod visitors;
 
 /// Queries dedicated to specific pairs of shapes.
@@ -71,7 +71,7 @@ pub mod details {
     pub use super::clip::*;
     pub use super::closest_points::*;
     pub use super::contact::*;
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub use super::contact_manifolds::*;
     pub use super::distance::*;
     pub use super::intersection_test::*;

--- a/src/query/nonlinear_shape_cast/mod.rs
+++ b/src/query/nonlinear_shape_cast/mod.rs
@@ -1,6 +1,6 @@
 //! Implementation details of the `cast_shapes_nonlinear` function.
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::nonlinear_shape_cast_composite_shape_shape::{
     cast_shapes_nonlinear_composite_shape_shape, cast_shapes_nonlinear_shape_composite_shape,
     NonlinearTOICompositeShapeShapeBestFirstVisitor,
@@ -12,7 +12,7 @@ pub use self::nonlinear_shape_cast_support_map_support_map::{
     cast_shapes_nonlinear_support_map_support_map, NonlinearShapeCastMode,
 };
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod nonlinear_shape_cast_composite_shape_shape;
 //mod cast_shapes_nonlinear_halfspace_support_map;
 mod nonlinear_rigid_motion;

--- a/src/query/nonlinear_shape_cast/nonlinear_shape_cast_support_map_support_map.rs
+++ b/src/query/nonlinear_shape_cast/nonlinear_shape_cast_support_map_support_map.rs
@@ -1,5 +1,3 @@
-#[cfg(not(feature = "alloc"))]
-use na::ComplexField; // for .abs()
 use na::{RealField, Unit};
 
 use crate::math::{Point, Real, Vector};

--- a/src/query/nonlinear_shape_cast/nonlinear_shape_cast_support_map_support_map.rs
+++ b/src/query/nonlinear_shape_cast/nonlinear_shape_cast_support_map_support_map.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::ComplexField; // for .abs()
 use na::{RealField, Unit};
 

--- a/src/query/point/mod.rs
+++ b/src/query/point/mod.rs
@@ -1,20 +1,20 @@
 //! Point inclusion and projection.
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::point_composite_shape::{
     PointCompositeShapeProjBestFirstVisitor, PointCompositeShapeProjWithFeatureBestFirstVisitor,
     PointCompositeShapeProjWithLocationBestFirstVisitor,
 };
 #[doc(inline)]
 pub use self::point_query::{PointProjection, PointQuery, PointQueryWithLocation};
-#[cfg(feature = "std")] // TODO: can’t be used without std because of EPA
+#[cfg(feature = "alloc")]
 pub use self::point_support_map::local_point_projection_on_support_map;
 
 mod point_aabb;
 mod point_ball;
 mod point_bounding_sphere;
 mod point_capsule;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod point_composite_shape;
 #[cfg(feature = "dim3")]
 mod point_cone;
@@ -22,13 +22,13 @@ mod point_cuboid;
 #[cfg(feature = "dim3")]
 mod point_cylinder;
 mod point_halfspace;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod point_heightfield;
 #[doc(hidden)]
 pub mod point_query;
 mod point_round_shape;
 mod point_segment;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod point_support_map;
 #[cfg(feature = "dim3")]
 mod point_tetrahedron;

--- a/src/query/point/point_round_shape.rs
+++ b/src/query/point/point_round_shape.rs
@@ -8,12 +8,12 @@ use crate::shape::{FeatureId, RoundShape, SupportMap};
 impl<S: SupportMap> PointQuery for RoundShape<S> {
     #[inline]
     fn project_local_point(&self, point: &Point<Real>, solid: bool) -> PointProjection {
-        #[cfg(not(feature = "std"))] // TODO: can’t be used without std because of EPA
+        #[cfg(not(feature = "alloc"))]
         return unimplemented!(
-            "The projection of points on a round shapes isn’t supported on no-std platforms yet."
+            "The projection of points on a round shape isn't supported without alloc yet."
         );
 
-        #[cfg(feature = "std")] // TODO: can’t be used without std because of EPA
+        #[cfg(feature = "alloc")]
         return crate::query::details::local_point_projection_on_support_map(
             self,
             &mut VoronoiSimplex::new(),

--- a/src/query/point/point_support_map.rs
+++ b/src/query/point/point_support_map.rs
@@ -1,15 +1,15 @@
 use na::Unit;
 
 use crate::math::{Isometry, Point, Real, Vector};
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use crate::query::epa::EPA;
 use crate::query::gjk::{self, CSOPoint, ConstantOrigin, VoronoiSimplex};
 use crate::query::{PointProjection, PointQuery};
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use crate::shape::ConvexPolygon;
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use crate::shape::ConvexPolyhedron;
 use crate::shape::{FeatureId, SupportMap};
 

--- a/src/query/query_dispatcher.rs
+++ b/src/query/query_dispatcher.rs
@@ -1,14 +1,15 @@
 use crate::math::{Isometry, Real, Vector};
 use crate::query::details::ShapeCastOptions;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use crate::query::{
     contact_manifolds::{ContactManifoldsWorkspace, NormalConstraints},
     ContactManifold,
 };
 use crate::query::{ClosestPoints, Contact, NonlinearRigidMotion, ShapeCastHit, Unsupported};
 use crate::shape::Shape;
+use alloc::vec::Vec;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 /// A query dispatcher for queries relying on spatial coherence, including contact-manifold computation.
 pub trait PersistentQueryDispatcher<ManifoldData = (), ContactData = ()>: QueryDispatcher {
     /// Compute all the contacts between two shapes.
@@ -207,7 +208,7 @@ where
     ) -> Option<ShapeCastHit>);
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<ManifoldData, ContactData, T, U> PersistentQueryDispatcher<ManifoldData, ContactData>
     for QueryDispatcherChain<T, U>
 where

--- a/src/query/query_dispatcher.rs
+++ b/src/query/query_dispatcher.rs
@@ -7,6 +7,7 @@ use crate::query::{
 };
 use crate::query::{ClosestPoints, Contact, NonlinearRigidMotion, ShapeCastHit, Unsupported};
 use crate::shape::Shape;
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 #[cfg(feature = "alloc")]

--- a/src/query/ray/mod.rs
+++ b/src/query/ray/mod.rs
@@ -3,7 +3,7 @@
 #[doc(inline)]
 pub use self::ray::{Ray, RayCast, RayIntersection};
 pub use self::ray_ball::ray_toi_with_ball;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::ray_composite_shape::{
     RayCompositeShapeToiAndNormalBestFirstVisitor, RayCompositeShapeToiBestFirstVisitor,
 };
@@ -18,11 +18,11 @@ pub mod ray;
 mod ray_aabb;
 mod ray_ball;
 mod ray_bounding_sphere;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod ray_composite_shape;
 mod ray_cuboid;
 mod ray_halfspace;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod ray_heightfield;
 mod ray_round_shape;
 mod ray_support_map;

--- a/src/query/ray/ray_aabb.rs
+++ b/src/query/ray/ray_aabb.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use core::mem;
 
 use na;
 

--- a/src/query/ray/ray_support_map.rs
+++ b/src/query/ray/ray_support_map.rs
@@ -1,6 +1,4 @@
 use na;
-#[cfg(not(feature = "alloc"))]
-use na::ComplexField; // for .abs()
 
 use crate::math::Real;
 #[cfg(feature = "dim2")]

--- a/src/query/ray/ray_support_map.rs
+++ b/src/query/ray/ray_support_map.rs
@@ -1,5 +1,5 @@
 use na;
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::ComplexField; // for .abs()
 
 use crate::math::Real;
@@ -7,9 +7,9 @@ use crate::math::Real;
 use crate::query;
 use crate::query::gjk::{self, CSOPoint, VoronoiSimplex};
 use crate::query::{Ray, RayCast, RayIntersection};
-#[cfg(all(feature = "std", feature = "dim2"))]
+#[cfg(all(feature = "alloc", feature = "dim2"))]
 use crate::shape::ConvexPolygon;
-#[cfg(all(feature = "std", feature = "dim3"))]
+#[cfg(all(feature = "alloc", feature = "dim3"))]
 use crate::shape::ConvexPolyhedron;
 use crate::shape::{Capsule, FeatureId, Segment, SupportMap};
 #[cfg(feature = "dim3")]
@@ -126,7 +126,7 @@ impl RayCast for Capsule {
 }
 
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl RayCast for ConvexPolyhedron {
     fn cast_local_ray_and_get_normal(
         &self,
@@ -145,7 +145,7 @@ impl RayCast for ConvexPolyhedron {
 }
 
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl RayCast for ConvexPolygon {
     fn cast_local_ray_and_get_normal(
         &self,

--- a/src/query/ray/ray_triangle.rs
+++ b/src/query/ray/ray_triangle.rs
@@ -6,9 +6,6 @@ use crate::shape::{FeatureId, Triangle};
 #[cfg(feature = "dim3")]
 use {crate::math::Point, na::Vector3};
 
-#[cfg(not(feature = "alloc"))]
-use na::ComplexField; // for .abs()
-
 impl RayCast for Triangle {
     #[inline]
     #[cfg(feature = "dim2")]

--- a/src/query/ray/ray_triangle.rs
+++ b/src/query/ray/ray_triangle.rs
@@ -6,7 +6,7 @@ use crate::shape::{FeatureId, Triangle};
 #[cfg(feature = "dim3")]
 use {crate::math::Point, na::Vector3};
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::ComplexField; // for .abs()
 
 impl RayCast for Triangle {

--- a/src/query/sat/sat_cuboid_cuboid.rs
+++ b/src/query/sat/sat_cuboid_cuboid.rs
@@ -1,7 +1,5 @@
 use crate::math::{Isometry, Real, Vector, DIM};
 use crate::shape::{Cuboid, SupportMap};
-#[cfg(not(feature = "alloc"))]
-use na::RealField; // For .copysign()
 
 /// Computes the separation of two cuboids along `axis1`.
 #[cfg(feature = "dim3")]

--- a/src/query/sat/sat_cuboid_cuboid.rs
+++ b/src/query/sat/sat_cuboid_cuboid.rs
@@ -1,6 +1,6 @@
 use crate::math::{Isometry, Real, Vector, DIM};
 use crate::shape::{Cuboid, SupportMap};
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::RealField; // For .copysign()
 
 /// Computes the separation of two cuboids along `axis1`.

--- a/src/query/shape_cast/mod.rs
+++ b/src/query/shape_cast/mod.rs
@@ -5,7 +5,7 @@ pub use self::shape_cast_ball_ball::cast_shapes_ball_ball;
 pub use self::shape_cast_halfspace_support_map::{
     cast_shapes_halfspace_support_map, cast_shapes_support_map_halfspace,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::{
     shape_cast_composite_shape_shape::{
         cast_shapes_composite_shape_shape, cast_shapes_shape_composite_shape,
@@ -17,10 +17,10 @@ pub use self::{
 
 mod shape_cast;
 mod shape_cast_ball_ball;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod shape_cast_composite_shape_shape;
 mod shape_cast_halfspace_support_map;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod shape_cast_heightfield_shape;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod shape_cast_support_map_support_map;

--- a/src/query/split/mod.rs
+++ b/src/query/split/mod.rs
@@ -4,5 +4,5 @@ mod split;
 mod split_aabb;
 mod split_segment;
 
-#[cfg(all(feature = "alloc", feature = "dim3"))]
+#[cfg(all(feature = "dim3", feature = "spade"))]
 mod split_trimesh;

--- a/src/query/split/mod.rs
+++ b/src/query/split/mod.rs
@@ -4,5 +4,5 @@ mod split;
 mod split_aabb;
 mod split_segment;
 
-#[cfg(all(feature = "std", feature = "dim3"))]
+#[cfg(all(feature = "alloc", feature = "dim3"))]
 mod split_trimesh;

--- a/src/query/split/split_trimesh.rs
+++ b/src/query/split/split_trimesh.rs
@@ -5,8 +5,9 @@ use crate::query::{IntersectResult, PointQuery, SplitResult};
 use crate::shape::{Cuboid, FeatureId, Polyline, Segment, Shape, TriMesh, TriMeshFlags, Triangle};
 use crate::transformation::{intersect_meshes, MeshIntersectionError};
 use crate::utils::{hashmap::HashMap, SortedPair, WBasis};
+use alloc::{vec, vec::Vec};
+use core::cmp::Ordering;
 use spade::{handles::FixedVertexHandle, ConstrainedDelaunayTriangulation, Triangulation as _};
-use std::cmp::Ordering;
 
 struct Triangulation {
     delaunay: ConstrainedDelaunayTriangulation<spade::Point2<Real>>,
@@ -231,7 +232,7 @@ impl TriMesh {
                     // The plane splits the triangle into 1 + 2 triangles.
                     // First, make sure the edge indices are consecutive.
                     if e2 != (e1 + 1) % 3 {
-                        std::mem::swap(&mut e1, &mut e2);
+                        core::mem::swap(&mut e1, &mut e2);
                     }
 
                     let ia = e2; // The first point of the second edge is the vertex shared by both edges.
@@ -549,7 +550,7 @@ impl TriMesh {
                     // The plane splits the triangle into 1 + 2 triangles.
                     // First, make sure the edge indices are consecutive.
                     if e2 != (e1 + 1) % 3 {
-                        std::mem::swap(&mut e1, &mut e2);
+                        core::mem::swap(&mut e1, &mut e2);
                     }
 
                     let ia = e2; // The first point of the second edge is the vertex shared by both edges.

--- a/src/query/visitors/aabb_sets_interferences_collector.rs
+++ b/src/query/visitors/aabb_sets_interferences_collector.rs
@@ -1,4 +1,5 @@
 use crate::math::{Isometry, Matrix, Real};
+use alloc::vec::Vec;
 
 /// Spatial partitioning data structure visitor collecting interferences with a given bounding volume.
 pub struct AabbSetsInterferencesCollector<'a, T: 'a> {

--- a/src/query/visitors/bounding_volume_intersections_simultaneous_visitor.rs
+++ b/src/query/visitors/bounding_volume_intersections_simultaneous_visitor.rs
@@ -1,9 +1,9 @@
 use crate::bounding_volume::SimdAabb;
 use crate::math::{Isometry, Real, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdSimultaneousVisitStatus, SimdSimultaneousVisitor};
+use core::marker::PhantomData;
 use na::SimdValue;
 use simba::simd::SimdBool as _;
-use std::marker::PhantomData;
 
 #[cfg(feature = "parallel")]
 use crate::partitioning::{QbvhNode, SimdNodeIndex};

--- a/src/query/visitors/bounding_volume_intersections_visitor.rs
+++ b/src/query/visitors/bounding_volume_intersections_visitor.rs
@@ -1,8 +1,8 @@
 use crate::bounding_volume::{Aabb, SimdAabb};
 use crate::math::SIMD_WIDTH;
 use crate::partitioning::{SimdVisitStatus, SimdVisitor};
+use core::marker::PhantomData;
 use simba::simd::SimdBool as _;
-use std::marker::PhantomData;
 
 /// Spatial partitioning data structure visitor collecting interferences with a given bounding volume.
 pub struct BoundingVolumeIntersectionsVisitor<T, F> {

--- a/src/query/visitors/point_intersections_visitor.rs
+++ b/src/query/visitors/point_intersections_visitor.rs
@@ -1,8 +1,8 @@
 use crate::bounding_volume::SimdAabb;
 use crate::math::{Point, Real, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdVisitStatus, SimdVisitor};
+use core::marker::PhantomData;
 use simba::simd::{SimdBool as _, SimdValue};
-use std::marker::PhantomData;
 
 // TODO: add a point cost fn.
 

--- a/src/query/visitors/ray_intersections_visitor.rs
+++ b/src/query/visitors/ray_intersections_visitor.rs
@@ -2,8 +2,8 @@ use crate::bounding_volume::SimdAabb;
 use crate::math::{Real, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdVisitStatus, SimdVisitor};
 use crate::query::{Ray, SimdRay};
+use core::marker::PhantomData;
 use simba::simd::{SimdBool as _, SimdValue};
-use std::marker::PhantomData;
 
 /// Bounding Volume Tree visitor collecting intersections with a given ray.
 pub struct RayIntersectionsVisitor<'a, T, F> {

--- a/src/shape/ball.rs
+++ b/src/shape/ball.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "std")]
 use either::Either;
 use na::Unit;
 
@@ -33,7 +32,7 @@ impl Ball {
     /// ball. Instead, a convex polygon approximation (with `nsubdivs`
     /// subdivisions) is returned. Returns `None` if that approximation had degenerate
     /// normals (for example if the scaling factor along one axis is zero).
-    #[cfg(all(feature = "dim2", feature = "std"))]
+    #[cfg(all(feature = "dim2", feature = "alloc"))]
     #[inline]
     pub fn scaled(
         self,
@@ -60,7 +59,7 @@ impl Ball {
     /// ball. Instead, a convex polygon approximation (with `nsubdivs`
     /// subdivisions) is returned. Returns `None` if that approximation had degenerate
     /// normals (for example if the scaling factor along one axis is zero).
-    #[cfg(all(feature = "dim3", feature = "std"))]
+    #[cfg(all(feature = "dim3", feature = "alloc"))]
     #[inline]
     pub fn scaled(
         self,

--- a/src/shape/capsule.rs
+++ b/src/shape/capsule.rs
@@ -2,7 +2,7 @@ use crate::math::{Isometry, Point, Real, Rotation, Vector};
 use crate::shape::{Segment, SupportMap};
 use na::Unit;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use either::Either;
 
 #[cfg(feature = "rkyv")]
@@ -109,7 +109,7 @@ impl Capsule {
     /// capsule. Instead, a convex polygon approximation (with `nsubdivs`
     /// subdivisions) is returned. Returns `None` if that approximation had degenerate
     /// normals (for example if the scaling factor along one axis is zero).
-    #[cfg(all(feature = "dim2", feature = "std"))]
+    #[cfg(all(feature = "dim2", feature = "alloc"))]
     pub fn scaled(
         self,
         scale: &Vector<Real>,
@@ -139,7 +139,7 @@ impl Capsule {
     /// capsule. Instead, a convex polygon approximation (with `nsubdivs`
     /// subdivisions) is returned. Returns `None` if that approximation had degenerate
     /// normals (for example if the scaling factor along one axis is zero).
-    #[cfg(all(feature = "dim3", feature = "std"))]
+    #[cfg(all(feature = "dim3", feature = "alloc"))]
     pub fn scaled(
         self,
         scale: &Vector<Real>,

--- a/src/shape/composite_shape.rs
+++ b/src/shape/composite_shape.rs
@@ -7,7 +7,7 @@ use crate::shape::Shape;
 ///
 /// A composite shape is composed of several shapes. For example, this can
 /// be a convex decomposition of a concave shape; or a triangle-mesh.
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub trait SimdCompositeShape {
     /// Applies a function to one sub-shape of this composite shape.
     fn map_part_at(
@@ -20,7 +20,7 @@ pub trait SimdCompositeShape {
     fn qbvh(&self) -> &Qbvh<u32>;
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub trait TypedSimdCompositeShape {
     type PartShape: ?Sized + Shape;
     type PartNormalConstraints: ?Sized + NormalConstraints;
@@ -44,7 +44,7 @@ pub trait TypedSimdCompositeShape {
     fn typed_qbvh(&self) -> &Qbvh<Self::PartId>;
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl TypedSimdCompositeShape for dyn SimdCompositeShape + '_ {
     type PartShape = dyn Shape;
     type PartNormalConstraints = dyn NormalConstraints;

--- a/src/shape/compound.rs
+++ b/src/shape/compound.rs
@@ -11,6 +11,7 @@ use crate::shape::{ConvexPolygon, TriMesh, Triangle};
 use crate::shape::{Shape, SharedShape, SimdCompositeShape, TypedSimdCompositeShape};
 #[cfg(feature = "dim2")]
 use crate::transformation::hertel_mehlhorn;
+use alloc::vec::Vec;
 
 /// A compound shape with an aabb bounding volume.
 ///

--- a/src/shape/cone.rs
+++ b/src/shape/cone.rs
@@ -5,10 +5,10 @@ use crate::shape::SupportMap;
 use na;
 use num::Zero;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use either::Either;
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::RealField; // for .copysign()
 
 #[cfg(feature = "rkyv")]
@@ -50,7 +50,7 @@ impl Cone {
     /// cone. Instead, a convex polyhedral approximation (with `nsubdivs`
     /// subdivisions) is returned. Returns `None` if that approximation had degenerate
     /// normals (for example if the scaling factor along one axis is zero).
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn scaled(
         self,

--- a/src/shape/convex_polygon.rs
+++ b/src/shape/convex_polygon.rs
@@ -1,6 +1,7 @@
 use crate::math::{Point, Real, Vector};
 use crate::shape::{FeatureId, PackedFeatureId, PolygonalFeature, PolygonalFeatureMap, SupportMap};
 use crate::utils;
+use alloc::vec::Vec;
 use na::{self, ComplexField, RealField, Unit};
 
 /// A 2D convex polygon.

--- a/src/shape/convex_polyhedron.rs
+++ b/src/shape/convex_polyhedron.rs
@@ -3,11 +3,12 @@ use crate::shape::{FeatureId, PackedFeatureId, PolygonalFeature, PolygonalFeatur
 // use crate::transformation;
 use crate::utils::hashmap::{Entry, HashMap};
 use crate::utils::{self, SortedPair};
-use na::{self, ComplexField, Point2, Unit};
-use std::f64;
-
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+use core::f64;
 #[cfg(not(feature = "std"))]
-use na::ComplexField; // for .abs()
+use na::ComplexField; // for .abs(), .sqrt(), and .sin_cos()
+use na::{self, Point2, Unit};
 
 #[cfg(feature = "rkyv")]
 use rkyv::{bytecheck, CheckBytes};
@@ -134,7 +135,7 @@ impl ConvexPolyhedron {
         points: Vec<Point<Real>>,
         indices: &[[u32; DIM]],
     ) -> Option<ConvexPolyhedron> {
-        let eps = ComplexField::sqrt(crate::math::DEFAULT_EPSILON);
+        let eps = crate::math::DEFAULT_EPSILON.sqrt();
 
         let mut vertices = Vec::new();
         let mut edges = Vec::<Edge>::new();
@@ -461,7 +462,7 @@ impl ConvexPolyhedron {
         local_dir: &Unit<Vector<Real>>,
         eps: Real,
     ) -> FeatureId {
-        let (seps, ceps) = ComplexField::sin_cos(eps);
+        let (seps, ceps) = eps.sin_cos();
         let support_pt_id = utils::point_cloud_support_point_id(local_dir.as_ref(), &self.points);
         let vertex = &self.vertices[support_pt_id];
 

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -7,7 +7,7 @@ use crate::shape::{FeatureId, PackedFeatureId, PolygonalFeature, SupportMap};
 use crate::utils::WSign;
 use na::Unit;
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::RealField; // for .copysign()
 
 #[cfg(feature = "rkyv")]

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -7,9 +7,6 @@ use crate::shape::{FeatureId, PackedFeatureId, PolygonalFeature, SupportMap};
 use crate::utils::WSign;
 use na::Unit;
 
-#[cfg(not(feature = "alloc"))]
-use na::RealField; // for .copysign()
-
 #[cfg(feature = "rkyv")]
 use rkyv::{bytecheck, CheckBytes};
 

--- a/src/shape/cylinder.rs
+++ b/src/shape/cylinder.rs
@@ -8,9 +8,6 @@ use num::Zero;
 #[cfg(feature = "alloc")]
 use either::Either;
 
-#[cfg(not(feature = "alloc"))]
-use na::RealField; // for .copysign()
-
 #[cfg(feature = "rkyv")]
 use rkyv::{bytecheck, CheckBytes};
 

--- a/src/shape/cylinder.rs
+++ b/src/shape/cylinder.rs
@@ -5,10 +5,10 @@ use crate::shape::SupportMap;
 use na;
 use num::Zero;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use either::Either;
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::RealField; // for .copysign()
 
 #[cfg(feature = "rkyv")]
@@ -52,7 +52,7 @@ impl Cylinder {
     /// cylinder. Instead, a convex polyhedral approximation (with `nsubdivs`
     /// subdivisions) is returned. Returns `None` if that approximation had degenerate
     /// normals (for example if the scaling factor along one axis is zero).
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn scaled(
         self,

--- a/src/shape/heightfield2.rs
+++ b/src/shape/heightfield2.rs
@@ -1,8 +1,8 @@
+use core::ops::Range;
 #[cfg(not(feature = "std"))]
 use na::ComplexField;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use na::DVector;
-use std::ops::Range;
 
 use na::Point2;
 
@@ -33,7 +33,7 @@ pub struct HeightField {
     aabb: Aabb,
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl HeightField {
     /// Creates a new 2D heightfield with the given heights and scale factor.
     pub fn new(heights: DVector<Real>, scale: Vector<Real>) -> Self {

--- a/src/shape/heightfield3.rs
+++ b/src/shape/heightfield3.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "std")]
+use core::ops::Range;
+#[cfg(feature = "alloc")]
 use na::DMatrix;
-use std::ops::Range;
 
 use crate::bounding_volume::Aabb;
 use crate::math::{Real, Vector};
@@ -76,7 +76,7 @@ pub struct HeightField {
     flags: HeightFieldFlags,
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl HeightField {
     /// Initializes a new heightfield with the given heights, scaling factor, and flags.
     pub fn new(heights: DMatrix<Real>, scale: Vector<Real>) -> Self {

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -16,7 +16,7 @@ pub use self::shape::{Shape, ShapeType, TypedShape};
 pub use self::support_map::SupportMap;
 pub use self::triangle::{Triangle, TriangleOrientation, TrianglePointLocation};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::{
     composite_shape::{SimdCompositeShape, TypedSimdCompositeShape},
     compound::Compound,
@@ -25,10 +25,10 @@ pub use self::{
 };
 
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::convex_polygon::ConvexPolygon;
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::heightfield2::*;
 #[cfg(feature = "dim2")]
 pub use self::polygonal_feature2d::PolygonalFeature;
@@ -36,19 +36,19 @@ pub use self::polygonal_feature2d::PolygonalFeature;
 #[cfg(feature = "dim3")]
 pub use self::cone::Cone;
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::convex_polyhedron::ConvexPolyhedron;
 #[cfg(feature = "dim3")]
 pub use self::cylinder::Cylinder;
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::heightfield3::*;
 #[cfg(feature = "dim3")]
 pub use self::polygonal_feature3d::PolygonalFeature;
 #[cfg(feature = "dim3")]
 pub use self::tetrahedron::{Tetrahedron, TetrahedronPointLocation};
 pub use self::triangle_pseudo_normals::TrianglePseudoNormals;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::trimesh::*;
 
 /// A cylinder dilated by a sphere (so it has round corners).
@@ -63,25 +63,25 @@ pub type RoundCuboid = RoundShape<Cuboid>;
 pub type RoundTriangle = RoundShape<Triangle>;
 /// A convex polyhedron dilated by a sphere (so it has round corners).
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub type RoundConvexPolyhedron = RoundShape<ConvexPolyhedron>;
 /// A convex polygon dilated by a sphere (so it has round corners).
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub type RoundConvexPolygon = RoundShape<ConvexPolygon>;
 
 pub(crate) use self::round_shape::RoundShapeRef;
 
 mod ball;
 mod capsule;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 #[doc(hidden)]
 pub mod composite_shape;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod compound;
 mod cuboid;
 mod half_space;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod polyline;
 mod round_shape;
 mod segment;
@@ -92,33 +92,33 @@ pub mod support_map;
 mod triangle;
 
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod convex_polygon;
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod heightfield2;
 
 #[cfg(feature = "dim3")]
 mod cone;
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod convex_polyhedron;
 #[cfg(feature = "dim3")]
 mod cylinder;
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod heightfield3;
 #[cfg(feature = "dim3")]
 mod polygonal_feature3d;
 mod polygonal_feature_map;
 #[cfg(feature = "dim3")]
 mod tetrahedron;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub(crate) mod trimesh;
 // TODO: move this elsewhere?
 mod feature_id;
 #[cfg(feature = "dim2")]
 mod polygonal_feature2d;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod shared_shape;
 mod triangle_pseudo_normals;

--- a/src/shape/polygonal_feature2d.rs
+++ b/src/shape/polygonal_feature2d.rs
@@ -1,5 +1,5 @@
 use crate::math::{Isometry, Point, Real, Vector};
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use crate::query::{self, ContactManifold, TrackedContact};
 use crate::shape::{PackedFeatureId, Segment};
 
@@ -47,7 +47,7 @@ impl PolygonalFeature {
     }
 
     /// Computes the contacts between two polygonal features.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn contacts<ManifoldData, ContactData: Default + Copy>(
         pos12: &Isometry<Real>,
         pos21: &Isometry<Real>,
@@ -75,7 +75,7 @@ impl PolygonalFeature {
     /// Compute contacts points between a face and a vertex.
     ///
     /// This method assume we already know that at least one contact exists.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn face_vertex_contacts<ManifoldData, ContactData: Default + Copy>(
         pos12: &Isometry<Real>,
         face1: &Self,
@@ -105,7 +105,7 @@ impl PolygonalFeature {
     }
 
     /// Computes the contacts between two polygonal faces.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn face_face_contacts<ManifoldData, ContactData: Default + Copy>(
         pos12: &Isometry<Real>,
         face1: &Self,

--- a/src/shape/polygonal_feature3d.rs
+++ b/src/shape/polygonal_feature3d.rs
@@ -1,6 +1,6 @@
 use crate::approx::AbsDiffEq;
 use crate::math::{Isometry, Point, Real, Vector};
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use crate::query::{ContactManifold, TrackedContact};
 use crate::shape::{PackedFeatureId, Segment, Triangle};
 use crate::utils::WBasis;
@@ -72,7 +72,7 @@ impl PolygonalFeature {
     }
 
     /// Computes all the contacts between two polygonal features.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn contacts<ManifoldData, ContactData: Default + Copy>(
         pos12: &Isometry<Real>,
         _pos21: &Isometry<Real>,
@@ -91,7 +91,7 @@ impl PolygonalFeature {
         }
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn contacts_edge_edge<ManifoldData, ContactData: Default + Copy>(
         pos12: &Isometry<Real>,
         face1: &PolygonalFeature,
@@ -204,7 +204,7 @@ impl PolygonalFeature {
         }
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn contacts_face_face<ManifoldData, ContactData: Default + Copy>(
         pos12: &Isometry<Real>,
         face1: &PolygonalFeature,

--- a/src/shape/polygonal_feature_map.rs
+++ b/src/shape/polygonal_feature_map.rs
@@ -10,7 +10,7 @@ use {
     approx::AbsDiffEq,
 };
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::{ComplexField, RealField}; // for .abs() and .copysign()
 
 /// Trait implemented by convex shapes with features with polyhedral approximations.

--- a/src/shape/polyline.rs
+++ b/src/shape/polyline.rs
@@ -8,8 +8,6 @@ use crate::shape::{FeatureId, Segment, SegmentPointLocation, Shape, TypedSimdCom
 use alloc::vec::Vec;
 
 use crate::query::details::NormalConstraints;
-#[cfg(not(feature = "std"))]
-use na::ComplexField; // for .abs()
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]

--- a/src/shape/polyline.rs
+++ b/src/shape/polyline.rs
@@ -4,6 +4,8 @@ use crate::partitioning::Qbvh;
 use crate::query::{PointProjection, PointQueryWithLocation};
 use crate::shape::composite_shape::SimdCompositeShape;
 use crate::shape::{FeatureId, Segment, SegmentPointLocation, Shape, TypedSimdCompositeShape};
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use crate::query::details::NormalConstraints;
 #[cfg(not(feature = "std"))]
@@ -112,7 +114,7 @@ impl Polyline {
         unsafe {
             let len = self.indices.len() * 2;
             let data = self.indices.as_ptr() as *const u32;
-            std::slice::from_raw_parts(data, len)
+            core::slice::from_raw_parts(data, len)
         }
     }
 
@@ -192,8 +194,8 @@ impl Polyline {
                     // Start node reached: build polyline and start next component
                     component_indices.push([(i - start_i) as u32, 0]);
                     components.push(Polyline::new(
-                        std::mem::take(&mut component_vertices),
-                        Some(std::mem::take(&mut component_indices)),
+                        core::mem::take(&mut component_vertices),
+                        Some(core::mem::take(&mut component_indices)),
                     ));
 
                     if i + 1 < indices.len() {

--- a/src/shape/segment.rs
+++ b/src/shape/segment.rs
@@ -3,8 +3,8 @@
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::shape::{FeatureId, SupportMap};
 
+use core::mem;
 use na::{self, Unit};
-use std::mem;
 
 #[cfg(feature = "rkyv")]
 use rkyv::{bytecheck, CheckBytes};

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -1,14 +1,16 @@
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, vec::Vec};
 use core::fmt::Debug;
 
 use crate::bounding_volume::{Aabb, BoundingSphere, BoundingVolume};
 use crate::mass_properties::MassProperties;
 use crate::math::{Isometry, Point, Real, Vector};
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use crate::num::Float;
 use crate::query::{PointQuery, RayCast};
 #[cfg(feature = "serde-serialize")]
 use crate::shape::SharedShape;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use crate::shape::{composite_shape::SimdCompositeShape, Compound, HeightField, Polyline, TriMesh};
 use crate::shape::{
     Ball, Capsule, Cuboid, FeatureId, HalfSpace, PolygonalFeatureMap, RoundCuboid, RoundShape,
@@ -18,11 +20,11 @@ use crate::shape::{
 use crate::shape::{Cone, Cylinder, RoundCone, RoundCylinder};
 
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use crate::shape::{ConvexPolyhedron, RoundConvexPolyhedron};
 
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use crate::shape::{ConvexPolygon, RoundConvexPolygon};
 use downcast_rs::{impl_downcast, DowncastSync};
 use na::{RealField, Unit};
@@ -104,24 +106,24 @@ pub enum TypedShape<'a> {
     /// A triangle shape.
     Triangle(&'a Triangle),
     /// A triangle mesh shape.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     TriMesh(&'a TriMesh),
     /// A set of segments.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     Polyline(&'a Polyline),
     /// A shape representing a full half-space.
     HalfSpace(&'a HalfSpace),
     /// A heightfield shape.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     HeightField(&'a HeightField),
     /// A Compound shape.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     Compound(&'a Compound),
     #[cfg(feature = "dim2")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     ConvexPolygon(&'a ConvexPolygon),
     #[cfg(feature = "dim3")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     /// A convex polyhedron.
     ConvexPolyhedron(&'a ConvexPolyhedron),
     #[cfg(feature = "dim3")]
@@ -146,11 +148,11 @@ pub enum TypedShape<'a> {
     RoundCone(&'a RoundCone),
     /// A convex polyhedron with rounded corners.
     #[cfg(feature = "dim3")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     RoundConvexPolyhedron(&'a RoundConvexPolyhedron),
     /// A convex polygon with rounded corners.
     #[cfg(feature = "dim2")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     RoundConvexPolygon(&'a RoundConvexPolygon),
     /// A custom user-defined shape.
     #[cfg_attr(feature = "serde-serialize", serde(skip))]
@@ -164,20 +166,20 @@ impl Debug for TypedShape<'_> {
             Self::Capsule(arg0) => f.debug_tuple("Capsule").field(arg0).finish(),
             Self::Segment(arg0) => f.debug_tuple("Segment").field(arg0).finish(),
             Self::Triangle(arg0) => f.debug_tuple("Triangle").field(arg0).finish(),
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             Self::TriMesh(arg0) => f.debug_tuple("TriMesh").field(arg0).finish(),
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             Self::Polyline(arg0) => f.debug_tuple("Polyline").field(arg0).finish(),
             Self::HalfSpace(arg0) => f.debug_tuple("HalfSpace").field(arg0).finish(),
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             Self::HeightField(arg0) => f.debug_tuple("HeightField").field(arg0).finish(),
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             Self::Compound(arg0) => f.debug_tuple("Compound").field(arg0).finish(),
             #[cfg(feature = "dim2")]
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             Self::ConvexPolygon(arg0) => f.debug_tuple("ConvexPolygon").field(arg0).finish(),
             #[cfg(feature = "dim3")]
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             Self::ConvexPolyhedron(arg0) => f.debug_tuple("ConvexPolyhedron").field(arg0).finish(),
             #[cfg(feature = "dim3")]
             Self::Cylinder(arg0) => f.debug_tuple("Cylinder").field(arg0).finish(),
@@ -190,12 +192,12 @@ impl Debug for TypedShape<'_> {
             #[cfg(feature = "dim3")]
             Self::RoundCone(arg0) => f.debug_tuple("RoundCone").field(arg0).finish(),
             #[cfg(feature = "dim3")]
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             Self::RoundConvexPolyhedron(arg0) => {
                 f.debug_tuple("RoundConvexPolyhedron").field(arg0).finish()
             }
             #[cfg(feature = "dim2")]
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             Self::RoundConvexPolygon(arg0) => {
                 f.debug_tuple("RoundConvexPolygon").field(arg0).finish()
             }
@@ -220,24 +222,24 @@ pub(crate) enum DeserializableTypedShape {
     /// A triangle shape.
     Triangle(Triangle),
     /// A triangle mesh shape.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     TriMesh(TriMesh),
     /// A set of segments.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     Polyline(Polyline),
     /// A shape representing a full half-space.
     HalfSpace(HalfSpace),
     /// A heightfield shape.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     HeightField(HeightField),
     /// A Compound shape.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     Compound(Compound),
     #[cfg(feature = "dim2")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     ConvexPolygon(ConvexPolygon),
     #[cfg(feature = "dim3")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     /// A convex polyhedron.
     ConvexPolyhedron(ConvexPolyhedron),
     #[cfg(feature = "dim3")]
@@ -264,11 +266,11 @@ pub(crate) enum DeserializableTypedShape {
     RoundCone(RoundCone),
     /// A convex polyhedron with rounded corners.
     #[cfg(feature = "dim3")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     RoundConvexPolyhedron(RoundConvexPolyhedron),
     /// A convex polygon with rounded corners.
     #[cfg(feature = "dim2")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     RoundConvexPolygon(RoundConvexPolygon),
     /// A custom user-defined shape.
     #[allow(dead_code)]
@@ -285,20 +287,20 @@ impl DeserializableTypedShape {
             DeserializableTypedShape::Capsule(s) => Some(SharedShape::new(s)),
             DeserializableTypedShape::Segment(s) => Some(SharedShape::new(s)),
             DeserializableTypedShape::Triangle(s) => Some(SharedShape::new(s)),
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             DeserializableTypedShape::TriMesh(s) => Some(SharedShape::new(s)),
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             DeserializableTypedShape::Polyline(s) => Some(SharedShape::new(s)),
             DeserializableTypedShape::HalfSpace(s) => Some(SharedShape::new(s)),
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             DeserializableTypedShape::HeightField(s) => Some(SharedShape::new(s)),
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             DeserializableTypedShape::Compound(s) => Some(SharedShape::new(s)),
             #[cfg(feature = "dim2")]
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             DeserializableTypedShape::ConvexPolygon(s) => Some(SharedShape::new(s)),
             #[cfg(feature = "dim3")]
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             DeserializableTypedShape::ConvexPolyhedron(s) => Some(SharedShape::new(s)),
             #[cfg(feature = "dim3")]
             DeserializableTypedShape::Cylinder(s) => Some(SharedShape::new(s)),
@@ -311,10 +313,10 @@ impl DeserializableTypedShape {
             #[cfg(feature = "dim3")]
             DeserializableTypedShape::RoundCone(s) => Some(SharedShape::new(s)),
             #[cfg(feature = "dim3")]
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             DeserializableTypedShape::RoundConvexPolyhedron(s) => Some(SharedShape::new(s)),
             #[cfg(feature = "dim2")]
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             DeserializableTypedShape::RoundConvexPolygon(s) => Some(SharedShape::new(s)),
             DeserializableTypedShape::Custom => None,
         }
@@ -331,7 +333,7 @@ pub trait Shape: RayCast + PointQuery + DowncastSync {
     /// Clones this shape into a boxed trait-object.
     ///
     /// The boxed trait-object has the same concrete type as `Self`.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[deprecated = "renamed to `clone_dyn`"]
     fn clone_box(&self) -> Box<dyn Shape> {
         self.clone_dyn()
@@ -340,7 +342,7 @@ pub trait Shape: RayCast + PointQuery + DowncastSync {
     /// Clones this shape into a boxed trait-object.
     ///
     /// The boxed trait-object has the same concrete type as `Self`.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn clone_dyn(&self) -> Box<dyn Shape>;
 
     /// Scales this shape by `scale` into a boxed trait-object.
@@ -348,7 +350,7 @@ pub trait Shape: RayCast + PointQuery + DowncastSync {
     /// In some cases, the resulting shape doesn’t have the same type as Self. For example,
     /// if a non-uniform scale is provided and Self as a [`Ball`], then the result will be discretized
     /// (based on the `num_subdivisions` parameter) as a `ConvexPolyhedron` (in 3D) or `ConvexPolygon` (in 2D).
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn scale_dyn(&self, scale: &Vector<Real>, num_subdivisions: u32) -> Option<Box<dyn Shape>>;
 
     /// Computes the [`Aabb`] of this shape with the given position.
@@ -393,7 +395,7 @@ pub trait Shape: RayCast + PointQuery + DowncastSync {
         None
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn as_composite_shape(&self) -> Option<&dyn SimdCompositeShape> {
         None
     }
@@ -492,45 +494,45 @@ impl dyn Shape {
     }
 
     /// Converts this abstract shape to a compound shape, if it is one.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_compound(&self) -> Option<&Compound> {
         self.downcast_ref()
     }
     /// Converts this abstract shape to a mutable compound shape, if it is one.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_compound_mut(&mut self) -> Option<&mut Compound> {
         self.downcast_mut()
     }
 
     /// Converts this abstract shape to a triangle mesh, if it is one.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_trimesh(&self) -> Option<&TriMesh> {
         self.downcast_ref()
     }
     /// Converts this abstract shape to a mutable triangle mesh, if it is one.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_trimesh_mut(&mut self) -> Option<&mut TriMesh> {
         self.downcast_mut()
     }
 
     /// Converts this abstract shape to a polyline, if it is one.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_polyline(&self) -> Option<&Polyline> {
         self.downcast_ref()
     }
     /// Converts this abstract shape to a mutable polyline, if it is one.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_polyline_mut(&mut self) -> Option<&mut Polyline> {
         self.downcast_mut()
     }
 
     /// Converts this abstract shape to a heightfield, if it is one.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_heightfield(&self) -> Option<&HeightField> {
         self.downcast_ref()
     }
     /// Converts this abstract shape to a mutable heightfield, if it is one.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_heightfield_mut(&mut self) -> Option<&mut HeightField> {
         self.downcast_mut()
     }
@@ -555,37 +557,37 @@ impl dyn Shape {
 
     /// Converts this abstract shape to a convex polygon, if it is one.
     #[cfg(feature = "dim2")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_convex_polygon(&self) -> Option<&ConvexPolygon> {
         self.downcast_ref()
     }
     /// Converts this abstract shape to a mutable convex polygon, if it is one.
     #[cfg(feature = "dim2")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_convex_polygon_mut(&mut self) -> Option<&mut ConvexPolygon> {
         self.downcast_mut()
     }
 
     /// Converts this abstract shape to a round convex polygon, if it is one.
     #[cfg(feature = "dim2")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_round_convex_polygon(&self) -> Option<&RoundConvexPolygon> {
         self.downcast_ref()
     }
     /// Converts this abstract shape to a mutable round convex polygon, if it is one.
     #[cfg(feature = "dim2")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_round_convex_polygon_mut(&mut self) -> Option<&mut RoundConvexPolygon> {
         self.downcast_mut()
     }
 
     #[cfg(feature = "dim3")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_convex_polyhedron(&self) -> Option<&ConvexPolyhedron> {
         self.downcast_ref()
     }
     #[cfg(feature = "dim3")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_convex_polyhedron_mut(&mut self) -> Option<&mut ConvexPolyhedron> {
         self.downcast_mut()
     }
@@ -636,25 +638,25 @@ impl dyn Shape {
 
     /// Converts this abstract shape to a round convex polyhedron, if it is one.
     #[cfg(feature = "dim3")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_round_convex_polyhedron(&self) -> Option<&RoundConvexPolyhedron> {
         self.downcast_ref()
     }
     /// Converts this abstract shape to a mutable round convex polyhedron, if it is one.
     #[cfg(feature = "dim3")]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn as_round_convex_polyhedron_mut(&mut self) -> Option<&mut RoundConvexPolyhedron> {
         self.downcast_mut()
     }
 }
 
 impl Shape for Ball {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(*self)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn scale_dyn(&self, scale: &Vector<Real>, num_subdivisions: u32) -> Option<Box<dyn Shape>> {
         let scaled = self.scaled(scale, num_subdivisions)?;
         Some(scaled.either::<_, _, Box<dyn Shape>>(|x| Box::new(x), |x| Box::new(x)))
@@ -712,12 +714,12 @@ impl Shape for Ball {
 }
 
 impl Shape for Cuboid {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(*self)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn scale_dyn(&self, scale: &Vector<Real>, _num_subdivisions: u32) -> Option<Box<dyn Shape>> {
         Some(Box::new(self.scaled(scale)))
     }
@@ -776,12 +778,12 @@ impl Shape for Cuboid {
 }
 
 impl Shape for Capsule {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(*self)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn scale_dyn(&self, scale: &Vector<Real>, num_subdivisions: u32) -> Option<Box<dyn Shape>> {
         let scaled = self.scaled(scale, num_subdivisions)?;
         Some(scaled.either::<_, _, Box<dyn Shape>>(|x| Box::new(x), |x| Box::new(x)))
@@ -833,12 +835,12 @@ impl Shape for Capsule {
 }
 
 impl Shape for Triangle {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(*self)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn scale_dyn(&self, scale: &Vector<Real>, _num_subdivisions: u32) -> Option<Box<dyn Shape>> {
         Some(Box::new(self.scaled(scale)))
     }
@@ -904,12 +906,12 @@ impl Shape for Triangle {
 }
 
 impl Shape for Segment {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(*self)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn scale_dyn(&self, scale: &Vector<Real>, _num_subdivisions: u32) -> Option<Box<dyn Shape>> {
         Some(Box::new(self.scaled(scale)))
     }
@@ -967,7 +969,7 @@ impl Shape for Segment {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl Shape for Compound {
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(self.clone())
@@ -1029,13 +1031,13 @@ impl Shape for Compound {
         })
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn as_composite_shape(&self) -> Option<&dyn SimdCompositeShape> {
         Some(self as &dyn SimdCompositeShape)
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl Shape for Polyline {
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(self.clone())
@@ -1079,13 +1081,13 @@ impl Shape for Polyline {
         Real::frac_pi_4()
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn as_composite_shape(&self) -> Option<&dyn SimdCompositeShape> {
         Some(self as &dyn SimdCompositeShape)
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl Shape for TriMesh {
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(self.clone())
@@ -1142,13 +1144,13 @@ impl Shape for TriMesh {
         return self.feature_normal(_feature);
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn as_composite_shape(&self) -> Option<&dyn SimdCompositeShape> {
         Some(self as &dyn SimdCompositeShape)
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl Shape for HeightField {
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(self.clone())
@@ -1194,7 +1196,7 @@ impl Shape for HeightField {
 }
 
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl Shape for ConvexPolygon {
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(self.clone())
@@ -1261,7 +1263,7 @@ impl Shape for ConvexPolygon {
 }
 
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl Shape for ConvexPolyhedron {
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(self.clone())
@@ -1330,12 +1332,12 @@ impl Shape for ConvexPolyhedron {
 
 #[cfg(feature = "dim3")]
 impl Shape for Cylinder {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(*self)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn scale_dyn(&self, scale: &Vector<Real>, num_subdivisions: u32) -> Option<Box<dyn Shape>> {
         let scaled = self.scaled(scale, num_subdivisions)?;
         Some(scaled.either::<_, _, Box<dyn Shape>>(|x| Box::new(x), |x| Box::new(x)))
@@ -1388,12 +1390,12 @@ impl Shape for Cylinder {
 
 #[cfg(feature = "dim3")]
 impl Shape for Cone {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(*self)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn scale_dyn(&self, scale: &Vector<Real>, num_subdivisions: u32) -> Option<Box<dyn Shape>> {
         let scaled = self.scaled(scale, num_subdivisions)?;
         Some(scaled.either::<_, _, Box<dyn Shape>>(|x| Box::new(x), |x| Box::new(x)))
@@ -1448,12 +1450,12 @@ impl Shape for Cone {
 }
 
 impl Shape for HalfSpace {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn clone_dyn(&self) -> Box<dyn Shape> {
         Box::new(*self)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn scale_dyn(&self, scale: &Vector<Real>, _num_subdivisions: u32) -> Option<Box<dyn Shape>> {
         Some(Box::new(self.scaled(scale)?))
     }
@@ -1501,12 +1503,12 @@ impl Shape for HalfSpace {
 macro_rules! impl_shape_for_round_shape(
     ($S: ty, $Tag: ident, $t: tt) => {
         impl Shape for RoundShape<$S> {
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             fn clone_dyn(&self) -> Box<dyn Shape> {
                 Box::new(self.clone())
             }
 
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             fn scale_dyn(&self, scale: &Vector<Real>, num_subdivisions: u32) -> Option<Box<dyn Shape>> {
                 $t(self, scale, num_subdivisions)
             }
@@ -1585,7 +1587,7 @@ impl_shape_for_round_shape!(
 );
 
 #[cfg(feature = "dim2")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl_shape_for_round_shape!(
     ConvexPolygon,
     RoundConvexPolygon,
@@ -1650,7 +1652,7 @@ impl_shape_for_round_shape!(
 );
 
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl_shape_for_round_shape!(
     ConvexPolyhedron,
     RoundConvexPolyhedron,

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -12,10 +12,11 @@ use crate::shape::{
 #[cfg(feature = "dim3")]
 use crate::shape::{Cone, ConvexPolyhedron, Cylinder};
 use crate::transformation::vhacd::{VHACDParameters, VHACD};
+use alloc::sync::Arc;
+use alloc::{vec, vec::Vec};
+use core::fmt;
+use core::ops::Deref;
 use na::Unit;
-use std::fmt;
-use std::ops::Deref;
-use std::sync::Arc;
 
 use super::TriMeshBuilderError;
 

--- a/src/shape/tetrahedron.rs
+++ b/src/shape/tetrahedron.rs
@@ -3,10 +3,10 @@
 use crate::math::{Matrix, Point, Real};
 use crate::shape::{Segment, Triangle};
 use crate::utils;
+use core::mem;
 use na::Matrix3;
-use std::mem;
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::ComplexField; // for .abs()
 
 #[cfg(feature = "rkyv")]

--- a/src/shape/tetrahedron.rs
+++ b/src/shape/tetrahedron.rs
@@ -6,7 +6,7 @@ use crate::utils;
 use core::mem;
 use na::Matrix3;
 
-#[cfg(not(feature = "alloc"))]
+#[cfg(all(feature = "dim2", not(feature = "std")))]
 use na::ComplexField; // for .abs()
 
 #[cfg(feature = "rkyv")]

--- a/src/shape/triangle.rs
+++ b/src/shape/triangle.rs
@@ -5,12 +5,12 @@ use crate::shape::SupportMap;
 use crate::shape::{PolygonalFeature, Segment};
 use crate::utils;
 
+use core::mem;
 use na::{self, ComplexField, Unit};
 use num::Zero;
-use std::mem;
 
 #[cfg(feature = "dim3")]
-use {crate::shape::FeatureId, std::f64};
+use {crate::shape::FeatureId, core::f64};
 
 #[cfg(feature = "dim2")]
 use crate::shape::PackedFeatureId;

--- a/src/shape/triangle_pseudo_normals.rs
+++ b/src/shape/triangle_pseudo_normals.rs
@@ -1,7 +1,10 @@
-use crate::math::{Real, UnitVector, Vector};
+#[cfg(feature = "alloc")]
+use crate::math::Vector;
+use crate::math::{Real, UnitVector};
+#[cfg(feature = "alloc")]
 use na::Vector3;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use crate::query::details::NormalConstraints;
 
 // NOTE: ideally, the normal cone should take into account the point where the normal cone is
@@ -28,7 +31,7 @@ pub struct TrianglePseudoNormals {
     pub edges: [UnitVector<Real>; 3],
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl NormalConstraints for TrianglePseudoNormals {
     /// Projects the given direction to it is contained in the polygonal
     /// cone defined `self`.
@@ -93,7 +96,7 @@ impl NormalConstraints for TrianglePseudoNormals {
 }
 
 #[cfg(test)]
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "alloc"))]
 mod test {
     use crate::math::{Real, Vector};
     use crate::shape::TrianglePseudoNormals;

--- a/src/transformation/convex_hull2.rs
+++ b/src/transformation/convex_hull2.rs
@@ -1,4 +1,5 @@
-use std::marker::PhantomData;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
 
 use crate::math::Real;
 use crate::transformation::convex_hull_utils::{indexed_support_point_id, support_point_id};

--- a/src/transformation/convex_hull3/convex_hull.rs
+++ b/src/transformation/convex_hull3/convex_hull.rs
@@ -4,6 +4,7 @@ use crate::math::Real;
 use crate::transformation::convex_hull_utils::indexed_support_point_nth;
 use crate::transformation::convex_hull_utils::{indexed_support_point_id, normalize};
 use crate::utils;
+use alloc::{vec, vec::Vec};
 use na::{self, Point3};
 
 /// Computes the convex hull of a set of 3d points.
@@ -250,7 +251,7 @@ fn fix_silhouette_topology(
         }
 
         let mut removing = None;
-        let old_facets_and_idx = std::mem::take(out_facets_and_idx);
+        let old_facets_and_idx = core::mem::take(out_facets_and_idx);
 
         for i in 0..old_facets_and_idx.len() {
             let facet_id = (loop_start + i) % old_facets_and_idx.len();

--- a/src/transformation/convex_hull3/initial_mesh.rs
+++ b/src/transformation/convex_hull3/initial_mesh.rs
@@ -4,8 +4,9 @@ use crate::shape::Triangle;
 use crate::transformation;
 use crate::transformation::convex_hull_utils::support_point_id;
 use crate::utils;
+use alloc::{vec, vec::Vec};
+use core::cmp::Ordering;
 use na::{Point2, Point3, Vector3};
-use std::cmp::Ordering;
 
 #[derive(Debug)]
 pub enum InitialMesh {

--- a/src/transformation/convex_hull3/mod.rs
+++ b/src/transformation/convex_hull3/mod.rs
@@ -3,6 +3,7 @@ use self::initial_mesh::{try_get_initial_mesh, InitialMesh};
 use self::triangle_facet::TriangleFacet;
 use self::validation::check_facet_links;
 pub use convex_hull::{convex_hull, try_convex_hull};
+#[cfg(feature = "std")]
 pub use validation::check_convex_hull;
 
 mod convex_hull;

--- a/src/transformation/convex_hull3/triangle_facet.rs
+++ b/src/transformation/convex_hull3/triangle_facet.rs
@@ -1,5 +1,6 @@
 use crate::math::Real;
 use crate::shape::Triangle;
+use alloc::vec::Vec;
 use na::{Point3, Vector3};
 use num::Bounded;
 

--- a/src/transformation/convex_hull3/validation.rs
+++ b/src/transformation/convex_hull3/validation.rs
@@ -1,5 +1,7 @@
 use super::TriangleFacet;
+#[cfg(feature = "std")]
 use crate::math::Real;
+#[cfg(feature = "std")]
 use na::Point3;
 
 pub fn check_facet_links(ifacet: usize, facets: &[TriangleFacet]) {

--- a/src/transformation/convex_hull3/validation.rs
+++ b/src/transformation/convex_hull3/validation.rs
@@ -26,7 +26,10 @@ pub fn check_facet_links(ifacet: usize, facets: &[TriangleFacet]) {
 }
 
 /// Checks if a convex-hull is properly formed.
+#[cfg(feature = "std")]
 pub fn check_convex_hull(points: &[Point3<Real>], triangles: &[[u32; 3]]) {
+    use std::println;
+
     use crate::utils::hashmap::{Entry, HashMap};
     use crate::utils::SortedPair;
     let mut edges = HashMap::default();
@@ -93,7 +96,7 @@ pub fn check_convex_hull(points: &[Point3<Real>], triangles: &[[u32; 3]]) {
     assert_eq!(points.len() + triangles.len() - edges.len(), 2);
 }
 
-// fn print_buildable_vec<T: std::fmt::Display + na::Scalar>(desc: &str, elts: &[Point3<T>]) {
+// fn print_buildable_vec<T: core::fmt::Display + na::Scalar>(desc: &str, elts: &[Point3<T>]) {
 //     print!("let {} = vec![", desc);
 //     for elt in elts {
 //         print!("Point3::new({},{},{}),", elt.x, elt.y, elt.z);

--- a/src/transformation/ear_clipping.rs
+++ b/src/transformation/ear_clipping.rs
@@ -5,6 +5,7 @@ use crate::{
     math::{Point, Real},
     utils::point_in_triangle::{corner_direction, is_point_in_triangle, Orientation},
 };
+use alloc::{vec, vec::Vec};
 
 /// The information stored for each vertex in the ear clipping algorithm.
 #[derive(Clone, Default)]

--- a/src/transformation/hertel_mehlhorn.rs
+++ b/src/transformation/hertel_mehlhorn.rs
@@ -1,6 +1,8 @@
 //! Hertel-Mehlhorn algorithm for convex partitioning.
 //! Based on <https://github.com/ivanfratric/polypartition>, contributed by embotech AG.
 
+use alloc::vec::Vec;
+
 use crate::math::{Point, Real};
 use crate::utils::point_in_triangle::{corner_direction, Orientation};
 

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -7,10 +7,13 @@ use crate::utils;
 use crate::utils::hashmap::Entry;
 use crate::utils::hashmap::HashMap;
 use crate::utils::hashset::HashSet;
+use alloc::collections::BTreeMap;
+use alloc::{vec, vec::Vec};
+#[cfg(not(feature = "std"))]
+use na::ComplexField;
 use na::{Point3, Vector3};
 use rstar::RTree;
 use spade::{ConstrainedDelaunayTriangulation, InsertionError, Triangulation as _};
-use std::collections::BTreeMap;
 #[cfg(feature = "wavefront")]
 use std::path::PathBuf;
 

--- a/src/transformation/mesh_intersection/triangle_triangle_intersection.rs
+++ b/src/transformation/mesh_intersection/triangle_triangle_intersection.rs
@@ -7,6 +7,7 @@ use crate::transformation::polygon_intersection::{
     PolygonIntersectionTolerances, PolylinePointLocation,
 };
 use crate::utils::WBasis;
+use alloc::{vec, vec::Vec};
 use na::Point2;
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -221,6 +222,7 @@ fn segment_plane_intersection(
 /// lines to copy/paste into the Desmos online graphing tool (for visual debugging), as well as
 /// some rust code to add to the `tris` array in the `intersect_triangle_common_vertex` test for
 /// regression checking.
+#[cfg(feature = "std")]
 fn debug_check_intersections(
     tri1: &Triangle,
     tri2: &Triangle,
@@ -229,6 +231,8 @@ fn debug_check_intersections(
     poly2: &[Point2<Real>], // Projection of tri2 on the basis `basis2` with the origin at tri2.a.
     intersections: &[TriangleTriangleIntersectionPoint],
 ) {
+    use std::{print, println};
+
     let proj = |vect: Vector<Real>| Point2::new(vect.dot(&basis[0]), vect.dot(&basis[1]));
     let mut incorrect = false;
     for pt in intersections {

--- a/src/transformation/mesh_intersection/triangle_triangle_intersection.rs
+++ b/src/transformation/mesh_intersection/triangle_triangle_intersection.rs
@@ -176,11 +176,14 @@ pub(crate) fn triangle_triangle_intersection(
                 },
             );
 
-            // NOTE: set this to `true` to automatically check if the computed intersection is
-            //       valid, and print debug infos if it is not.
-            const DEBUG_INTERSECTIONS: bool = false;
-            if DEBUG_INTERSECTIONS {
-                debug_check_intersections(tri1, tri2, &basis, &poly1, &poly2, &intersections);
+            #[cfg(feature = "std")]
+            {
+                // NOTE: set this to `true` to automatically check if the computed intersection is
+                //       valid, and print debug infos if it is not.
+                const DEBUG_INTERSECTIONS: bool = false;
+                if DEBUG_INTERSECTIONS {
+                    debug_check_intersections(tri1, tri2, &basis, &poly1, &poly2, &intersections);
+                }
             }
 
             Some(TriangleTriangleIntersection::Polygon(intersections))

--- a/src/transformation/mod.rs
+++ b/src/transformation/mod.rs
@@ -4,8 +4,10 @@
 pub(crate) use self::convex_hull2::convex_hull2_idx;
 #[cfg(feature = "dim2")]
 pub use self::convex_hull2::{convex_hull2 as convex_hull, convex_hull2_idx as convex_hull_idx};
+#[cfg(all(feature = "dim3", feature = "std"))]
+pub use self::convex_hull3::check_convex_hull;
 #[cfg(feature = "dim3")]
-pub use self::convex_hull3::{check_convex_hull, convex_hull, try_convex_hull, ConvexHullError};
+pub use self::convex_hull3::{convex_hull, try_convex_hull, ConvexHullError};
 #[cfg(feature = "dim3")]
 pub use self::mesh_intersection::{
     intersect_meshes, intersect_meshes_with_tolerances, MeshIntersectionError,

--- a/src/transformation/mod.rs
+++ b/src/transformation/mod.rs
@@ -8,7 +8,7 @@ pub use self::convex_hull2::{convex_hull2 as convex_hull, convex_hull2_idx as co
 pub use self::convex_hull3::check_convex_hull;
 #[cfg(feature = "dim3")]
 pub use self::convex_hull3::{convex_hull, try_convex_hull, ConvexHullError};
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "spade"))]
 pub use self::mesh_intersection::{
     intersect_meshes, intersect_meshes_with_tolerances, MeshIntersectionError,
     MeshIntersectionTolerances,
@@ -37,7 +37,7 @@ pub(crate) mod ear_clipping;
 pub(crate) mod hertel_mehlhorn;
 #[cfg(feature = "dim2")]
 pub use hertel_mehlhorn::{hertel_mehlhorn, hertel_mehlhorn_idx};
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "spade"))]
 mod mesh_intersection;
 #[cfg(feature = "dim3")]
 mod to_outline;

--- a/src/transformation/polygon_intersection.rs
+++ b/src/transformation/polygon_intersection.rs
@@ -1,3 +1,4 @@
+use alloc::{vec, vec::Vec};
 use log::error;
 use na::Point2;
 use ordered_float::OrderedFloat;
@@ -415,7 +416,7 @@ pub fn polygons_intersection_points(
         } else if let Some(loc2) = loc2 {
             curr_poly.push(loc2.to_point(poly2))
         } else if !curr_poly.is_empty() {
-            result.push(std::mem::take(&mut curr_poly));
+            result.push(core::mem::take(&mut curr_poly));
         }
     })?;
 
@@ -663,7 +664,9 @@ mod test {
     use crate::shape::Triangle;
     use crate::transformation::convex_polygons_intersection_points_with_tolerances;
     use crate::transformation::polygon_intersection::PolygonIntersectionTolerances;
+    use alloc::vec::Vec;
     use na::Point2;
+    use std::println;
 
     #[test]
     fn intersect_triangle_common_vertex() {

--- a/src/transformation/to_outline/ball_to_outline.rs
+++ b/src/transformation/to_outline/ball_to_outline.rs
@@ -1,6 +1,7 @@
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::shape::Ball;
 use crate::transformation::utils;
+use alloc::vec::Vec;
 use na::{self, Point3, RealField};
 
 #[cfg(not(feature = "std"))]

--- a/src/transformation/to_outline/ball_to_outline.rs
+++ b/src/transformation/to_outline/ball_to_outline.rs
@@ -4,9 +4,6 @@ use crate::transformation::utils;
 use alloc::vec::Vec;
 use na::{self, Point3, RealField};
 
-#[cfg(not(feature = "std"))]
-use na::ComplexField;
-
 impl Ball {
     /// Outlines this ball’s shape using polylines.
     pub fn to_outline(&self, nsubdiv: u32) -> (Vec<Point3<Real>>, Vec<[u32; 2]>) {

--- a/src/transformation/to_outline/capsule_to_outline.rs
+++ b/src/transformation/to_outline/capsule_to_outline.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::{Capsule, Cylinder};
 use crate::transformation::utils;
+use alloc::vec::Vec;
 use na::{self, Point3};
 
 impl Capsule {

--- a/src/transformation/to_outline/cone_to_outline.rs
+++ b/src/transformation/to_outline/cone_to_outline.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::Cone;
 use crate::transformation::utils;
+use alloc::{vec, vec::Vec};
 use na::{self, Point3, Vector3};
 
 impl Cone {

--- a/src/transformation/to_outline/cuboid_to_outline.rs
+++ b/src/transformation/to_outline/cuboid_to_outline.rs
@@ -2,6 +2,7 @@ use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 use crate::shape::Cuboid;
 use crate::transformation::utils;
+use alloc::{vec, vec::Vec};
 
 impl Aabb {
     /// Outlines this Aabb’s shape using polylines.

--- a/src/transformation/to_outline/cylinder_to_outline.rs
+++ b/src/transformation/to_outline/cylinder_to_outline.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::Cylinder;
 use crate::transformation::utils;
+use alloc::{vec, vec::Vec};
 use na::{self, Point3, Vector3};
 
 impl Cylinder {

--- a/src/transformation/to_outline/round_cone_to_outline.rs
+++ b/src/transformation/to_outline/round_cone_to_outline.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::RoundCone;
 use crate::transformation::utils;
+use alloc::{vec, vec::Vec};
 use na::{self, Point3, Vector3};
 
 impl RoundCone {

--- a/src/transformation/to_outline/round_convex_polyhedron_to_outline.rs
+++ b/src/transformation/to_outline/round_convex_polyhedron_to_outline.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::RoundConvexPolyhedron;
 use crate::transformation::utils;
+use alloc::{vec, vec::Vec};
 use na::Point3;
 
 impl RoundConvexPolyhedron {

--- a/src/transformation/to_outline/round_cuboid_to_outline.rs
+++ b/src/transformation/to_outline/round_cuboid_to_outline.rs
@@ -2,6 +2,7 @@ use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 use crate::shape::RoundCuboid;
 use crate::transformation::utils;
+use alloc::{vec, vec::Vec};
 
 impl RoundCuboid {
     /// Outlines this round cuboid’s surface with polylines.

--- a/src/transformation/to_outline/round_cylinder_to_outline.rs
+++ b/src/transformation/to_outline/round_cylinder_to_outline.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::RoundCylinder;
 use crate::transformation::utils;
+use alloc::{vec, vec::Vec};
 use na::{self, Point3};
 
 impl RoundCylinder {

--- a/src/transformation/to_polyline/ball_to_polyline.rs
+++ b/src/transformation/to_polyline/ball_to_polyline.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::Ball;
 use crate::transformation::utils;
+use alloc::vec::Vec;
 use na::{self, Point2, RealField};
 
 impl Ball {

--- a/src/transformation/to_polyline/capsule_to_polyline.rs
+++ b/src/transformation/to_polyline/capsule_to_polyline.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::Capsule;
 use crate::transformation::utils;
+use alloc::vec::Vec;
 use na::{self, Point2, RealField, Vector2};
 
 impl Capsule {

--- a/src/transformation/to_polyline/cuboid_to_polyline.rs
+++ b/src/transformation/to_polyline/cuboid_to_polyline.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::Cuboid;
 use crate::transformation::utils;
+use alloc::{vec, vec::Vec};
 use na::{self, Point2};
 
 impl Cuboid {

--- a/src/transformation/to_polyline/heightfield_to_polyline.rs
+++ b/src/transformation/to_polyline/heightfield_to_polyline.rs
@@ -1,5 +1,6 @@
 use crate::math::Real;
 use crate::shape::HeightField;
+use alloc::{vec, vec::Vec};
 use na::Point2;
 
 impl HeightField {

--- a/src/transformation/to_polyline/round_convex_polygon_to_polyline.rs
+++ b/src/transformation/to_polyline/round_convex_polygon_to_polyline.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::RoundConvexPolygon;
 use crate::transformation::utils;
+use alloc::{vec, vec::Vec};
 use na::{self, Point2};
 
 impl RoundConvexPolygon {

--- a/src/transformation/to_polyline/round_cuboid_to_polyline.rs
+++ b/src/transformation/to_polyline/round_cuboid_to_polyline.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::RoundCuboid;
 use crate::transformation::utils;
+use alloc::{vec, vec::Vec};
 use na::{self, Point2};
 
 impl RoundCuboid {

--- a/src/transformation/to_trimesh/ball_to_trimesh.rs
+++ b/src/transformation/to_trimesh/ball_to_trimesh.rs
@@ -1,6 +1,7 @@
 use crate::math::{Point, Real, Vector, DIM};
 use crate::shape::Ball;
 use crate::transformation::utils;
+use alloc::vec::Vec;
 use na::{self, ComplexField, Point3, RealField};
 
 impl Ball {

--- a/src/transformation/to_trimesh/capsule_to_trimesh.rs
+++ b/src/transformation/to_trimesh/capsule_to_trimesh.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::Capsule;
 use crate::transformation::utils;
+use alloc::vec::Vec;
 use na::{self, Point3};
 
 impl Capsule {

--- a/src/transformation/to_trimesh/cone_to_trimesh.rs
+++ b/src/transformation/to_trimesh/cone_to_trimesh.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::Cone;
 use crate::transformation::utils;
+use alloc::vec::Vec;
 use na::{self, Point3, RealField, Vector3};
 
 impl Cone {

--- a/src/transformation/to_trimesh/convex_polyhedron_to_trimesh.rs
+++ b/src/transformation/to_trimesh/convex_polyhedron_to_trimesh.rs
@@ -1,5 +1,6 @@
 use crate::math::Real;
 use crate::shape::ConvexPolyhedron;
+use alloc::vec::Vec;
 use na::Point3;
 
 impl ConvexPolyhedron {

--- a/src/transformation/to_trimesh/cuboid_to_trimesh.rs
+++ b/src/transformation/to_trimesh/cuboid_to_trimesh.rs
@@ -2,6 +2,7 @@ use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real};
 use crate::shape::Cuboid;
 use crate::transformation::utils;
+use alloc::vec::Vec;
 
 impl Aabb {
     /// Discretize the boundary of this Aabb as a triangle-mesh.

--- a/src/transformation/to_trimesh/cylinder_to_trimesh.rs
+++ b/src/transformation/to_trimesh/cylinder_to_trimesh.rs
@@ -1,6 +1,7 @@
 use crate::math::Real;
 use crate::shape::Cylinder;
 use crate::transformation::utils;
+use alloc::vec::Vec;
 use na::{self, Point3, RealField, Vector3};
 
 impl Cylinder {

--- a/src/transformation/to_trimesh/heightfield_to_trimesh.rs
+++ b/src/transformation/to_trimesh/heightfield_to_trimesh.rs
@@ -1,5 +1,6 @@
 use crate::math::Real;
 use crate::shape::HeightField;
+use alloc::vec::Vec;
 use na::Point3;
 
 impl HeightField {

--- a/src/transformation/utils.rs
+++ b/src/transformation/utils.rs
@@ -2,6 +2,7 @@
 
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::na::ComplexField;
+use alloc::vec::Vec;
 #[cfg(feature = "dim3")]
 use {crate::math::DIM, num::Zero};
 
@@ -163,7 +164,7 @@ pub fn reverse_clockwising(indices: &mut [[u32; DIM]]) {
 /// Pushes the index buffer of a closed loop.
 #[cfg(feature = "dim3")]
 #[inline]
-pub fn push_circle_outline_indices(indices: &mut Vec<[u32; 2]>, range: std::ops::Range<u32>) {
+pub fn push_circle_outline_indices(indices: &mut Vec<[u32; 2]>, range: core::ops::Range<u32>) {
     indices.extend((range.start..range.end - 1).map(|i| [i, i + 1]));
     indices.push([range.end - 1, range.start]);
 }
@@ -171,7 +172,7 @@ pub fn push_circle_outline_indices(indices: &mut Vec<[u32; 2]>, range: std::ops:
 /// Pushes the index buffer of an open chain.
 #[cfg(feature = "dim3")]
 #[inline]
-pub fn push_open_circle_outline_indices(indices: &mut Vec<[u32; 2]>, range: std::ops::Range<u32>) {
+pub fn push_open_circle_outline_indices(indices: &mut Vec<[u32; 2]>, range: core::ops::Range<u32>) {
     indices.extend((range.start..range.end - 1).map(|i| [i, i + 1]));
 }
 
@@ -249,7 +250,7 @@ pub fn push_arc(
 /// Pushes the index buffer for an arc between `start` and `end` and intermediate points in the
 /// range `arc`.
 #[cfg(feature = "dim3")]
-pub fn push_arc_idx(start: u32, arc: std::ops::Range<u32>, end: u32, out: &mut Vec<[u32; 2]>) {
+pub fn push_arc_idx(start: u32, arc: core::ops::Range<u32>, end: u32, out: &mut Vec<[u32; 2]>) {
     if arc.is_empty() {
         out.push([start, end]);
     } else {
@@ -266,7 +267,7 @@ pub fn push_arc_idx(start: u32, arc: std::ops::Range<u32>, end: u32, out: &mut V
 pub fn apply_revolution(
     collapse_bottom: bool,
     collapse_top: bool,
-    circle_ranges: &[std::ops::Range<u32>],
+    circle_ranges: &[core::ops::Range<u32>],
     nsubdivs: u32,
     out_vtx: &mut Vec<Point<Real>>, // Must be set to the half-profile.
     out_idx: &mut Vec<[u32; 2]>,

--- a/src/transformation/vhacd/vhacd.rs
+++ b/src/transformation/vhacd/vhacd.rs
@@ -19,7 +19,8 @@
 use crate::math::{Point, Real, Vector, DIM};
 use crate::transformation::vhacd::VHACDParameters;
 use crate::transformation::voxelization::{VoxelSet, VoxelizedVolume};
-use std::sync::Arc;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
 
 #[cfg(feature = "dim2")]
 type ConvexHull = Vec<Point<Real>>;
@@ -363,7 +364,7 @@ impl VHACD {
         let mut input_parts = Vec::new();
         let mut parts = Vec::new();
         let mut temp = Vec::new();
-        input_parts.push(std::mem::take(&mut voxels));
+        input_parts.push(core::mem::take(&mut voxels));
 
         let mut first_iteration = true;
         self.volume_ch0 = 1.0;
@@ -406,7 +407,7 @@ impl VHACD {
                 first_iteration = false;
             }
 
-            std::mem::swap(&mut input_parts, &mut temp);
+            core::mem::swap(&mut input_parts, &mut temp);
             // Note that temp is already clear because our previous for
             // loop used `drain`. However we call `clear` here explicitly
             // to make sure it still works if we remove the `drain` in the

--- a/src/transformation/voxelization/voxel_set.rs
+++ b/src/transformation/voxelization/voxel_set.rs
@@ -20,7 +20,8 @@ use super::{FillMode, VoxelizedVolume};
 use crate::bounding_volume::Aabb;
 use crate::math::{Matrix, Point, Real, Vector, DIM};
 use crate::transformation::vhacd::CutPlane;
-use std::sync::Arc;
+use alloc::sync::Arc;
+use alloc::{vec, vec::Vec};
 
 #[cfg(feature = "dim2")]
 type ConvexHull = Vec<Point<Real>>;

--- a/src/transformation/voxelization/voxelized_volume.rs
+++ b/src/transformation/voxelization/voxelized_volume.rs
@@ -20,7 +20,8 @@ use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector, DIM};
 use crate::query;
 use crate::transformation::voxelization::{Voxel, VoxelSet};
-use std::sync::Arc;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
 
 /// Controls how the voxelization determines which voxel needs
 /// to be considered empty, and which ones will be considered full.

--- a/src/transformation/wavefront.rs
+++ b/src/transformation/wavefront.rs
@@ -1,4 +1,5 @@
 use crate::shape::TriMesh;
+use alloc::{string::ToString, vec};
 use obj::{Group, IndexTuple, ObjData, ObjError, Object, SimplePolygon};
 use std::path::PathBuf;
 

--- a/src/utils/as_bytes.rs
+++ b/src/utils/as_bytes.rs
@@ -1,5 +1,5 @@
-use std::mem;
-use std::slice;
+use core::mem;
+use core::slice;
 
 use na::{Point2, Point3, Vector2, Vector3};
 use simba::scalar::RealField;

--- a/src/utils/cleanup.rs
+++ b/src/utils/cleanup.rs
@@ -1,5 +1,6 @@
 use crate::math::{Point, Real};
-use std::iter;
+use alloc::vec::Vec;
+use core::iter;
 
 /// Given an index buffer, remove from `points` every point that is not indexed.
 pub fn remove_unused_points(points: &mut Vec<Point<Real>>, idx: &mut [[u32; 3]]) {

--- a/src/utils/deterministic_state.rs
+++ b/src/utils/deterministic_state.rs
@@ -1,5 +1,5 @@
+use core::hash::BuildHasher;
 use std::collections::hash_map::DefaultHasher;
-use std::hash::BuildHasher;
 
 /// A hasher builder that creates `DefaultHasher` with default keys.
 #[derive(Default)]

--- a/src/utils/fx_hasher.rs
+++ b/src/utils/fx_hasher.rs
@@ -18,12 +18,12 @@ impl Default for FxHasher32 {
 impl FxHasher32 {
     #[inline]
     fn add_to_hash(&mut self, i: u32) {
-        use std::ops::BitXor;
+        use core::ops::BitXor;
         self.hash = self.hash.rotate_left(5).bitxor(i).wrapping_mul(K);
     }
 }
 
-impl std::hash::Hasher for FxHasher32 {
+impl core::hash::Hasher for FxHasher32 {
     #[inline]
     fn write(&mut self, mut bytes: &[u8]) {
         let read_u32 = |bytes: &[u8]| u32::from_ne_bytes(bytes[..4].try_into().unwrap());

--- a/src/utils/hashable_partial_eq.rs
+++ b/src/utils/hashable_partial_eq.rs
@@ -1,5 +1,5 @@
 use crate::utils::AsBytes;
-use std::hash::{Hash, Hasher};
+use core::hash::{Hash, Hasher};
 
 /// A structure that implements `Eq` and is hashable even if the wrapped data implements only
 /// `PartialEq`.

--- a/src/utils/hashmap.rs
+++ b/src/utils/hashmap.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap as StdHashMap;
 
 /// Serializes only the capacity of a hash-map instead of its actual content.
 #[cfg(feature = "serde-serialize")]
-pub fn serialize_hashmap_capacity<S: serde::Serializer, K, V, H: std::hash::BuildHasher>(
+pub fn serialize_hashmap_capacity<S: serde::Serializer, K, V, H: core::hash::BuildHasher>(
     map: &StdHashMap<K, V, H>,
     s: S,
 ) -> Result<S::Ok, S::Error> {
@@ -22,7 +22,7 @@ pub fn deserialize_hashmap_capacity<
     D: serde::Deserializer<'de>,
     K,
     V,
-    H: std::hash::BuildHasher + Default,
+    H: core::hash::BuildHasher + Default,
 >(
     d: D,
 ) -> Result<StdHashMap<K, V, H>, D::Error> {
@@ -52,8 +52,12 @@ pub fn deserialize_hashmap_capacity<
 /// Deterministic hashmap using [`indexmap::IndexMap`]
 #[cfg(feature = "enhanced-determinism")]
 pub type FxHashMap32<K, V> =
-    indexmap::IndexMap<K, V, std::hash::BuildHasherDefault<super::fx_hasher::FxHasher32>>;
+    indexmap::IndexMap<K, V, core::hash::BuildHasherDefault<super::fx_hasher::FxHasher32>>;
 #[cfg(feature = "enhanced-determinism")]
 pub use {self::FxHashMap32 as HashMap, indexmap::map::Entry};
+
 #[cfg(not(feature = "enhanced-determinism"))]
-pub use {rustc_hash::FxHashMap as HashMap, std::collections::hash_map::Entry};
+pub use hashbrown::hash_map::Entry;
+/// Hashmap using [`hashbrown::HashMap`]
+#[cfg(not(feature = "enhanced-determinism"))]
+pub type HashMap<K, V> = hashbrown::hash_map::HashMap<K, V, hashbrown::DefaultHashBuilder>;

--- a/src/utils/hashset.rs
+++ b/src/utils/hashset.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet as StdHashSet;
 
 /// Serializes only the capacity of a hash-set instead of its actual content.
 #[cfg(feature = "serde-serialize")]
-pub fn serialize_hashset_capacity<S: serde::Serializer, K, H: std::hash::BuildHasher>(
+pub fn serialize_hashset_capacity<S: serde::Serializer, K, H: core::hash::BuildHasher>(
     set: &StdHashSet<K, H>,
     s: S,
 ) -> Result<S::Ok, S::Error> {
@@ -22,7 +22,7 @@ pub fn deserialize_hashset_capacity<
     D: serde::Deserializer<'de>,
     K,
     V,
-    H: std::hash::BuildHasher + Default,
+    H: core::hash::BuildHasher + Default,
 >(
     d: D,
 ) -> Result<StdHashSet<K, H>, D::Error> {
@@ -30,7 +30,7 @@ pub fn deserialize_hashset_capacity<
     impl<'de> serde::de::Visitor<'de> for CapacityVisitor {
         type Value = u64;
 
-        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
             write!(formatter, "an integer between 0 and 2^64")
         }
 
@@ -49,8 +49,12 @@ pub fn deserialize_hashset_capacity<
 /// Deterministic hashset using [`indexmap::IndexSet`]
 #[cfg(feature = "enhanced-determinism")]
 pub type FxHashSet32<K> =
-    indexmap::IndexSet<K, std::hash::BuildHasherDefault<super::fx_hasher::FxHasher32>>;
+    indexmap::IndexSet<K, core::hash::BuildHasherDefault<super::fx_hasher::FxHasher32>>;
 #[cfg(feature = "enhanced-determinism")]
 pub use self::FxHashSet32 as HashSet;
+
 #[cfg(not(feature = "enhanced-determinism"))]
-pub use rustc_hash::FxHashSet as HashSet;
+pub use hashbrown::hash_set::Entry;
+/// Hashset using [`hashbrown::HashSet`]
+#[cfg(not(feature = "enhanced-determinism"))]
+pub type HashSet<K> = hashbrown::hash_set::HashSet<K, hashbrown::DefaultHashBuilder>;

--- a/src/utils/interval.rs
+++ b/src/utils/interval.rs
@@ -1,8 +1,9 @@
 // "Complete Interval Arithmetic and its Implementation on the Computer"
 // Ulrich W. Kulisch
+use alloc::{vec, vec::Vec};
+use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 use na::{RealField, SimdPartialOrd};
 use num::{One, Zero};
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 /// A derivable valued function which can be bounded on intervals.
 pub trait IntervalFunction<T> {

--- a/src/utils/isometry_ops.rs
+++ b/src/utils/isometry_ops.rs
@@ -2,7 +2,7 @@ use crate::math::{Isometry, Point, Real, SimdReal, Vector};
 use na::SimdComplexField;
 use na::Unit; // for .abs()
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::ComplexField;
 
 /// Extra operations with isometries.

--- a/src/utils/isometry_ops.rs
+++ b/src/utils/isometry_ops.rs
@@ -1,9 +1,6 @@
 use crate::math::{Isometry, Point, Real, SimdReal, Vector};
 use na::SimdComplexField;
-use na::Unit; // for .abs()
-
-#[cfg(not(feature = "alloc"))]
-use na::ComplexField;
+use na::Unit;
 
 /// Extra operations with isometries.
 pub trait IsometryOps<T> {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -29,7 +29,7 @@ pub use self::segments_intersection::{segments_intersection2d, SegmentsIntersect
 pub(crate) use self::sort::sort2;
 pub(crate) use self::sort::sort3;
 pub use self::sorted_pair::SortedPair;
-#[cfg(all(feature = "dim3", feature = "alloc"))]
+#[cfg(all(feature = "dim3", feature = "spade"))]
 pub(crate) use self::spade::sanitize_spade_point;
 pub(crate) use self::weighted_value::WeightedValue;
 pub(crate) use self::wops::{simd_swap, WBasis, WCross, WSign};
@@ -65,7 +65,7 @@ mod sdp_matrix;
 mod segments_intersection;
 mod sort;
 mod sorted_pair;
-#[cfg(all(feature = "dim3", feature = "alloc"))]
+#[cfg(all(feature = "dim3", feature = "spade"))]
 mod spade;
 mod weighted_value;
 mod wops;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,7 +6,7 @@ pub use self::center::center;
 pub use self::deterministic_state::DeterministicState;
 
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::cleanup::remove_unused_points;
 pub(crate) use self::inv::inv;
 pub use self::isometry_ops::{IsometryOps, IsometryOpt};
@@ -21,7 +21,7 @@ pub use self::as_bytes::AsBytes;
 pub(crate) use self::consts::*;
 pub use self::cov::{center_cov, cov};
 pub use self::hashable_partial_eq::HashablePartialEq;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::interval::{find_root_intervals, find_root_intervals_to, Interval, IntervalFunction};
 pub use self::obb::obb;
 pub use self::segments_intersection::{segments_intersection2d, SegmentsIntersection};
@@ -29,7 +29,7 @@ pub use self::segments_intersection::{segments_intersection2d, SegmentsIntersect
 pub(crate) use self::sort::sort2;
 pub(crate) use self::sort::sort3;
 pub use self::sorted_pair::SortedPair;
-#[cfg(all(feature = "dim3", feature = "std"))]
+#[cfg(all(feature = "dim3", feature = "alloc"))]
 pub(crate) use self::spade::sanitize_spade_point;
 pub(crate) use self::weighted_value::WeightedValue;
 pub(crate) use self::wops::{simd_swap, WBasis, WCross, WSign};
@@ -38,7 +38,7 @@ mod as_bytes;
 mod ccw_face_normal;
 mod center;
 #[cfg(feature = "dim3")]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod cleanup;
 mod consts;
 mod cov;
@@ -47,11 +47,11 @@ mod deterministic_state;
 #[cfg(feature = "enhanced-determinism")]
 mod fx_hasher;
 mod hashable_partial_eq;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub mod hashmap;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub mod hashset;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod interval;
 mod inv;
 mod isometry_ops;
@@ -65,7 +65,7 @@ mod sdp_matrix;
 mod segments_intersection;
 mod sort;
 mod sorted_pair;
-#[cfg(all(feature = "dim3", feature = "std"))]
+#[cfg(all(feature = "dim3", feature = "alloc"))]
 mod spade;
 mod weighted_value;
 mod wops;

--- a/src/utils/point_in_poly2d.rs
+++ b/src/utils/point_in_poly2d.rs
@@ -151,7 +151,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "dim2")]
+    #[cfg(all(feature = "dim2", feature = "alloc"))]
     fn point_in_poly2d_concave_exact_vertex_bug() {
         let poly = crate::shape::Ball::new(1.0).to_polyline(10);
         assert!(point_in_poly2d(&Point2::origin(), &poly));

--- a/src/utils/point_in_triangle.rs
+++ b/src/utils/point_in_triangle.rs
@@ -37,9 +37,9 @@ pub fn corner_direction(p1: &Point<Real>, p2: &Point<Real>, p3: &Point<Real>) ->
         .partial_cmp(&0.0)
         .expect("Found NaN while computing corner direction.")
     {
-        std::cmp::Ordering::Less => Orientation::Ccw,
-        std::cmp::Ordering::Equal => Orientation::None,
-        std::cmp::Ordering::Greater => Orientation::Cw,
+        core::cmp::Ordering::Less => Orientation::Ccw,
+        core::cmp::Ordering::Equal => Orientation::None,
+        core::cmp::Ordering::Greater => Orientation::Cw,
     }
 }
 

--- a/src/utils/sdp_matrix.rs
+++ b/src/utils/sdp_matrix.rs
@@ -1,6 +1,6 @@
 use crate::math::Real;
 use na::{Matrix2, Matrix3, Matrix3x2, SimdRealField, Vector2, Vector3};
-use std::ops::{Add, Mul};
+use core::ops::{Add, Mul};
 
 #[cfg(feature = "rkyv")]
 #[cfg(feature = "rkyv")]

--- a/src/utils/sdp_matrix.rs
+++ b/src/utils/sdp_matrix.rs
@@ -1,6 +1,6 @@
 use crate::math::Real;
-use na::{Matrix2, Matrix3, Matrix3x2, SimdRealField, Vector2, Vector3};
 use core::ops::{Add, Mul};
+use na::{Matrix2, Matrix3, Matrix3x2, SimdRealField, Vector2, Vector3};
 
 #[cfg(feature = "rkyv")]
 #[cfg(feature = "rkyv")]

--- a/src/utils/segments_intersection.rs
+++ b/src/utils/segments_intersection.rs
@@ -3,7 +3,7 @@ use na::Point2;
 use crate::math::Real;
 use crate::shape::{SegmentPointLocation, Triangle, TriangleOrientation};
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "alloc"))]
 use na::ComplexField;
 
 /// Intersection between two segments.

--- a/src/utils/sorted_pair.rs
+++ b/src/utils/sorted_pair.rs
@@ -1,6 +1,6 @@
-use std::cmp::PartialOrd;
-use std::mem;
-use std::ops::Deref;
+use core::cmp::PartialOrd;
+use core::mem;
+use core::ops::Deref;
 
 /// A pair of elements sorted in increasing order.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -33,11 +33,11 @@ impl<T: PartialOrd> Deref for SortedPair<T> {
 
 // TODO: can we avoid these manual impls of Hash/PartialEq/Eq for the archived types?
 #[cfg(feature = "rkyv")]
-impl<T: rkyv::Archive + PartialOrd> std::hash::Hash for ArchivedSortedPair<T>
+impl<T: rkyv::Archive + PartialOrd> core::hash::Hash for ArchivedSortedPair<T>
 where
-    [<T as rkyv::Archive>::Archived; 2]: std::hash::Hash,
+    [<T as rkyv::Archive>::Archived; 2]: core::hash::Hash,
 {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state)
     }
 }

--- a/src/utils/weighted_value.rs
+++ b/src/utils/weighted_value.rs
@@ -1,5 +1,5 @@
 use crate::math::Real;
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 #[derive(Copy, Clone)]
 pub struct WeightedValue<T> {

--- a/src/utils/z_order.rs
+++ b/src/utils/z_order.rs
@@ -1,5 +1,5 @@
+use core::cmp::Ordering;
 use num_traits::float::FloatCore;
-use std::cmp::Ordering;
 
 #[allow(dead_code)] // We don't use this currently, but might in the future.
 pub fn z_cmp_ints(lhs: &[usize], rhs: &[usize]) -> Ordering {


### PR DESCRIPTION
Fixes #84.
Updated alternative to #170.

Parry *technically* supports `no_std`, but it is incredibly limited. `SharedShape`, `partitioning`, `transformation`, all of the polytopes, trimeshes, heightfields, and many more features are gated behind `std`. This makes it practically unusable for physics in `no_std` environments.

Additionally, the current `no_std` setup is quite confusing. as `core` is type aliased as `std`, and `alloc` is also only available if `std` is not. It would be much clearer to use `core` and `alloc` directly, and enforce this via the official Clippy lints.

This PR aims to improve Parry's `no_std` compatibility. This allows [Avian](https://github.com/Jondolf/avian) to support `no_std`, and could be used for Rapier too. Prior to my changes here, I was getting numerous errors because `SharedShape` and `Qbvh` (among other types) required `std`.

## Changes

This PR is large, but most changes are largely mechanical and fairly trivial, changing use of `std` to `core` or `alloc`.

Some notable changes:

- `core` is no longer type aliased as `std` in `no_std` environments. `core` and `alloc` are used directly wherever possible.
- Use of `core` over `alloc` and `std`, and use of `alloc` over `std` is enforced via Clippy lints.
- Most `std` feature gates have been changed to `alloc` instead.
- More dependencies have default features disabled.
- `spade` is now optional, and must be disabled for `no_std`.
  - Despite the crate itself having an optional `std` feature, I was getting errors about `num-traits`. It seems that this is because `spade` has default features enabled for most of their dependencies ([link](https://github.com/Stoeoef/spade/blob/94269a1514cfe61309490aa91c56fde21c7cfa72/Cargo.toml#L27-L31)). `robust` has a `no_std` feature that we could manually enable, but `num-traits` just has `std` and `libm`, and `spade` unconditionally enables `std`. So this would most likely have to be fixed in `spade`.
- `hashbrown` is now used instead of `rustc-hash` for the `HashMap` and `HashSet` when `enhanced-determinism` is *not* enabled. This also changes the hashing algorithm from fxhash to foldhash. Aside from having `no_std` support, foldhash should also be faster for larger inputs, and has fewer hash collisions, see [foldhash](https://crates.io/crates/foldhash).

Things that still require `std`:

- `mesh_intersections` and `split_trimesh` (`spade`)
- Some debug things, like convex hull validation (there are some prints that we could probably replace with `log`)
- `TriMesh::compute_connected_components` (performs union-find using `ena`, which does not support `no_std`)

Usage without `alloc` is also still supported, though it is quite limited. It could be worth considering dropping `no_alloc` support, since practical uses seem very limited and having to feature gate it everywhere is annoying, but I will leave that for future consideration.