### PR TITLE
Fix deserialize_hashmap_capacity by returning the hashbrown hashmap

### DIFF
--- a/src/utils/hashmap.rs
+++ b/src/utils/hashmap.rs
@@ -4,7 +4,7 @@
 #[cfg(all(feature = "enhanced-determinism", feature = "serde-serialize"))]
 use indexmap::IndexMap as StdHashMap;
 #[cfg(all(not(feature = "enhanced-determinism"), feature = "serde-serialize"))]
-use std::collections::HashMap as StdHashMap;
+use hashbrown::hash_map::HashMap as StdHashMap;
 
 /// Serializes only the capacity of a hash-map instead of its actual content.
 #[cfg(feature = "serde-serialize")]


### PR DESCRIPTION
Fix issue introduced in #330 that broke rapier by returning the incorrect type in `deserialize_hashmap_capacity`.