### PR TITLE
Fix wrong sign in `MassProperties::construct_shifted_inertia_matrix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Fix
 
 - Fix trimesh inertia tensor computation [#331](https://github.com/dimforge/parry/pull/331).
+- Fix shifted inertia tensor computation [#334](https://github.com/dimforge/parry/pull/334).
 
 ## v0.18.0
 

--- a/src/mass_properties/mass_properties.rs
+++ b/src/mass_properties/mass_properties.rs
@@ -614,7 +614,7 @@ mod test {
         .sum::<MassProperties>();
 
         // Check that the mass properties of the compound shape match the mass properties
-        // of a single cuboid 1x3x1
+        // of a single 1x3x1 cuboid.
         #[cfg(feature = "dim2")]
         let expected = Cuboid::new(Vector::new(0.5, 1.5)).mass_properties(1.0);
         #[cfg(feature = "dim3")]

--- a/src/mass_properties/mass_properties.rs
+++ b/src/mass_properties/mass_properties.rs
@@ -598,14 +598,14 @@ mod test {
         use crate::{math::Vector, shape::Cuboid};
 
         // Compute the mass properties of a compound shape made of three 1x1x1 cuboids.
-        let m = Cuboid::new(Vector::repeat(0.5)).mass_properties(1.0);
+        let mp = Cuboid::new(Vector::repeat(0.5)).mass_properties(1.0);
         let sum = [
-            m,
-            m.transform_by(&Isometry::from_parts(
+            mp,
+            mp.transform_by(&Isometry::from_parts(
                 Vector::y().into(),
                 Default::default(),
             )),
-            m.transform_by(&Isometry::from_parts(
+            mp.transform_by(&Isometry::from_parts(
                 (-Vector::y()).into(),
                 Default::default(),
             )),

--- a/src/mass_properties/mass_properties.rs
+++ b/src/mass_properties/mass_properties.rs
@@ -202,7 +202,7 @@ impl MassProperties {
             let mass = 1.0 / self.inv_mass;
             let diag = shift.norm_squared();
             let diagm = Matrix3::from_diagonal_element(diag);
-            matrix + (diagm + shift * shift.transpose()) * mass
+            matrix + (diagm - shift * shift.transpose()) * mass
         } else {
             matrix
         }


### PR DESCRIPTION
# Objective

Parry's formula for the 3D shifted angular inertia tensor is wrong, causing compound shapes with offsets to have an incorrect angular inertia. This results in wonky behavior in physics engines such as Rapier and Avian.

An example of this: A 1x3x1 cuboid collider in bevy_rapier3d has a principal angular inertia of `[2.5, 0.5, 2.5]`. However, a compound collider of three 1x1x1 cubes stacked on top of each other has a principal angular inertia of `[2.5, 4.5, 2.5]`.

![Logs](https://github.com/user-attachments/assets/872e6243-e6f8-48e4-a007-61d527fb8051)

Spawning dynamic bodies for the two colliders with a slight rotation about the x axis and some initial angular velocity, this results in the following behavior:

https://github.com/user-attachments/assets/0bcc9cc4-10ed-467b-9907-a85b6092f5f8

The 1x3x1 cuboid spins a bit at the start, falls on its side, and goes to rest quickly, like expected. However, the compound shape has a lot more angular inertia about the y axis, causing it to spin a lot longer and even start rolling on the ground in a bizarre way.

## Solution

`MassProperties::construct_shifted_inertia_matrix` uses the [parallel axis theorem](https://en.wikipedia.org/wiki/Parallel_axis_theorem) to compute the moment of inertia at a given offset. More specifically, it uses the [generalization for tensors](https://en.wikipedia.org/wiki/Parallel_axis_theorem#Tensor_generalization).

The correct formula looks like the following:

```
I_shifted = I + m * (dot(R, R) E_3x3 - outer_product(R, R))
```

where `E_3x3` is the 3x3 identity matrix and `R` is the displacement vector (i.e. shift). However, Parry incorrectly *adds* the outer product of the displacement rather than subtracting it.

Fixing this results in the correct values and much more reasonable behavior.

![Logs](https://github.com/user-attachments/assets/0b4118c3-a959-4453-9b7b-195b17e0dbde)

https://github.com/user-attachments/assets/8b73fb08-f440-41b9-8eb3-2d2bf388524c