### PR TITLE
Release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## v0.19.0
 
 ### Added
 

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -180,8 +180,8 @@ impl Aabb {
     ///
     /// # Parameters
     /// - `scale`: the scaling factor. It can be non-uniform and/or negative. The AABB being
-    ///            symmetric wrt. its center, a negative scale value has the same effect as scaling
-    ///            by its absolute value.
+    ///   symmetric wrt. its center, a negative scale value has the same effect as scaling
+    ///   by its absolute value.
     #[inline]
     #[must_use]
     pub fn scaled_wrt_center(self, scale: &Vector<Real>) -> Self {

--- a/src/query/gjk/gjk.rs
+++ b/src/query/gjk/gjk.rs
@@ -73,9 +73,9 @@ pub fn project_origin<G: ?Sized + SupportMap>(
 /// from the origin.
 ///
 /// # Arguments:
-/// * simplex - the simplex to be used by the GJK algorithm. It must be already initialized
-///             with at least one point on the shape boundary.
-/// * exact_dist - if `false`, the gjk will stop as soon as it can prove that the origin is at
+/// * `simplex` - the simplex to be used by the GJK algorithm. It must be already initialized
+///   with at least one point on the shape boundary.
+/// * `exact_dist` - if `false`, the gjk will stop as soon as it can prove that the origin is at
 ///   a distance smaller than `max_dist` but not inside of `shape`. In that case, it returns a
 ///   `GJKResult::Proximity(sep_axis)` where `sep_axis` is a separating axis. If `false` the gjk will
 ///   compute the exact distance and return `GJKResult::Projection(point)` if the origin is closer

--- a/src/query/query_dispatcher.rs
+++ b/src/query/query_dispatcher.rs
@@ -99,12 +99,12 @@ pub trait QueryDispatcher: Send + Sync {
     /// # Parameters
     /// - `pos12`: the position of the second shape relative to the first shape.
     /// - `local_vel12`: the relative velocity between the two shapes, expressed in the local-space
-    ///                  of the first shape. In other world: `pos1.inverse() * (vel2 - vel1)`.
+    ///   of the first shape. In other world: `pos1.inverse() * (vel2 - vel1)`.
     /// - `g1`: the first shape involved in the shape-cast.
     /// - `g2`: the second shape involved in the shape-cast.
     /// - `target_dist`: a hit will be returned as soon as the two shapes get closer than `target_dist`.
     /// - `max_time_of_impact`: the maximum allowed travel time. This method returns `None` if the time-of-impact
-    ///              detected is theater than this value.
+    ///   detected is theater than this value.
     fn cast_shapes(
         &self,
         pos12: &Isometry<Real>,


### PR DESCRIPTION
## v0.19.0

### Added

- Derive `Copy` for `VHACDParameters`.
- Add `spade` default feature for algorithms using Delaunay triangulation from `spade`.
- Add `SharedShape::from_convex_polyline_unmodified` and `ConvexPolygon::from_convex_polyline_unmodified`
  to initialize a polyline from a set of points assumed to be convex, and without modifying this set even
  if some points are collinear.
- Add `TriMesh::pseudo_normals_if_oriented` that returns `Some` only if the mesh has the `TriMeshFlags::ORIENTED`
  flag enabled.

### Modified

- The `TriMeshFlags::FIX_INTERNAL_EDGES` flag no longer automatically enable the `TriMeshFlags::ORIENTED`
  flag (but the mesh pseudo-normals will still be computed).
- Improve `no_std` compatibility.
  - Everything is now compatible, except `mesh_intersections`, `split_trimesh`,
    convex hull validation, and computation of connected components for `TriMesh`.
  - Add the `alloc_instead_of_core`, `std_instead_of_alloc`, and `std_instead_of_core` Clippy lints to the workspace.
  - Use `core` and `alloc` directly rather than using an `std` alias.
  - Use `hashbrown` instead of `rustc-hash` when `enhanced-determinism` is not enabled.
  - Make `spade` optional.

### Fix

- Fix trimesh inertia tensor computation [#331](https://github.com/dimforge/parry/pull/331).
- Fix shifted inertia tensor computation [#334](https://github.com/dimforge/parry/pull/334).