### PR TITLE
feat: decouple the FIX_INTERNAL_EDGES from the ORIENTED trimesh flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@
 - Add `SharedShape::from_convex_polyline_unmodified` and `ConvexPolygon::from_convex_polyline_unmodified`
   to initialize a polyline from a set of points assumed to be convex, and without modifying this set even
   if some points are collinear.
+- Add `TriMesh::pseudo_normals_if_oriented` that returns `Some` only if the mesh has the `TriMeshFlags::ORIENTED`
+  flag enabled.
 
 ### Modified
 
+- The `TriMeshFlags::FIX_INTERNAL_EDGES` flag no longer automatically enable the `TriMeshFlags::ORIENTED`
+  flag (but the mesh pseudo-normals will still be computed).
 - Improve `no_std` compatibility.
   - Everything is now compatible, except `mesh_intersections`, `split_trimesh`,
     convex hull validation, and computation of connected components for `TriMesh`.

--- a/src/query/point/point_composite_shape.rs
+++ b/src/query/point/point_composite_shape.rs
@@ -168,7 +168,7 @@ impl PointQueryWithLocation for TriMesh {
                 .traverse_best_first_node(&mut visitor, 0, max_dist)
         {
             #[cfg(feature = "dim3")]
-            if let Some(pseudo_normals) = self.pseudo_normals() {
+            if let Some(pseudo_normals) = self.pseudo_normals_if_oriented() {
                 let pseudo_normal = match location {
                     TrianglePointLocation::OnFace(..) | TrianglePointLocation::OnSolid => {
                         Some(self.triangle(part_id).scaled_normal())

--- a/src/query/split/split_trimesh.rs
+++ b/src/query/split/split_trimesh.rs
@@ -94,7 +94,7 @@ impl TriMesh {
         bias: Real,
         epsilon: Real,
     ) -> SplitResult<Self> {
-        let mut triangulation = if self.pseudo_normals().is_some() {
+        let mut triangulation = if self.pseudo_normals_if_oriented().is_some() {
             Some(Triangulation::new(*local_axis, self.vertices()[0]))
         } else {
             None
@@ -654,7 +654,7 @@ impl TriMesh {
         flip_cuboid: bool,
         _epsilon: Real,
     ) -> Result<Option<Self>, MeshIntersectionError> {
-        if self.topology().is_some() && self.pseudo_normals().is_some() {
+        if self.topology().is_some() && self.pseudo_normals_if_oriented().is_some() {
             let (cuboid_vtx, cuboid_idx) = cuboid.to_trimesh();
             let cuboid_trimesh = TriMesh::with_flags(
                 cuboid_vtx,

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -270,7 +270,7 @@ bitflags::bitflags! {
         ///
         /// This is achieved by taking into account adjacent triangle normals when computing contact
         /// points for a given triangle.
-        const FIX_INTERNAL_EDGES = (1 << 7) | Self::ORIENTED.bits() | Self::MERGE_DUPLICATE_VERTICES.bits();
+        const FIX_INTERNAL_EDGES = (1 << 7) | Self::MERGE_DUPLICATE_VERTICES.bits();
     }
 }
 
@@ -350,7 +350,7 @@ impl TriMesh {
         }
 
         #[cfg(feature = "dim3")]
-        if !flags.contains(TriMeshFlags::ORIENTED) {
+        if !flags.intersects(TriMeshFlags::ORIENTED | TriMeshFlags::FIX_INTERNAL_EDGES) {
             self.pseudo_normals = None;
         }
 
@@ -384,7 +384,7 @@ impl TriMesh {
         }
 
         #[cfg(feature = "dim3")]
-        if difference.contains(TriMeshFlags::ORIENTED) {
+        if difference.intersects(TriMeshFlags::ORIENTED | TriMeshFlags::FIX_INTERNAL_EDGES) {
             self.compute_pseudo_normals();
         }
 
@@ -1063,6 +1063,18 @@ impl TriMesh {
     #[cfg(feature = "dim3")]
     pub fn pseudo_normals(&self) -> Option<&TriMeshPseudoNormals> {
         self.pseudo_normals.as_ref()
+    }
+
+
+    /// The pseudo-normals of this triangle mesh, if they have been computed **and** this mesh was
+    /// marked as [`TriMeshFlags::ORIENTED`].
+    #[cfg(feature = "dim3")]
+    pub fn pseudo_normals_if_oriented(&self) -> Option<&TriMeshPseudoNormals> {
+        if self.flags.intersects(TriMeshFlags::ORIENTED) {
+            self.pseudo_normals.as_ref()
+        } else {
+            None
+        }
     }
 }
 

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -1065,7 +1065,6 @@ impl TriMesh {
         self.pseudo_normals.as_ref()
     }
 
-
     /// The pseudo-normals of this triangle mesh, if they have been computed **and** this mesh was
     /// marked as [`TriMeshFlags::ORIENTED`].
     #[cfg(feature = "dim3")]

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -109,7 +109,7 @@ pub fn intersect_meshes_with_tolerances(
         return Err(MeshIntersectionError::MissingTopology);
     }
 
-    if mesh1.pseudo_normals().is_none() || mesh2.pseudo_normals().is_none() {
+    if mesh1.pseudo_normals_if_oriented().is_none() || mesh2.pseudo_normals_if_oriented().is_none() {
         return Err(MeshIntersectionError::MissingPseudoNormals);
     }
 

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -109,7 +109,8 @@ pub fn intersect_meshes_with_tolerances(
         return Err(MeshIntersectionError::MissingTopology);
     }
 
-    if mesh1.pseudo_normals_if_oriented().is_none() || mesh2.pseudo_normals_if_oriented().is_none() {
+    if mesh1.pseudo_normals_if_oriented().is_none() || mesh2.pseudo_normals_if_oriented().is_none()
+    {
         return Err(MeshIntersectionError::MissingPseudoNormals);
     }
 


### PR DESCRIPTION
Currently, enabling the `TriMeshFlags::FIX_INTERNAL_EDGES` flag on a `TriMesh` would automatically enable the `ORIENTED` flag too. This is problematic because some users (on rapier in particular) want to enable  `FIX_INTERNAL_EDGES` on open meshes. While this is technically valid, the implied `ORIENTED` flag results in some incorrect collision-detection between mesh and balls due to the malformed interior of these open meshes.

This PR decouples both flags so that `FIX_INTERNAL_EDGES` can be specified without having an impact on point projection.