### PR TITLE
feat: add experimental support for a shape type dedicated to voxels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+- Added the `Voxels` type: a dedicated shape for voxel models. This is currently experimental because some features are
+  still missing (in particular: shape-casting, mass properties, and collision-detection against non-convex shapes).
+- Added `SharedShape::voxels` and `::voxelized_mesh` for creating a voxels shape from centroids or automatic
+  voxelization of a triangle mesh.
+
 ## v0.19.0
 
 ### Added

--- a/src/bounding_volume/aabb_voxels.rs
+++ b/src/bounding_volume/aabb_voxels.rs
@@ -1,0 +1,20 @@
+use crate::bounding_volume::Aabb;
+use crate::math::{Isometry, Real, Translation};
+use crate::shape::{Cuboid, Voxels};
+
+impl Voxels {
+    /// Computes the world-space Aabb of this set of voxels, transformed by `pos`.
+    #[inline]
+    pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
+        let shift = Translation::from(self.origin + self.extents() / 2.0);
+        Cuboid::new(self.extents() / 2.0).aabb(&(pos * shift))
+    }
+
+    /// Computes the local-space Aabb of this set of voxels.
+    #[inline]
+    pub fn local_aabb(&self) -> Aabb {
+        Cuboid::new(self.extents() / 2.0)
+            .local_aabb()
+            .translated(&(self.origin.coords + self.extents() / 2.0))
+    }
+}

--- a/src/bounding_volume/aabb_voxels.rs
+++ b/src/bounding_volume/aabb_voxels.rs
@@ -6,7 +6,7 @@ impl Voxels {
     /// Computes the world-space Aabb of this set of voxels, transformed by `pos`.
     #[inline]
     pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
-        let shift = Translation::from(self.origin + self.extents() / 2.0);
+        let shift = Translation::from(self.center());
         Cuboid::new(self.extents() / 2.0).aabb(&(pos * shift))
     }
 
@@ -15,6 +15,6 @@ impl Voxels {
     pub fn local_aabb(&self) -> Aabb {
         Cuboid::new(self.extents() / 2.0)
             .local_aabb()
-            .translated(&(self.origin.coords + self.extents() / 2.0))
+            .translated(&self.center().coords)
     }
 }

--- a/src/bounding_volume/bounding_sphere.rs
+++ b/src/bounding_volume/bounding_sphere.rs
@@ -1,7 +1,7 @@
 //! Bounding sphere.
 
 use crate::bounding_volume::BoundingVolume;
-use crate::math::{Isometry, Point, Real};
+use crate::math::{Isometry, Point, Real, Vector};
 use na;
 use num::Zero;
 
@@ -45,6 +45,12 @@ impl BoundingSphere {
     #[inline]
     pub fn transform_by(&self, m: &Isometry<Real>) -> BoundingSphere {
         BoundingSphere::new(m * self.center, self.radius)
+    }
+
+    /// Translates this bounding sphere by the given translation.
+    #[inline]
+    pub fn translated(&self, translation: &Vector<Real>) -> BoundingSphere {
+        BoundingSphere::new(self.center + translation, self.radius)
     }
 }
 

--- a/src/bounding_volume/bounding_sphere_voxels.rs
+++ b/src/bounding_volume/bounding_sphere_voxels.rs
@@ -1,0 +1,20 @@
+use crate::bounding_volume::BoundingSphere;
+use crate::math::{Isometry, Real, Translation};
+use crate::shape::{Cuboid, Voxels};
+
+impl Voxels {
+    /// Computes the world-space bounding sphere of this set of voxels, transformed by `pos`.
+    #[inline]
+    pub fn bounding_sphere(&self, pos: &Isometry<Real>) -> BoundingSphere {
+        let shift = Translation::from(self.origin + self.extents() / 2.0);
+        Cuboid::new(self.extents() / 2.0).bounding_sphere(&(pos * shift))
+    }
+
+    /// Computes the local-space bounding sphere of this set of voxels.
+    #[inline]
+    pub fn local_bounding_sphere(&self) -> BoundingSphere {
+        Cuboid::new(self.extents() / 2.0)
+            .local_bounding_sphere()
+            .translated(&(self.origin.coords + self.extents() / 2.0))
+    }
+}

--- a/src/bounding_volume/bounding_sphere_voxels.rs
+++ b/src/bounding_volume/bounding_sphere_voxels.rs
@@ -6,7 +6,7 @@ impl Voxels {
     /// Computes the world-space bounding sphere of this set of voxels, transformed by `pos`.
     #[inline]
     pub fn bounding_sphere(&self, pos: &Isometry<Real>) -> BoundingSphere {
-        let shift = Translation::from(self.origin + self.extents() / 2.0);
+        let shift = Translation::from(self.center().coords);
         Cuboid::new(self.extents() / 2.0).bounding_sphere(&(pos * shift))
     }
 
@@ -15,6 +15,6 @@ impl Voxels {
     pub fn local_bounding_sphere(&self) -> BoundingSphere {
         Cuboid::new(self.extents() / 2.0)
             .local_bounding_sphere()
-            .translated(&(self.origin.coords + self.extents() / 2.0))
+            .translated(&(self.center().coords))
     }
 }

--- a/src/bounding_volume/mod.rs
+++ b/src/bounding_volume/mod.rs
@@ -30,6 +30,7 @@ mod aabb_triangle;
 mod aabb_utils;
 
 mod aabb_capsule;
+#[cfg(feature = "alloc")]
 mod aabb_voxels;
 #[doc(hidden)]
 pub mod bounding_sphere;
@@ -56,6 +57,7 @@ mod bounding_sphere_triangle;
 #[cfg(feature = "alloc")]
 mod bounding_sphere_trimesh;
 mod bounding_sphere_utils;
+#[cfg(feature = "alloc")]
 mod bounding_sphere_voxels;
 mod simd_aabb;
 

--- a/src/bounding_volume/mod.rs
+++ b/src/bounding_volume/mod.rs
@@ -30,6 +30,7 @@ mod aabb_triangle;
 mod aabb_utils;
 
 mod aabb_capsule;
+mod aabb_voxels;
 #[doc(hidden)]
 pub mod bounding_sphere;
 mod bounding_sphere_ball;
@@ -55,6 +56,7 @@ mod bounding_sphere_triangle;
 #[cfg(feature = "alloc")]
 mod bounding_sphere_trimesh;
 mod bounding_sphere_utils;
+mod bounding_sphere_voxels;
 mod simd_aabb;
 
 /// Free functions for some special cases of bounding-volume computation.

--- a/src/partitioning/qbvh/qbvh.rs
+++ b/src/partitioning/qbvh/qbvh.rs
@@ -131,25 +131,25 @@ impl QbvhNode {
     }
 
     #[inline]
-    /// Does the AABB of this node needs to be updated?
+    /// Does the Aabb of this node needs to be updated?
     pub fn is_dirty(&self) -> bool {
         self.flags.contains(QbvhNodeFlags::DIRTY)
     }
 
     #[inline]
-    /// Sets if the AABB of this node needs to be updated.
+    /// Sets if the Aabb of this node needs to be updated.
     pub fn set_dirty(&mut self, dirty: bool) {
         self.flags.set(QbvhNodeFlags::DIRTY, dirty);
     }
 
     #[inline]
-    /// Was the AABB of this node changed since the last rebalancing?
+    /// Was the Aabb of this node changed since the last rebalancing?
     pub fn is_changed(&self) -> bool {
         self.flags.contains(QbvhNodeFlags::CHANGED)
     }
 
     #[inline]
-    /// Sets if the AABB of this node changed since the last rebalancing.
+    /// Sets if the Aabb of this node changed since the last rebalancing.
     pub fn set_changed(&mut self, changed: bool) {
         self.flags.set(QbvhNodeFlags::CHANGED, changed);
     }
@@ -250,6 +250,31 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
             free_list: Vec::new(),
             proxies: Vec::new(),
         }
+    }
+
+    // TODO: support a crate like get_size2 (will require support on nalgebra too)?
+    /// An approximation of the memory usage (in bytes) for this struct plus
+    /// the memory it allocates dynamically.
+    pub fn get_size(&self) -> usize {
+        size_of::<Self>() + self.get_heap_size()
+    }
+
+    /// An approximation of the memory dynamically-allocated by this struct.
+    pub fn get_heap_size(&self) -> usize {
+        let Self {
+            root_aabb: _,
+            nodes,
+            dirty_nodes,
+            free_list,
+            proxies,
+        } = self;
+        let sz_root_aabb = 0;
+        let sz_nodes = nodes.capacity() * size_of::<u32>();
+        let sz_dirty_nodes = dirty_nodes.capacity() * size_of::<u32>();
+        let sz_free_list = free_list.capacity() * size_of::<u32>();
+        let sz_proxies = proxies.capacity() * size_of::<u32>();
+
+        sz_root_aabb + sz_nodes + sz_dirty_nodes + sz_free_list + sz_proxies
     }
 
     /// Iterates mutably through all the leaf data in this Qbvh.

--- a/src/partitioning/qbvh/update.rs
+++ b/src/partitioning/qbvh/update.rs
@@ -204,7 +204,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
                 assert_eq!(parent.children[node.parent.lane as usize], id);
 
                 if check_aabbs {
-                    // Make sure the parent AABB contains its child AABB.
+                    // Make sure the parent Aabb contains its child Aabb.
                     assert!(
                         parent
                             .simd_aabb
@@ -229,7 +229,7 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
                         proxy_id_found[proxy_id as usize] = true;
 
                         if check_aabbs {
-                            // Proxy AABB is correct.
+                            // Proxy Aabb is correct.
                             let aabb = node.simd_aabb.extract(ii);
                             assert!(
                                 aabb.contains(&aabb_builder(&self.proxies[proxy_id as usize].data))

--- a/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
@@ -125,7 +125,7 @@ pub fn contact_manifolds_trimesh_shape<ManifoldData, ContactData>(
 
         core::mem::swap(manifolds, &mut old_manifolds);
 
-        // This assertion may fire due to the invalid triangle_ids that the
+        // NOTE: This assertion may fire due to the invalid triangle_ids that the
         // near-phase may return (due to SIMD sentinels).
         //
         // assert_eq!(

--- a/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
@@ -55,7 +55,7 @@ pub fn contact_manifolds_voxels_ball<'a, ManifoldData, ContactData>(
     let aabb2 = ball2.aabb(pos12).loosened(prediction / 2.0);
     let geometry1 = voxels1.primitive_geometry();
     if let Some(aabb_intersection) = aabb1.intersection(&aabb2) {
-        for (center1, data1) in voxels1.voxels_intersecting_local_aabb(&aabb_intersection) {
+        for (_, center1, data1) in voxels1.voxels_intersecting_local_aabb(&aabb_intersection) {
             let voxel1 = data1.voxel_type();
             match voxel1 {
                 #[cfg(feature = "dim2")]

--- a/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
@@ -2,7 +2,7 @@ use crate::bounding_volume::BoundingVolume;
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::query::{ContactManifold, PointQuery, TrackedContact};
 use crate::shape::{
-    Ball, Cuboid, OctantPattern, PackedFeatureId, Shape, VoxelData, VoxelPrimitiveGeometry,
+    Ball, Cuboid, OctantPattern, PackedFeatureId, Shape, VoxelPrimitiveGeometry, VoxelState,
     VoxelType, Voxels,
 };
 
@@ -77,7 +77,7 @@ pub(crate) fn detect_hit_voxel_ball<ManifoldData, ContactData>(
     pos12: Isometry<Real>,
     center1: Point<Real>,
     radius1: Real,
-    data1: VoxelData,
+    data1: VoxelState,
     geometry1: VoxelPrimitiveGeometry,
     center2: Point<Real>,
     radius2: Real,
@@ -147,9 +147,9 @@ pub fn project_point_on_pseudo_ball(
     // NOTE: in 2D the array is [0, 1, 3, 2] which matches the one in 3D.
     const AABB_OCTANT_KEYS: [u32; 8] = [0, 1, 3, 2, 4, 5, 7, 6];
     #[cfg(feature = "dim2")]
-    let octant_key = (((dpos.x >= 0.0) as usize) << 0) | (((dpos.y >= 0.0) as usize) << 1);
+    let octant_key = (dpos.x >= 0.0) as usize | (((dpos.y >= 0.0) as usize) << 1);
     #[cfg(feature = "dim3")]
-    let octant_key = (((dpos.x >= 0.0) as usize) << 0)
+    let octant_key = (dpos.x >= 0.0) as usize
         | (((dpos.y >= 0.0) as usize) << 1)
         | (((dpos.z >= 0.0) as usize) << 2);
     let aabb_octant_key = AABB_OCTANT_KEYS[octant_key];
@@ -231,9 +231,9 @@ pub fn project_point_on_pseudo_cube(
     // NOTE: in 2D the array is [0, 1, 3, 2] which matches the one in 3D.
     const AABB_OCTANT_KEYS: [u32; 8] = [0, 1, 3, 2, 4, 5, 7, 6];
     #[cfg(feature = "dim2")]
-    let octant_key = (((dpos.x >= 0.0) as usize) << 0) | (((dpos.y >= 0.0) as usize) << 1);
+    let octant_key = ((dpos.x >= 0.0) as usize) | (((dpos.y >= 0.0) as usize) << 1);
     #[cfg(feature = "dim3")]
-    let octant_key = (((dpos.x >= 0.0) as usize) << 0)
+    let octant_key = ((dpos.x >= 0.0) as usize)
         | (((dpos.y >= 0.0) as usize) << 1)
         | (((dpos.z >= 0.0) as usize) << 2);
     let aabb_octant_key = AABB_OCTANT_KEYS[octant_key];

--- a/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
@@ -1,0 +1,300 @@
+use crate::bounding_volume::BoundingVolume;
+use crate::math::{Isometry, Point, Real, Vector};
+use crate::query::{ContactManifold, PointQuery, TrackedContact};
+use crate::shape::{
+    Ball, Cuboid, OctantPattern, PackedFeatureId, Shape, VoxelData, VoxelPrimitiveGeometry,
+    VoxelType, Voxels,
+};
+
+/// Computes the contact manifold between a convex shape and a ball, both represented as a `Shape` trait-object.
+pub fn contact_manifolds_voxels_ball_shapes<ManifoldData, ContactData>(
+    pos12: &Isometry<Real>,
+    shape1: &dyn Shape,
+    shape2: &dyn Shape,
+    prediction: Real,
+    manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+) where
+    ManifoldData: Default,
+    ContactData: Default + Copy,
+{
+    if let (Some(voxels1), Some(ball2)) = (shape1.as_voxels(), shape2.as_ball()) {
+        contact_manifolds_voxels_ball(pos12, voxels1, ball2, prediction, manifolds, false);
+    } else if let (Some(ball1), Some(voxels2)) = (shape1.as_ball(), shape2.as_voxels()) {
+        contact_manifolds_voxels_ball(
+            &pos12.inverse(),
+            voxels2,
+            ball1,
+            prediction,
+            manifolds,
+            true,
+        );
+    }
+}
+
+/// Computes the contact manifold between a convex shape and a ball.
+pub fn contact_manifolds_voxels_ball<'a, ManifoldData, ContactData>(
+    pos12: &Isometry<Real>,
+    voxels1: &'a Voxels,
+    ball2: &'a Ball,
+    prediction: Real,
+    manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+    flipped: bool,
+) where
+    ManifoldData: Default,
+    ContactData: Default + Copy,
+{
+    // TODO: don’t generate one manifold per voxel.
+    manifolds.clear();
+
+    let radius1 = voxels1.scale / 2.0;
+    let radius2 = ball2.radius;
+    let center2 = Point::origin(); // The ball’s center.
+
+    // FIXME: optimize this.
+    let aabb1 = voxels1.local_aabb().loosened(prediction / 2.0);
+    let aabb2 = ball2.aabb(pos12).loosened(prediction / 2.0);
+    let geometry1 = voxels1.primitive_geometry();
+    if let Some(aabb_intersection) = aabb1.intersection(&aabb2) {
+        for (center1, data1) in voxels1.voxels_intersecting_local_aabb(&aabb_intersection) {
+            let voxel1 = data1.voxel_type();
+            match voxel1 {
+                #[cfg(feature = "dim2")]
+                VoxelType::Vertex | VoxelType::Face => { /* Ok */ }
+                #[cfg(feature = "dim3")]
+                VoxelType::Vertex | VoxelType::Edge | VoxelType::Face => { /* Ok */ }
+                _ => continue,
+            }
+
+            detect_hit_voxel_ball(
+                *pos12, center1, radius1, data1, geometry1, center2, radius2, prediction, flipped,
+                manifolds,
+            );
+        }
+    }
+}
+
+pub(crate) fn detect_hit_voxel_ball<ManifoldData, ContactData>(
+    pos12: Isometry<Real>,
+    center1: Point<Real>,
+    radius1: Real,
+    data1: VoxelData,
+    geometry1: VoxelPrimitiveGeometry,
+    center2: Point<Real>,
+    radius2: Real,
+    prediction: Real,
+    flipped: bool,
+    manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+) where
+    ManifoldData: Default,
+    ContactData: Default + Copy,
+{
+    let center2_1 = pos12 * center2;
+
+    let projection = match geometry1 {
+        VoxelPrimitiveGeometry::PseudoBall => {
+            project_point_on_pseudo_ball(center1, radius1, data1.octant_mask(), center2_1)
+        }
+        VoxelPrimitiveGeometry::PseudoCube => {
+            project_point_on_pseudo_cube(center1, radius1, data1.octant_mask(), center2_1)
+        }
+    };
+
+    if let Some((local_n1, dist_to_voxel)) = projection {
+        let dist = dist_to_voxel - radius2;
+
+        if dist <= prediction {
+            let local_n2 = pos12.inverse_transform_vector(&-local_n1);
+            let local_p1 = center2_1 - local_n1 * dist_to_voxel;
+            let local_p2 = center2 + local_n2 * radius2;
+            let contact_point = TrackedContact::<ContactData>::flipped(
+                local_p1,
+                local_p2,
+                PackedFeatureId::UNKNOWN,
+                PackedFeatureId::UNKNOWN,
+                dist,
+                flipped,
+            );
+
+            let mut manifold = ContactManifold::<ManifoldData, ContactData>::new();
+            manifold.points.push(contact_point);
+
+            if flipped {
+                manifold.local_n1 = local_n2;
+                manifold.local_n2 = local_n1;
+            } else {
+                manifold.local_n1 = local_n1;
+                manifold.local_n2 = local_n2;
+            }
+
+            manifolds.push(manifold);
+        }
+    }
+}
+
+pub fn project_point_on_pseudo_ball(
+    voxel_center: Point<Real>,
+    voxel_radius: Real,
+    voxel_mask: u32,
+    point: Point<Real>,
+) -> Option<(Vector<Real>, Real)> {
+    let dpos = point - voxel_center;
+
+    // This maps our easy-to map octant_key, to the vertex key as
+    // used by the Aabb::FACES_VERTEX_IDS and Aabb::EDGES_VERTEX_IDS
+    // arrays. Could we find a way to avoid this map by computing the
+    // correct key right away?
+    //
+    // NOTE: in 2D the array is [0, 1, 3, 2] which matches the one in 3D.
+    const AABB_OCTANT_KEYS: [u32; 8] = [0, 1, 3, 2, 4, 5, 7, 6];
+    #[cfg(feature = "dim2")]
+    let octant_key = (((dpos.x >= 0.0) as usize) << 0) | (((dpos.y >= 0.0) as usize) << 1);
+    #[cfg(feature = "dim3")]
+    let octant_key = (((dpos.x >= 0.0) as usize) << 0)
+        | (((dpos.y >= 0.0) as usize) << 1)
+        | (((dpos.z >= 0.0) as usize) << 2);
+    let aabb_octant_key = AABB_OCTANT_KEYS[octant_key];
+    let dpos_signs = dpos.map(|x| x.signum());
+    let unit_dpos = dpos.abs() / voxel_radius; // Project the point in "local unit octant space".
+                                               // Extract the feature pattern specific to the selected octant.
+    let pattern = (voxel_mask >> (aabb_octant_key * 3)) & 0b0111;
+
+    let unit_result = match pattern {
+        OctantPattern::INTERIOR => None,
+        OctantPattern::VERTEX => {
+            let mut normal = unit_dpos;
+            let dist = normal.try_normalize_mut(1.0e-8)?;
+            Some((normal, dist))
+        }
+        #[cfg(feature = "dim3")]
+        OctantPattern::EDGE_X | OctantPattern::EDGE_Y | OctantPattern::EDGE_Z => {
+            let i = pattern as usize - OctantPattern::EDGE_X as usize;
+
+            if unit_dpos[i] > 1.0 || unit_dpos[i] < 0.0 {
+                None
+            } else {
+                let mut normal = unit_dpos;
+                normal[i] = 0.0;
+                let dist = normal.try_normalize_mut(1.0e-8)?;
+                Some((normal, dist))
+            }
+        }
+        #[cfg(feature = "dim2")]
+        OctantPattern::FACE_X | OctantPattern::FACE_Y => {
+            let i1 = pattern as usize - OctantPattern::FACE_X as usize;
+            let i2 = (i1 + 1) % 2;
+
+            if unit_dpos[i2] > 1.0 || unit_dpos[i2] < 0.0 {
+                None
+            } else {
+                let dist = unit_dpos[i1];
+                Some((Vector::ith(i1, 1.0), dist))
+            }
+        }
+        #[cfg(feature = "dim3")]
+        OctantPattern::FACE_X | OctantPattern::FACE_Y | OctantPattern::FACE_Z => {
+            let i1 = pattern as usize - OctantPattern::FACE_X as usize;
+            let i2 = (i1 + 1) % 3;
+            let i3 = (i1 + 2) % 3;
+
+            if unit_dpos[i2] > 1.0
+                || unit_dpos[i2] < 0.0
+                || unit_dpos[i3] > 1.0
+                || unit_dpos[i3] < 0.0
+            {
+                None
+            } else {
+                let dist = unit_dpos[i1];
+                Some((Vector::ith(i1, 1.0), dist))
+            }
+        }
+        _ => unreachable!(),
+    };
+
+    // NOTE: the subtraction by 1 in `(d - 1.0)` is so that the distance is expressed relative
+    //       to the voxel boundary instead of its center.
+    unit_result.map(|(n, d)| (n.component_mul(&dpos_signs), (d - 1.0) * voxel_radius))
+}
+
+pub fn project_point_on_pseudo_cube(
+    voxel_center: Point<Real>,
+    voxel_radius: Real,
+    voxel_mask: u32,
+    point: Point<Real>,
+) -> Option<(Vector<Real>, Real)> {
+    let dpos = point - voxel_center;
+
+    // This maps our easy-to map octant_key, to the vertex key as
+    // used by the Aabb::FACES_VERTEX_IDS and Aabb::EDGES_VERTEX_IDS
+    // arrays. Could we find a way to avoid this map by computing the
+    // correct key right away?
+    //
+    // NOTE: in 2D the array is [0, 1, 3, 2] which matches the one in 3D.
+    const AABB_OCTANT_KEYS: [u32; 8] = [0, 1, 3, 2, 4, 5, 7, 6];
+    #[cfg(feature = "dim2")]
+    let octant_key = (((dpos.x >= 0.0) as usize) << 0) | (((dpos.y >= 0.0) as usize) << 1);
+    #[cfg(feature = "dim3")]
+    let octant_key = (((dpos.x >= 0.0) as usize) << 0)
+        | (((dpos.y >= 0.0) as usize) << 1)
+        | (((dpos.z >= 0.0) as usize) << 2);
+    let aabb_octant_key = AABB_OCTANT_KEYS[octant_key];
+    let dpos_signs = dpos.map(|x| x.signum());
+    let unit_dpos = dpos.abs() / voxel_radius; // Project the point in "local unit octant space".
+                                               // Extract the feature pattern specific to the selected octant.
+    let pattern = (voxel_mask >> (aabb_octant_key * 3)) & 0b0111;
+
+    let unit_result = match pattern {
+        OctantPattern::INTERIOR => None,
+        OctantPattern::VERTEX => {
+            // PERF: inline the projection on cuboid to improve performances further.
+            //       In particular we already know on what octant we are to compute the
+            //       collision.
+            let cuboid = Cuboid::new(Vector::repeat(1.0));
+            let unit_dpos_pt = Point::from(unit_dpos);
+            let proj = cuboid.project_local_point(&unit_dpos_pt, false);
+            let mut normal = unit_dpos_pt - proj.point;
+            let dist = normal.try_normalize_mut(1.0e-8)?;
+            Some((normal, dist))
+        }
+        #[cfg(feature = "dim3")]
+        OctantPattern::EDGE_X | OctantPattern::EDGE_Y | OctantPattern::EDGE_Z => {
+            let cuboid = Cuboid::new(Vector::repeat(1.0));
+            let unit_dpos_pt = Point::from(unit_dpos);
+            let proj = cuboid.project_local_point(&unit_dpos_pt, false);
+            let mut normal = unit_dpos_pt - proj.point;
+            let dist = normal.try_normalize_mut(1.0e-8)?;
+            Some((normal, dist))
+        }
+        #[cfg(feature = "dim2")]
+        OctantPattern::FACE_X | OctantPattern::FACE_Y => {
+            let i1 = pattern as usize - OctantPattern::FACE_X as usize;
+            let i2 = (i1 + 1) % 2;
+
+            if unit_dpos[i2] > 1.0 || unit_dpos[i2] < 0.0 {
+                None
+            } else {
+                let dist = unit_dpos[i1] - 1.0; // Subtract 1 to get the distance wrt. the boundary of the unit voxel.
+                Some((Vector::ith(i1, 1.0), dist))
+            }
+        }
+        #[cfg(feature = "dim3")]
+        OctantPattern::FACE_X | OctantPattern::FACE_Y | OctantPattern::FACE_Z => {
+            let i1 = pattern as usize - OctantPattern::FACE_X as usize;
+            let i2 = (i1 + 1) % 3;
+            let i3 = (i1 + 2) % 3;
+
+            if unit_dpos[i2] > 1.0
+                || unit_dpos[i2] < 0.0
+                || unit_dpos[i3] > 1.0
+                || unit_dpos[i3] < 0.0
+            {
+                None
+            } else {
+                let dist = unit_dpos[i1] - 1.0; // Subtract 1 to get the distance wrt. the boundary of the unit voxel.
+                Some((Vector::ith(i1, 1.0), dist))
+            }
+        }
+        _ => unreachable!(),
+    };
+
+    unit_result.map(|(n, d)| (n.component_mul(&dpos_signs), d * voxel_radius))
+}

--- a/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
@@ -5,6 +5,7 @@ use crate::shape::{
     Ball, Cuboid, OctantPattern, PackedFeatureId, Shape, VoxelPrimitiveGeometry, VoxelState,
     VoxelType, Voxels,
 };
+use alloc::vec::Vec;
 
 /// Computes the contact manifold between a convex shape and a ball, both represented as a `Shape` trait-object.
 pub fn contact_manifolds_voxels_ball_shapes<ManifoldData, ContactData>(

--- a/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
@@ -235,12 +235,8 @@ pub fn contact_manifolds_voxels_shape<ManifoldData, ContactData>(
                 };
 
                 let canonical_shape1 = match voxels1.primitive_geometry() {
-                    VoxelPrimitiveGeometry::PseudoBall { .. } => {
-                        &canonical_pseudo_ball1 as &dyn Shape
-                    }
-                    VoxelPrimitiveGeometry::PseudoCube { .. } => {
-                        &canonical_pseudo_cube1 as &dyn Shape
-                    }
+                    VoxelPrimitiveGeometry::PseudoBall => &canonical_pseudo_ball1 as &dyn Shape,
+                    VoxelPrimitiveGeometry::PseudoCube => &canonical_pseudo_cube1 as &dyn Shape,
                 };
 
                 let canonical_pos12 = Translation::from(-canonical_center1) * pos12;

--- a/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
@@ -1,0 +1,344 @@
+use crate::bounding_volume::BoundingVolume;
+use crate::math::{Isometry, Real, Translation, Vector, DIM};
+use crate::query::{
+    ContactManifold, ContactManifoldsWorkspace, PersistentQueryDispatcher, PointQuery,
+    TypedWorkspaceData, WorkspaceData,
+};
+use crate::shape::{AxisMask, Cuboid, Shape, SupportMap, VoxelType, Voxels};
+use crate::utils::hashmap::{Entry, HashMap};
+use crate::utils::IsometryOpt;
+
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(check_bytes)
+)]
+#[derive(Clone)]
+struct SubDetector {
+    manifold_id: usize,
+    selected_contacts: u32,
+    timestamp: bool,
+}
+
+// NOTE: this is using a similar kind of cache as compound shape and height-field.
+//       It is different from the trimesh cash though. Which one is better?
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Default)]
+pub struct VoxelsShapeContactManifoldsWorkspace {
+    timestamp: bool,
+    sub_detectors: HashMap<[u32; 2], SubDetector>,
+}
+
+impl VoxelsShapeContactManifoldsWorkspace {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl WorkspaceData for VoxelsShapeContactManifoldsWorkspace {
+    fn as_typed_workspace_data(&self) -> TypedWorkspaceData {
+        TypedWorkspaceData::VoxelsShapeContactManifoldsWorkspace(self)
+    }
+
+    fn clone_dyn(&self) -> Box<dyn WorkspaceData> {
+        Box::new(self.clone())
+    }
+}
+
+fn ensure_workspace_exists(workspace: &mut Option<ContactManifoldsWorkspace>) {
+    if workspace
+        .as_ref()
+        .and_then(|w| w.0.downcast_ref::<VoxelsShapeContactManifoldsWorkspace>())
+        .is_some()
+    {
+        return;
+    }
+
+    *workspace = Some(ContactManifoldsWorkspace(Box::new(
+        VoxelsShapeContactManifoldsWorkspace::new(),
+    )));
+}
+
+/// Computes the contact manifold between a convex shape and a ball, both represented as a `Shape` trait-object.
+pub fn contact_manifolds_voxels_shape_shapes<ManifoldData, ContactData>(
+    dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
+    pos12: &Isometry<Real>,
+    shape1: &dyn Shape,
+    shape2: &dyn Shape,
+    prediction: Real,
+    manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+    workspace: &mut Option<ContactManifoldsWorkspace>,
+) where
+    ManifoldData: Default + Clone,
+    ContactData: Default + Copy,
+{
+    if let Some(voxels1) = shape1.as_voxels() {
+        contact_manifolds_voxels_shape(
+            dispatcher, &pos12, voxels1, shape2, prediction, manifolds, workspace, false,
+        );
+    } else if let Some(voxels2) = shape2.as_voxels() {
+        contact_manifolds_voxels_shape(
+            dispatcher,
+            &pos12.inverse(),
+            voxels2,
+            shape1,
+            prediction,
+            manifolds,
+            workspace,
+            true,
+        );
+    }
+}
+
+/// Computes the contact manifold between a convex shape and a ball.
+pub fn contact_manifolds_voxels_shape<'a, ManifoldData, ContactData>(
+    dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
+    pos12: &Isometry<Real>,
+    voxels1: &'a Voxels,
+    shape2: &dyn Shape,
+    prediction: Real,
+    manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+    workspace: &mut Option<ContactManifoldsWorkspace>,
+    flipped: bool,
+) where
+    ManifoldData: Default + Clone,
+    ContactData: Default + Copy,
+{
+    ensure_workspace_exists(workspace);
+    let workspace: &mut VoxelsShapeContactManifoldsWorkspace =
+        workspace.as_mut().unwrap().0.downcast_mut().unwrap();
+    let new_timestamp = !workspace.timestamp;
+
+    // TODO: avoid reallocating the new `manifolds` vec at each step.
+    let mut old_manifolds = std::mem::take(manifolds);
+
+    workspace.timestamp = new_timestamp;
+
+    let radius1 = voxels1.scale / 2.0;
+
+    let aabb2 = shape2.compute_local_aabb().loosened(prediction);
+    let aabb1 = voxels1.local_aabb();
+
+    let aabb2_1 = shape2.compute_aabb(&pos12);
+    let domain2_1 = aabb2_1.loosened(10.0 * radius1);
+
+    if let Some(intersection_aabb1) = aabb1.intersection(&aabb2_1) {
+        for (vid, center1, data1) in voxels1.voxels_intersecting_local_aabb(&intersection_aabb1) {
+            let voxel1 = data1.voxel_type();
+
+            // TODO: would be nice to have a strategy to handle interior voxels for depenetration.
+            if voxel1 == VoxelType::Empty || voxel1 == VoxelType::Interior {
+                continue;
+            }
+
+            let key_voxel = voxels1.to_key(vid);
+            let mut key_low = Vector::from(key_voxel);
+            let mut key_high = Vector::from(key_low);
+            let maxes = voxels1.dimensions().map(|e| e - 1);
+            let mask1 = data1.free_faces();
+
+            let mut adjust_canon = |axis: AxisMask, i: usize, key: &mut Vector<u32>, val: u32| {
+                if !mask1.contains(axis) {
+                    key[i] = val;
+                }
+            };
+
+            adjust_canon(AxisMask::X_POS, 0, &mut key_high, maxes[0]);
+            adjust_canon(AxisMask::X_NEG, 0, &mut key_low, 0);
+            adjust_canon(AxisMask::Y_POS, 1, &mut key_high, maxes[1]);
+            adjust_canon(AxisMask::Y_NEG, 1, &mut key_low, 0);
+
+            #[cfg(feature = "dim3")]
+            {
+                adjust_canon(AxisMask::Z_POS, 2, &mut key_high, maxes[2]);
+                adjust_canon(AxisMask::Z_NEG, 2, &mut key_low, 0);
+            }
+
+            let workspace_key = [
+                voxels1.linear_index(key_low.into()),
+                voxels1.linear_index(key_high.into()),
+            ];
+
+            // TODO: could we refactor the workspace system between Voxels, HeightField, and CompoundShape?
+            //       (and maybe TriMesh too but it’s using a different approach).
+            let (sub_detector, manifold_updated) =
+                match workspace.sub_detectors.entry(workspace_key) {
+                    Entry::Occupied(entry) => {
+                        let sub_detector = entry.into_mut();
+
+                        if sub_detector.timestamp != new_timestamp {
+                            let manifold = old_manifolds[sub_detector.manifold_id].take();
+                            *sub_detector = SubDetector {
+                                manifold_id: manifolds.len(),
+                                timestamp: new_timestamp,
+                                selected_contacts: 0,
+                            };
+
+                            manifolds.push(manifold);
+                            (sub_detector, false)
+                        } else {
+                            (sub_detector, true)
+                        }
+                    }
+                    Entry::Vacant(entry) => {
+                        let sub_detector = SubDetector {
+                            manifold_id: manifolds.len(),
+                            selected_contacts: 0,
+                            timestamp: new_timestamp,
+                        };
+
+                        let (id1, id2) = if flipped { (0, vid) } else { (vid, 0) };
+                        manifolds.push(ContactManifold::with_data(
+                            id1,
+                            id2,
+                            ManifoldData::default(),
+                        ));
+
+                        (entry.insert(sub_detector), false)
+                    }
+                };
+
+            /*
+             * Update the contact manifold if needed.
+             */
+            let manifold = &mut manifolds[sub_detector.manifold_id];
+
+            if !manifold_updated {
+                let mut canonical_mins1 = voxels1.key_center(key_low.into());
+                let mut canonical_maxs1 = voxels1.key_center(key_high.into());
+
+                for k in 0..DIM {
+                    if key_low[k] != key_voxel[k] {
+                        canonical_mins1[k] = canonical_mins1[k].max(domain2_1.mins[k]);
+                    }
+
+                    if key_high[k] != key_voxel[k] {
+                        canonical_maxs1[k] = canonical_maxs1[k].min(domain2_1.maxs[k]);
+                    }
+                }
+
+                let canonical_half_extents1 =
+                    (canonical_maxs1 - canonical_mins1) / 2.0 + Vector::repeat(radius1);
+                let canonical_center1 = na::center(&canonical_mins1, &canonical_maxs1);
+                let canonical_shape1 = Cuboid::new(canonical_half_extents1);
+
+                let canonical_pos12 = Translation::from(-canonical_center1) * pos12;
+
+                // If we already computed contacts in the previous simulation step, their
+                // local points are relative to the previously calculated canonical shape
+                // which might not have the same local center as the one computed in this
+                // step (because it’s based on the position of shape2 relative to voxels1).
+                // So we need to adjust the local points to account for the position difference
+                // and keep the point at the same "canonica-shape-space" location as in the previous frame.
+                let prev_center = if flipped {
+                    manifold
+                        .subshape_pos2
+                        .as_ref()
+                        .map(|p| p.translation.vector)
+                        .unwrap_or_default()
+                } else {
+                    manifold
+                        .subshape_pos1
+                        .as_ref()
+                        .map(|p| p.translation.vector)
+                        .unwrap_or_default()
+                };
+                let delta_center = canonical_center1.coords - prev_center;
+
+                if flipped {
+                    for pt in &mut manifold.points {
+                        pt.local_p2 -= delta_center;
+                    }
+                } else {
+                    for pt in &mut manifold.points {
+                        pt.local_p1 -= delta_center;
+                    }
+                }
+
+                // Update contacts.
+                if flipped {
+                    manifold.subshape_pos2 = Some(Isometry::from(canonical_center1));
+                    let _ = dispatcher.contact_manifold_convex_convex(
+                        &canonical_pos12.inverse(),
+                        shape2,
+                        &canonical_shape1,
+                        None,
+                        None,
+                        prediction,
+                        manifold,
+                    );
+                } else {
+                    manifold.subshape_pos1 = Some(Isometry::from(canonical_center1));
+                    let _ = dispatcher.contact_manifold_convex_convex(
+                        &canonical_pos12,
+                        &canonical_shape1,
+                        shape2,
+                        None,
+                        None,
+                        prediction,
+                        manifold,
+                    );
+                }
+            }
+
+            /*
+             * Filter-out points that don’t belong to this block.
+             */
+            let test_voxel = Cuboid::new(Vector::repeat(radius1 + 1.0e-2));
+            let penetration_dir1 = if flipped {
+                manifold.local_n2
+            } else {
+                manifold.local_n1
+            };
+
+            for (i, pt) in manifold.points.iter().enumerate() {
+                if pt.dist < 0.0 {
+                    // If this is a penetration, double-check that we are not hitting the
+                    // interior of the infinitely expanded canonical shape by checking if
+                    // the opposite normal would have led to a better vector.
+                    let cuboid1 = Cuboid::new(Vector::repeat(radius1));
+                    let sp1 = cuboid1.local_support_point(&-penetration_dir1) + center1.coords;
+                    let sm2 = shape2
+                        .as_support_map()
+                        .expect("Unsupported collision pair.");
+                    let sp2 = sm2.support_point(&pos12, &penetration_dir1);
+                    let test_dist = (sp2 - sp1).dot(&-penetration_dir1);
+                    let keep = test_dist < pt.dist;
+
+                    if !keep {
+                        // We don’t want to keep this point as it is an incorrect penetration
+                        // caused by the canonical shape expansion.
+                        continue;
+                    }
+                }
+
+                let pt_in_voxel_space = if flipped {
+                    manifold.subshape_pos2.transform_point(&pt.local_p2) - center1.coords
+                } else {
+                    manifold.subshape_pos1.transform_point(&pt.local_p1) - center1.coords
+                };
+                sub_detector.selected_contacts |=
+                    (test_voxel.contains_local_point(&pt_in_voxel_space) as u32) << i;
+            }
+        }
+    }
+
+    // Remove contacts marked as ignored.
+    for (_, sub_detector) in &workspace.sub_detectors {
+        if sub_detector.timestamp == new_timestamp {
+            let manifold = &mut manifolds[sub_detector.manifold_id];
+            let mut k = 0;
+            manifold.points.retain(|_| {
+                let keep = (sub_detector.selected_contacts & (1 << k)) != 0;
+                k += 1;
+                keep
+            });
+        }
+    }
+
+    // Remove detectors which no longer index a valid manifold.
+    workspace
+        .sub_detectors
+        .retain(|_, detector| detector.timestamp == new_timestamp);
+}

--- a/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
@@ -9,6 +9,7 @@ use crate::shape::{
 };
 use crate::utils::hashmap::{Entry, HashMap};
 use crate::utils::IsometryOpt;
+use alloc::{boxed::Box, vec::Vec};
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
@@ -115,7 +116,7 @@ pub fn contact_manifolds_voxels_shape<ManifoldData, ContactData>(
     let new_timestamp = !workspace.timestamp;
 
     // TODO: avoid reallocating the new `manifolds` vec at each step.
-    let mut old_manifolds = std::mem::take(manifolds);
+    let mut old_manifolds = core::mem::take(manifolds);
 
     workspace.timestamp = new_timestamp;
 

--- a/src/query/contact_manifolds/contact_manifolds_workspace.rs
+++ b/src/query/contact_manifolds/contact_manifolds_workspace.rs
@@ -7,7 +7,7 @@ use crate::query::contact_manifolds::{
     CompositeShapeCompositeShapeContactManifoldsWorkspace,
     CompositeShapeShapeContactManifoldsWorkspace,
     HeightFieldCompositeShapeContactManifoldsWorkspace, HeightFieldShapeContactManifoldsWorkspace,
-    TriMeshShapeContactManifoldsWorkspace,
+    TriMeshShapeContactManifoldsWorkspace, VoxelsShapeContactManifoldsWorkspace,
 };
 
 #[derive(Copy, Clone)]
@@ -28,6 +28,8 @@ pub enum TypedWorkspaceData<'a> {
     ),
     /// A composite shape vs. shape workspace.
     CompositeShapeShapeContactManifoldsWorkspace(&'a CompositeShapeShapeContactManifoldsWorkspace),
+    /// A voxels vs. shape workspace.
+    VoxelsShapeContactManifoldsWorkspace(&'a VoxelsShapeContactManifoldsWorkspace),
     /// A custom workspace.
     Custom,
 }

--- a/src/query/contact_manifolds/mod.rs
+++ b/src/query/contact_manifolds/mod.rs
@@ -37,9 +37,6 @@ pub use self::contact_manifolds_voxels_shape::{
     contact_manifolds_voxels_shape, contact_manifolds_voxels_shape_shapes,
     VoxelsShapeContactManifoldsWorkspace,
 };
-pub use self::contact_manifolds_voxels_voxels::{
-    contact_manifolds_voxels_voxels, contact_manifolds_voxels_voxels_shapes,
-};
 pub use self::contact_manifolds_workspace::{
     ContactManifoldsWorkspace, TypedWorkspaceData, WorkspaceData,
 };
@@ -51,7 +48,6 @@ use {
     self::contact_manifolds_heightfield_composite_shape::HeightFieldCompositeShapeContactManifoldsWorkspace,
     self::contact_manifolds_heightfield_shape::HeightFieldShapeContactManifoldsWorkspace,
     self::contact_manifolds_trimesh_shape::TriMeshShapeContactManifoldsWorkspace,
-    self::contact_manifolds_voxels_ball::detect_hit_voxel_ball,
 };
 
 mod contact_manifold;
@@ -70,6 +66,5 @@ mod contact_manifolds_pfm_pfm;
 mod contact_manifolds_trimesh_shape;
 mod contact_manifolds_voxels_ball;
 mod contact_manifolds_voxels_shape;
-mod contact_manifolds_voxels_voxels;
 mod contact_manifolds_workspace;
 mod normals_constraint;

--- a/src/query/contact_manifolds/mod.rs
+++ b/src/query/contact_manifolds/mod.rs
@@ -32,6 +32,14 @@ pub use self::contact_manifolds_pfm_pfm::{
 pub use self::contact_manifolds_trimesh_shape::{
     contact_manifolds_trimesh_shape, contact_manifolds_trimesh_shape_shapes,
 };
+pub use self::contact_manifolds_voxels_ball::contact_manifolds_voxels_ball_shapes;
+pub use self::contact_manifolds_voxels_shape::{
+    contact_manifolds_voxels_shape, contact_manifolds_voxels_shape_shapes,
+    VoxelsShapeContactManifoldsWorkspace,
+};
+pub use self::contact_manifolds_voxels_voxels::{
+    contact_manifolds_voxels_voxels, contact_manifolds_voxels_voxels_shapes,
+};
 pub use self::contact_manifolds_workspace::{
     ContactManifoldsWorkspace, TypedWorkspaceData, WorkspaceData,
 };
@@ -43,6 +51,7 @@ use {
     self::contact_manifolds_heightfield_composite_shape::HeightFieldCompositeShapeContactManifoldsWorkspace,
     self::contact_manifolds_heightfield_shape::HeightFieldShapeContactManifoldsWorkspace,
     self::contact_manifolds_trimesh_shape::TriMeshShapeContactManifoldsWorkspace,
+    self::contact_manifolds_voxels_ball::detect_hit_voxel_ball,
 };
 
 mod contact_manifold;
@@ -59,5 +68,8 @@ mod contact_manifolds_heightfield_composite_shape;
 mod contact_manifolds_heightfield_shape;
 mod contact_manifolds_pfm_pfm;
 mod contact_manifolds_trimesh_shape;
+mod contact_manifolds_voxels_ball;
+mod contact_manifolds_voxels_shape;
+mod contact_manifolds_voxels_voxels;
 mod contact_manifolds_workspace;
 mod normals_constraint;

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -492,8 +492,16 @@ where
                     );
                 }
             }
+            (ShapeType::Voxels, ShapeType::Voxels) => {
+                contact_manifolds_voxels_voxels_shapes(pos12, shape1, shape2, prediction, manifolds)
+            }
             (ShapeType::Voxels, ShapeType::Ball) | (ShapeType::Ball, ShapeType::Voxels) => {
                 contact_manifolds_voxels_ball_shapes(pos12, shape1, shape2, prediction, manifolds)
+            }
+            (ShapeType::Voxels, _) | (_, ShapeType::Voxels) => {
+                contact_manifolds_voxels_shape_shapes(
+                    self, pos12, shape1, shape2, prediction, manifolds, workspace,
+                )
             }
             _ => {
                 if let Some(composite1) = composite1 {

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -492,9 +492,6 @@ where
                     );
                 }
             }
-            (ShapeType::Voxels, ShapeType::Voxels) => {
-                contact_manifolds_voxels_voxels_shapes(pos12, shape1, shape2, prediction, manifolds)
-            }
             (ShapeType::Voxels, ShapeType::Ball) | (ShapeType::Ball, ShapeType::Voxels) => {
                 contact_manifolds_voxels_ball_shapes(pos12, shape1, shape2, prediction, manifolds)
             }

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -492,6 +492,9 @@ where
                     );
                 }
             }
+            (ShapeType::Voxels, ShapeType::Ball) | (ShapeType::Ball, ShapeType::Voxels) => {
+                contact_manifolds_voxels_ball_shapes(pos12, shape1, shape2, prediction, manifolds)
+            }
             _ => {
                 if let Some(composite1) = composite1 {
                     contact_manifolds_composite_shape_shape(

--- a/src/query/point/mod.rs
+++ b/src/query/point/mod.rs
@@ -33,4 +33,5 @@ mod point_support_map;
 #[cfg(feature = "dim3")]
 mod point_tetrahedron;
 mod point_triangle;
+#[cfg(feature = "alloc")]
 mod point_voxels;

--- a/src/query/point/mod.rs
+++ b/src/query/point/mod.rs
@@ -33,3 +33,4 @@ mod point_support_map;
 #[cfg(feature = "dim3")]
 mod point_tetrahedron;
 mod point_triangle;
+mod point_voxels;

--- a/src/query/point/point_voxels.rs
+++ b/src/query/point/point_voxels.rs
@@ -1,0 +1,37 @@
+use crate::math::{Point, Real, Vector};
+use crate::query::{PointProjection, PointQuery};
+use crate::shape::{Cuboid, FeatureId, VoxelType, Voxels};
+
+impl PointQuery for Voxels {
+    #[inline]
+    fn project_local_point(&self, pt: &Point<Real>, solid: bool) -> PointProjection {
+        // TODO: optimize this very naive implementation.
+        let base_cuboid = Cuboid::new(Vector::repeat(self.voxel_size() / 2.0));
+        let mut smallest_dist = Real::MAX;
+        let mut result = PointProjection::new(false, *pt);
+
+        for (_, center, data) in self.centers() {
+            if data.voxel_type() != VoxelType::Empty {
+                let mut candidate = base_cuboid.project_local_point(&(pt - center.coords), solid);
+                candidate.point += center.coords;
+
+                let candidate_dist = (candidate.point - pt).norm();
+                if candidate_dist < smallest_dist {
+                    result = candidate;
+                    smallest_dist = candidate_dist;
+                }
+            }
+        }
+
+        result
+    }
+
+    #[inline]
+    fn project_local_point_and_get_feature(
+        &self,
+        pt: &Point<Real>,
+    ) -> (PointProjection, FeatureId) {
+        // TODO: get the actual feature.
+        (self.project_local_point(pt, false), FeatureId::Unknown)
+    }
+}

--- a/src/query/point/point_voxels.rs
+++ b/src/query/point/point_voxels.rs
@@ -1,4 +1,4 @@
-use crate::math::{Point, Real, Vector};
+use crate::math::{Point, Real};
 use crate::query::{PointProjection, PointQuery};
 use crate::shape::{Cuboid, FeatureId, VoxelType, Voxels};
 
@@ -6,7 +6,7 @@ impl PointQuery for Voxels {
     #[inline]
     fn project_local_point(&self, pt: &Point<Real>, solid: bool) -> PointProjection {
         // TODO: optimize this very naive implementation.
-        let base_cuboid = Cuboid::new(Vector::repeat(self.voxel_size() / 2.0));
+        let base_cuboid = Cuboid::new(self.voxel_size() / 2.0);
         let mut smallest_dist = Real::MAX;
         let mut result = PointProjection::new(false, *pt);
 

--- a/src/query/ray/mod.rs
+++ b/src/query/ray/mod.rs
@@ -27,4 +27,5 @@ mod ray_heightfield;
 mod ray_round_shape;
 mod ray_support_map;
 mod ray_triangle;
+mod ray_voxels;
 mod simd_ray;

--- a/src/query/ray/mod.rs
+++ b/src/query/ray/mod.rs
@@ -27,5 +27,6 @@ mod ray_heightfield;
 mod ray_round_shape;
 mod ray_support_map;
 mod ray_triangle;
+#[cfg(feature = "alloc")]
 mod ray_voxels;
 mod simd_ray;

--- a/src/query/ray/ray_voxels.rs
+++ b/src/query/ray/ray_voxels.rs
@@ -1,0 +1,102 @@
+use crate::math::{Real, Vector};
+use crate::query::{Ray, RayCast, RayIntersection};
+use crate::shape::{FeatureId, Voxels};
+
+impl RayCast for Voxels {
+    #[inline]
+    fn cast_local_ray_and_get_normal(
+        &self,
+        ray: &Ray,
+        max_time_of_impact: Real,
+        solid: bool,
+    ) -> Option<RayIntersection> {
+        use num_traits::Bounded;
+
+        let aabb = self.local_aabb();
+        let dims = self.dimensions();
+        let (min_t, mut max_t) = aabb.clip_ray_parameters(ray)?;
+
+        #[cfg(feature = "dim2")]
+        let ii = [0, 1];
+        #[cfg(feature = "dim3")]
+        let ii = [0, 1, 2];
+
+        if min_t > max_time_of_impact {
+            return None;
+        }
+
+        max_t = max_t.min(max_time_of_impact);
+        let clip_ray_a = ray.point_at(min_t);
+        let voxel_key_signed = self.signed_key_at_point(clip_ray_a);
+        let mut voxel_key = ii.map(|i| voxel_key_signed[i].clamp(0, dims[i] as i32 - 1) as u32);
+
+        loop {
+            let voxel = self.voxel_data_at_key(voxel_key);
+            let aabb = self.voxel_aabb_at_key(voxel_key);
+
+            if !voxel.is_empty() {
+                // We hit a voxel!
+                // TODO: if `solid` is false, and we started hitting from the first iteration,
+                //       then we should continue the ray propagation until we reach empty space again.
+                let hit = aabb.cast_local_ray_and_get_normal(ray, max_t, solid);
+
+                if let Some(mut hit) = hit {
+                    // TODO: have the feature id be based on the voxel type?
+                    hit.feature = FeatureId::Face(self.linear_index(voxel_key));
+                    return Some(hit);
+                }
+            }
+
+            /*
+             * Find the next voxel to cast the ray on.
+             */
+            let toi = ii.map(|i| {
+                if ray.dir[i] > 0.0 {
+                    let t = (aabb.maxs[i] - ray.origin[i]) / ray.dir[i];
+                    if t < 0.0 {
+                        (Real::max_value(), true)
+                    } else {
+                        (t, true)
+                    }
+                } else if ray.dir[i] < 0.0 {
+                    let t = (aabb.mins[i] - ray.origin[i]) / ray.dir[i];
+                    if t < 0.0 {
+                        (Real::max_value(), false)
+                    } else {
+                        (t, false)
+                    }
+                } else {
+                    (Real::max_value(), false)
+                }
+            });
+
+            #[cfg(feature = "dim2")]
+            if toi[0].0 > max_t && toi[1].0 > max_t {
+                break;
+            }
+
+            #[cfg(feature = "dim3")]
+            if toi[0].0 > max_t && toi[1].0 > max_t && toi[2].0 > max_t {
+                break;
+            }
+
+            let imin = Vector::from(toi.map(|t| t.0)).imin();
+
+            if toi[imin].1 {
+                if voxel_key[imin] < dims[imin] - 1 {
+                    voxel_key[imin] += 1;
+                } else {
+                    // Leaving the shape’s bounds.
+                    break;
+                }
+            } else if voxel_key[imin] > 0 {
+                    voxel_key[imin] -= 1;
+                } else {
+                    // Leaving the shape’s bounds.
+                    break;
+                }
+        }
+
+        None
+    }
+}

--- a/src/query/ray/ray_voxels.rs
+++ b/src/query/ray/ray_voxels.rs
@@ -90,11 +90,11 @@ impl RayCast for Voxels {
                     break;
                 }
             } else if voxel_key[imin] > 0 {
-                    voxel_key[imin] -= 1;
-                } else {
-                    // Leaving the shape’s bounds.
-                    break;
-                }
+                voxel_key[imin] -= 1;
+            } else {
+                // Leaving the shape’s bounds.
+                break;
+            }
         }
 
         None

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -15,9 +15,6 @@ pub use self::shape::{Shape, ShapeType, TypedShape};
 #[doc(inline)]
 pub use self::support_map::SupportMap;
 pub use self::triangle::{Triangle, TriangleOrientation, TrianglePointLocation};
-pub use self::voxels::{
-    AxisMask, OctantPattern, VoxelPrimitiveGeometry, VoxelState, VoxelType, Voxels,
-};
 
 #[cfg(feature = "alloc")]
 pub use self::{
@@ -25,6 +22,7 @@ pub use self::{
     compound::Compound,
     polyline::Polyline,
     shared_shape::SharedShape,
+    voxels::{AxisMask, OctantPattern, VoxelPrimitiveGeometry, VoxelState, VoxelType, Voxels},
 };
 
 #[cfg(feature = "dim2")]
@@ -125,4 +123,5 @@ mod polygonal_feature2d;
 #[cfg(feature = "alloc")]
 mod shared_shape;
 mod triangle_pseudo_normals;
+#[cfg(feature = "alloc")]
 mod voxels;

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -15,7 +15,9 @@ pub use self::shape::{Shape, ShapeType, TypedShape};
 #[doc(inline)]
 pub use self::support_map::SupportMap;
 pub use self::triangle::{Triangle, TriangleOrientation, TrianglePointLocation};
-pub use self::voxels::{OctantPattern, VoxelData, VoxelPrimitiveGeometry, VoxelType, Voxels};
+pub use self::voxels::{
+    AxisMask, OctantPattern, VoxelData, VoxelPrimitiveGeometry, VoxelType, Voxels,
+};
 
 #[cfg(feature = "alloc")]
 pub use self::{

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -16,7 +16,7 @@ pub use self::shape::{Shape, ShapeType, TypedShape};
 pub use self::support_map::SupportMap;
 pub use self::triangle::{Triangle, TriangleOrientation, TrianglePointLocation};
 pub use self::voxels::{
-    AxisMask, OctantPattern, VoxelData, VoxelPrimitiveGeometry, VoxelType, Voxels,
+    AxisMask, OctantPattern, VoxelPrimitiveGeometry, VoxelState, VoxelType, Voxels,
 };
 
 #[cfg(feature = "alloc")]

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -15,6 +15,7 @@ pub use self::shape::{Shape, ShapeType, TypedShape};
 #[doc(inline)]
 pub use self::support_map::SupportMap;
 pub use self::triangle::{Triangle, TriangleOrientation, TrianglePointLocation};
+pub use self::voxels::{OctantPattern, VoxelData, VoxelPrimitiveGeometry, VoxelType, Voxels};
 
 #[cfg(feature = "alloc")]
 pub use self::{
@@ -122,3 +123,4 @@ mod polygonal_feature2d;
 #[cfg(feature = "alloc")]
 mod shared_shape;
 mod triangle_pseudo_normals;
+mod voxels;

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -14,18 +14,18 @@ use crate::shape::SharedShape;
 use crate::shape::{composite_shape::SimdCompositeShape, Compound, HeightField, Polyline, TriMesh};
 use crate::shape::{
     Ball, Capsule, Cuboid, FeatureId, HalfSpace, PolygonalFeatureMap, RoundCuboid, RoundShape,
-    RoundTriangle, Segment, SupportMap, Triangle, Voxels,
+    RoundTriangle, Segment, SupportMap, Triangle,
 };
 #[cfg(feature = "dim3")]
 use crate::shape::{Cone, Cylinder, RoundCone, RoundCylinder};
 
 #[cfg(feature = "dim3")]
 #[cfg(feature = "alloc")]
-use crate::shape::{ConvexPolyhedron, RoundConvexPolyhedron};
+use crate::shape::{ConvexPolyhedron, RoundConvexPolyhedron, Voxels};
 
 #[cfg(feature = "dim2")]
 #[cfg(feature = "alloc")]
-use crate::shape::{ConvexPolygon, RoundConvexPolygon};
+use crate::shape::{ConvexPolygon, RoundConvexPolygon, Voxels};
 use downcast_rs::{impl_downcast, DowncastSync};
 use na::{RealField, Unit};
 use num::Zero;
@@ -107,6 +107,7 @@ pub enum TypedShape<'a> {
     Segment(&'a Segment),
     /// A triangle shape.
     Triangle(&'a Triangle),
+    #[cfg(feature = "alloc")]
     /// A shape defined as a voxel grid.
     Voxels(&'a Voxels),
     /// A triangle mesh shape.
@@ -170,6 +171,7 @@ impl Debug for TypedShape<'_> {
             Self::Capsule(arg0) => f.debug_tuple("Capsule").field(arg0).finish(),
             Self::Segment(arg0) => f.debug_tuple("Segment").field(arg0).finish(),
             Self::Triangle(arg0) => f.debug_tuple("Triangle").field(arg0).finish(),
+            #[cfg(feature = "alloc")]
             Self::Voxels(arg0) => f.debug_tuple("Voxels").field(arg0).finish(),
             #[cfg(feature = "alloc")]
             Self::TriMesh(arg0) => f.debug_tuple("TriMesh").field(arg0).finish(),
@@ -227,6 +229,7 @@ pub(crate) enum DeserializableTypedShape {
     /// A triangle shape.
     Triangle(Triangle),
     /// A shape defined as a voxel grid.
+    #[cfg(feature = "alloc")]
     Voxels(Voxels),
     /// A triangle mesh shape.
     #[cfg(feature = "alloc")]
@@ -294,6 +297,7 @@ impl DeserializableTypedShape {
             DeserializableTypedShape::Capsule(s) => Some(SharedShape::new(s)),
             DeserializableTypedShape::Segment(s) => Some(SharedShape::new(s)),
             DeserializableTypedShape::Triangle(s) => Some(SharedShape::new(s)),
+            #[cfg(feature = "alloc")]
             DeserializableTypedShape::Voxels(s) => Some(SharedShape::new(s)),
             #[cfg(feature = "alloc")]
             DeserializableTypedShape::TriMesh(s) => Some(SharedShape::new(s)),
@@ -502,10 +506,12 @@ impl dyn Shape {
     }
 
     /// Converts this abstract shape to voxels, if it is one.
+    #[cfg(feature = "alloc")]
     pub fn as_voxels(&self) -> Option<&Voxels> {
         self.downcast_ref()
     }
     /// Converts this abstract shape to mutable voxels, if it is one.
+    #[cfg(feature = "alloc")]
     pub fn as_voxels_mut(&mut self) -> Option<&mut Voxels> {
         self.downcast_mut()
     }
@@ -1517,7 +1523,7 @@ impl Shape for HalfSpace {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl Shape for Voxels {
     fn compute_local_aabb(&self) -> Aabb {
         self.local_aabb()

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -1535,8 +1535,8 @@ impl Shape for Voxels {
         todo!()
     }
 
-    fn mass_properties(&self, density: Real) -> MassProperties {
-        MassProperties::from_voxels(density, self)
+    fn mass_properties(&self, _density: Real) -> MassProperties {
+        MassProperties::default()
     }
 
     fn shape_type(&self) -> ShapeType {

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -14,7 +14,7 @@ use crate::shape::SharedShape;
 use crate::shape::{composite_shape::SimdCompositeShape, Compound, HeightField, Polyline, TriMesh};
 use crate::shape::{
     Ball, Capsule, Cuboid, FeatureId, HalfSpace, PolygonalFeatureMap, RoundCuboid, RoundShape,
-    RoundTriangle, Segment, SupportMap, Triangle,
+    RoundTriangle, Segment, SupportMap, Triangle, Voxels,
 };
 #[cfg(feature = "dim3")]
 use crate::shape::{Cone, Cylinder, RoundCone, RoundCylinder};
@@ -44,6 +44,8 @@ pub enum ShapeType {
     Segment,
     /// A triangle shape.
     Triangle,
+    /// A shape defined as a voxel grid.
+    Voxels,
     /// A triangle mesh shape.
     TriMesh,
     /// A set of segments.
@@ -105,6 +107,8 @@ pub enum TypedShape<'a> {
     Segment(&'a Segment),
     /// A triangle shape.
     Triangle(&'a Triangle),
+    /// A shape defined as a voxel grid.
+    Voxels(&'a Voxels),
     /// A triangle mesh shape.
     #[cfg(feature = "alloc")]
     TriMesh(&'a TriMesh),
@@ -166,6 +170,7 @@ impl Debug for TypedShape<'_> {
             Self::Capsule(arg0) => f.debug_tuple("Capsule").field(arg0).finish(),
             Self::Segment(arg0) => f.debug_tuple("Segment").field(arg0).finish(),
             Self::Triangle(arg0) => f.debug_tuple("Triangle").field(arg0).finish(),
+            Self::Voxels(arg0) => f.debug_tuple("Voxels").field(arg0).finish(),
             #[cfg(feature = "alloc")]
             Self::TriMesh(arg0) => f.debug_tuple("TriMesh").field(arg0).finish(),
             #[cfg(feature = "alloc")]
@@ -221,6 +226,8 @@ pub(crate) enum DeserializableTypedShape {
     Segment(Segment),
     /// A triangle shape.
     Triangle(Triangle),
+    /// A shape defined as a voxel grid.
+    Voxels(Voxels),
     /// A triangle mesh shape.
     #[cfg(feature = "alloc")]
     TriMesh(TriMesh),
@@ -287,6 +294,7 @@ impl DeserializableTypedShape {
             DeserializableTypedShape::Capsule(s) => Some(SharedShape::new(s)),
             DeserializableTypedShape::Segment(s) => Some(SharedShape::new(s)),
             DeserializableTypedShape::Triangle(s) => Some(SharedShape::new(s)),
+            DeserializableTypedShape::Voxels(s) => Some(SharedShape::new(s)),
             #[cfg(feature = "alloc")]
             DeserializableTypedShape::TriMesh(s) => Some(SharedShape::new(s)),
             #[cfg(feature = "alloc")]
@@ -490,6 +498,15 @@ impl dyn Shape {
     }
     /// Converts this abstract shape to a mutable triangle, if it is one.
     pub fn as_triangle_mut(&mut self) -> Option<&mut Triangle> {
+        self.downcast_mut()
+    }
+
+    /// Converts this abstract shape to voxels, if it is one.
+    pub fn as_voxels(&self) -> Option<&Voxels> {
+        self.downcast_ref()
+    }
+    /// Converts this abstract shape to mutable voxels, if it is one.
+    pub fn as_voxels_mut(&mut self) -> Option<&mut Voxels> {
         self.downcast_mut()
     }
 
@@ -1497,6 +1514,45 @@ impl Shape for HalfSpace {
 
     fn as_typed_shape(&self) -> TypedShape {
         TypedShape::HalfSpace(self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl Shape for Voxels {
+    fn compute_local_aabb(&self) -> Aabb {
+        self.local_aabb()
+    }
+
+    fn compute_local_bounding_sphere(&self) -> BoundingSphere {
+        self.local_bounding_sphere()
+    }
+
+    fn clone_dyn(&self) -> Box<dyn Shape> {
+        Box::new(self.clone())
+    }
+
+    fn scale_dyn(&self, _scale: &Vector<Real>, _num_subdivisions: u32) -> Option<Box<dyn Shape>> {
+        todo!()
+    }
+
+    fn mass_properties(&self, density: Real) -> MassProperties {
+        MassProperties::from_voxels(density, self)
+    }
+
+    fn shape_type(&self) -> ShapeType {
+        ShapeType::Voxels
+    }
+
+    fn as_typed_shape(&self) -> TypedShape {
+        TypedShape::Voxels(self)
+    }
+
+    fn ccd_thickness(&self) -> Real {
+        self.scale
+    }
+
+    fn ccd_angular_thickness(&self) -> Real {
+        Real::frac_pi_2()
     }
 }
 

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -1554,7 +1554,7 @@ impl Shape for Voxels {
     }
 
     fn ccd_thickness(&self) -> Real {
-        self.scale
+        self.voxel_size.min()
     }
 
     fn ccd_angular_thickness(&self) -> Real {

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -219,14 +219,32 @@ impl SharedShape {
 
     /// Initializes a shape made of voxels.
     ///
-    /// Each voxel has the size `voxel_size` and centers given by `centers`.
+    /// Each voxel has the size `voxel_size` and grid coordinate given by `centers`.
     /// The `primitive_geometry` controls the behavior of collision detection at voxels boundaries.
+    ///
+    /// For initializing a voxels shape from points in space, see [`Self::voxels_from_points`].
+    /// For initializing a voxels shape from a mesh to voxelize, see [`Self::voxelized_mesh`].
+    /// For initializing multiple voxels shape from the convex decomposition of a mesh, see
+    /// [`Self::voxelized_convex_decomposition`].
     pub fn voxels(
         primitive_geometry: VoxelPrimitiveGeometry,
         voxel_size: Vector<Real>,
-        centers: &[Point<Real>],
+        centers: &[Point<i32>],
     ) -> Self {
-        let shape = Voxels::from_points(primitive_geometry, voxel_size, centers);
+        let shape = Voxels::new(primitive_geometry, voxel_size, centers);
+        SharedShape::new(shape)
+    }
+
+    /// Initializes a shape made of voxels.
+    ///
+    /// Each voxel has the size `voxel_size` and contains at least one point from `centers`.
+    /// The `primitive_geometry` controls the behavior of collision detection at voxels boundaries.
+    pub fn voxels_from_points(
+        primitive_geometry: VoxelPrimitiveGeometry,
+        voxel_size: Vector<Real>,
+        points: &[Point<Real>],
+    ) -> Self {
+        let shape = Voxels::from_points(primitive_geometry, voxel_size, points);
         SharedShape::new(shape)
     }
 
@@ -250,7 +268,8 @@ impl SharedShape {
             .iter()
             .map(|v| vox_set.get_voxel_point(v))
             .collect();
-        let shape = Voxels::from_points(primitive_geometry, Vector::repeat(vox_set.scale), &centers);
+        let shape =
+            Voxels::from_points(primitive_geometry, Vector::repeat(vox_set.scale), &centers);
         SharedShape::new(shape)
     }
 

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -223,10 +223,10 @@ impl SharedShape {
     /// The `primitive_geometry` controls the behavior of collision detection at voxels boundaries.
     pub fn voxels(
         primitive_geometry: VoxelPrimitiveGeometry,
+        voxel_size: Vector<Real>,
         centers: &[Point<Real>],
-        voxel_size: Real,
     ) -> Self {
-        let shape = Voxels::from_points(primitive_geometry, centers, voxel_size);
+        let shape = Voxels::from_points(primitive_geometry, voxel_size, centers);
         SharedShape::new(shape)
     }
 
@@ -250,7 +250,7 @@ impl SharedShape {
             .iter()
             .map(|v| vox_set.get_voxel_point(v))
             .collect();
-        let shape = Voxels::from_points(primitive_geometry, &centers, vox_set.scale);
+        let shape = Voxels::from_points(primitive_geometry, Vector::repeat(vox_set.scale), &centers);
         SharedShape::new(shape)
     }
 

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -1,4 +1,6 @@
+use super::TriMeshBuilderError;
 use crate::math::{Isometry, Point, Real, Vector, DIM};
+use crate::shape::voxels::VoxelPrimitiveGeometry;
 #[cfg(feature = "dim2")]
 use crate::shape::ConvexPolygon;
 #[cfg(feature = "serde-serialize")]
@@ -7,18 +9,17 @@ use crate::shape::DeserializableTypedShape;
 use crate::shape::HeightFieldFlags;
 use crate::shape::{
     Ball, Capsule, Compound, Cuboid, HalfSpace, HeightField, Polyline, RoundShape, Segment, Shape,
-    TriMesh, TriMeshFlags, Triangle, TypedShape,
+    TriMesh, TriMeshFlags, Triangle, TypedShape, Voxels,
 };
 #[cfg(feature = "dim3")]
 use crate::shape::{Cone, ConvexPolyhedron, Cylinder};
 use crate::transformation::vhacd::{VHACDParameters, VHACD};
+use crate::transformation::voxelization::{FillMode, VoxelSet};
 use alloc::sync::Arc;
 use alloc::{vec, vec::Vec};
 use core::fmt;
 use core::ops::Deref;
 use na::Unit;
-
-use super::TriMeshBuilderError;
 
 /// The shape of a collider.
 #[derive(Clone)]
@@ -214,6 +215,73 @@ impl SharedShape {
         Ok(SharedShape(Arc::new(TriMesh::with_flags(
             vertices, indices, flags,
         )?)))
+    }
+
+    pub fn voxels(
+        primitive_geometry: VoxelPrimitiveGeometry,
+        centers: &[Point<Real>],
+        voxel_size: Real,
+    ) -> Self {
+        let shape = Voxels::from_points(primitive_geometry, centers, voxel_size);
+        SharedShape::new(shape)
+    }
+
+    /// Initializes a compound shape obtained from the decomposition of the given trimesh (in 3D)
+    /// or polyline (in 2D) into voxelized convex parts.
+    pub fn voxelized_mesh(
+        primitive_geometry: VoxelPrimitiveGeometry,
+        vertices: &[Point<Real>],
+        indices: &[[u32; DIM]],
+        voxel_size: Real,
+        fill_mode: FillMode,
+    ) -> Self {
+        let mut voxels = VoxelSet::with_voxel_size(vertices, indices, voxel_size, fill_mode, true);
+        voxels.compute_bb();
+        Self::from_voxel_set(primitive_geometry, &voxels)
+    }
+
+    fn from_voxel_set(primitive_geometry: VoxelPrimitiveGeometry, vox_set: &VoxelSet) -> Self {
+        let dims = (vox_set.max_bb_voxels() - vox_set.min_bb_voxels()) + Vector::repeat(1);
+        let centers: Vec<_> = vox_set
+            .voxels()
+            .iter()
+            .map(|v| vox_set.get_voxel_point(v))
+            .collect();
+        let shape = Voxels::from_points(primitive_geometry, &centers, vox_set.scale);
+        SharedShape::new(shape)
+    }
+
+    /// Initializes a compound shape obtained from the decomposition of the given trimesh (in 3D)
+    /// or polyline (in 2D) into voxelized convex parts.
+    pub fn voxelized_convex_decomposition(
+        primitive_geometry: VoxelPrimitiveGeometry,
+        vertices: &[Point<Real>],
+        indices: &[[u32; DIM]],
+    ) -> Vec<Self> {
+        Self::voxelized_convex_decomposition_with_params(
+            primitive_geometry,
+            vertices,
+            indices,
+            &VHACDParameters::default(),
+        )
+    }
+
+    /// Initializes a compound shape obtained from the decomposition of the given trimesh (in 3D)
+    /// or polyline (in 2D) into voxelized convex parts.
+    pub fn voxelized_convex_decomposition_with_params(
+        primitive_geometry: VoxelPrimitiveGeometry,
+        vertices: &[Point<Real>],
+        indices: &[[u32; DIM]],
+        params: &VHACDParameters,
+    ) -> Vec<Self> {
+        let mut parts = vec![];
+        let decomp = VHACD::decompose(params, &vertices, &indices, true);
+
+        for vox_set in decomp.voxel_parts() {
+            parts.push(Self::from_voxel_set(primitive_geometry, vox_set));
+        }
+
+        parts
     }
 
     /// Initializes a compound shape obtained from the decomposition of the given trimesh (in 3D) or

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -217,6 +217,10 @@ impl SharedShape {
         )?)))
     }
 
+    /// Initializes a shape made of voxels.
+    ///
+    /// Each voxel has the size `voxel_size` and centers given by `centers`.
+    /// The `primitive_geometry` controls the behavior of collision detection at voxels boundaries.
     pub fn voxels(
         primitive_geometry: VoxelPrimitiveGeometry,
         centers: &[Point<Real>],
@@ -241,7 +245,6 @@ impl SharedShape {
     }
 
     fn from_voxel_set(primitive_geometry: VoxelPrimitiveGeometry, vox_set: &VoxelSet) -> Self {
-        let dims = (vox_set.max_bb_voxels() - vox_set.min_bb_voxels()) + Vector::repeat(1);
         let centers: Vec<_> = vox_set
             .voxels()
             .iter()
@@ -275,7 +278,7 @@ impl SharedShape {
         params: &VHACDParameters,
     ) -> Vec<Self> {
         let mut parts = vec![];
-        let decomp = VHACD::decompose(params, &vertices, &indices, true);
+        let decomp = VHACD::decompose(params, vertices, indices, true);
 
         for vox_set in decomp.voxel_parts() {
             parts.push(Self::from_voxel_set(primitive_geometry, vox_set));

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -230,7 +230,7 @@ impl SharedShape {
         SharedShape::new(shape)
     }
 
-    /// Initializes a compound shape obtained from the decomposition of the given trimesh (in 3D)
+    /// Initializes a voxels shape obtained from the decomposition of the given trimesh (in 3D)
     /// or polyline (in 2D) into voxelized convex parts.
     pub fn voxelized_mesh(
         primitive_geometry: VoxelPrimitiveGeometry,

--- a/src/shape/voxels.rs
+++ b/src/shape/voxels.rs
@@ -331,7 +331,11 @@ impl Voxels {
 
         let id = self.linear_index(key);
         let prev = self.data[id as usize];
-        let new = if is_filled { VoxelState::INTERIOR } else { VoxelState::EMPTY };
+        let new = if is_filled {
+            VoxelState::INTERIOR
+        } else {
+            VoxelState::EMPTY
+        };
 
         if prev.is_empty() ^ new.is_empty() {
             self.data[id as usize] = new;
@@ -356,13 +360,13 @@ impl Voxels {
             // Add 10% extra padding.
             let extra = self.dimensions.map(|k| k * 10 / 100);
             let neg_padding = ii.map(|k| key[k].min(0).unsigned_abs() + extra[k]);
-            let pos_padding = ii.map(|k|
+            let pos_padding = ii.map(|k| {
                 if key[k] >= self.dimensions[k] as i32 {
                     (key[k] - self.dimensions[k] as i32 + 1 + extra[k] as i32) as u32
                 } else {
                     0
                 }
-            );
+            });
             self.pad_model(neg_padding, pos_padding);
 
             // Shift the key based on the new origin.
@@ -408,23 +412,27 @@ impl Voxels {
             new_self.data[new_i as usize] = self.data[i];
         }
 
-
         *self = new_self;
     }
 
     /// Checks if the given key is within [`Self::dimensions`].
     #[cfg(feature = "dim2")]
     pub fn is_signed_key_in_bounds(&self, key: [i32; DIM]) -> bool {
-        key[0] >= 0 && key[0] < self.dimensions[0] as i32 &&
-            key[1] >= 0 && key[1] < self.dimensions[1] as i32
+        key[0] >= 0
+            && key[0] < self.dimensions[0] as i32
+            && key[1] >= 0
+            && key[1] < self.dimensions[1] as i32
     }
 
     /// Checks if the given key is within [`Self::dimensions`].
     #[cfg(feature = "dim3")]
     pub fn is_signed_key_in_bounds(&self, key: [i32; DIM]) -> bool {
-        key[0] >= 0 && key[0] < self.dimensions[0] as i32 &&
-            key[1] >= 0 && key[1] < self.dimensions[1] as i32 &&
-            key[2] >= 0 && key[2] < self.dimensions[2] as i32
+        key[0] >= 0
+            && key[0] < self.dimensions[0] as i32
+            && key[1] >= 0
+            && key[1] < self.dimensions[1] as i32
+            && key[2] >= 0
+            && key[2] < self.dimensions[2] as i32
     }
 
     fn update_voxel_and_neighbors_state(&mut self, key: [u32; DIM]) {
@@ -493,8 +501,11 @@ impl Voxels {
 
     fn key_at_point(&self, pt: Point<Real>) -> Option<[u32; DIM]> {
         let quant = self.signed_key_at_point(pt);
-        if quant[0] < 0 || quant[1] < 0 ||
-            quant[0] >= self.dimensions[0] as i32 || quant[1] >= self.dimensions[1] as i32 {
+        if quant[0] < 0
+            || quant[1] < 0
+            || quant[0] >= self.dimensions[0] as i32
+            || quant[1] >= self.dimensions[1] as i32
+        {
             return None;
         }
 

--- a/src/shape/voxels.rs
+++ b/src/shape/voxels.rs
@@ -1,5 +1,6 @@
 use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector, DIM};
+use alloc::{vec, vec::Vec};
 
 /// The primitive shape all voxels from a [`Voxels`] is given.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
@@ -686,6 +687,7 @@ impl Voxels {
 // FACES_TO_VOXEL_TYPES, FACES_TO_FEATURE_MASKS, FACES_TO_OCTANT_MASKS.
 #[allow(dead_code)]
 #[cfg(feature = "dim2")]
+#[cfg(test)]
 fn gen_const_tables() {
     // The `j-th` bit of `faces_adj_to_vtx[i]` is set to 1, if the j-th face of the AABB (based on
     // the face order depicted in `AABB::FACES_VERTEX_IDS`) is adjacent to the `i` vertex of the AABB
@@ -813,6 +815,7 @@ fn gen_const_tables() {
 // FACES_TO_VOXEL_TYPES, FACES_TO_FEATURE_MASKS, FACES_TO_OCTANT_MASKS.
 #[allow(dead_code)]
 #[cfg(feature = "dim3")]
+#[cfg(test)]
 fn gen_const_tables() {
     // The `j-th` bit of `faces_adj_to_vtx[i]` is set to 1, if the j-th face of the AABB (based on
     // the face order depicted in `AABB::FACES_VERTEX_IDS`) is adjacent to the `i` vertex of the AABB

--- a/src/shape/voxels.rs
+++ b/src/shape/voxels.rs
@@ -1,0 +1,1047 @@
+use crate::bounding_volume::Aabb;
+use crate::math::{Point, Real, Vector, DIM};
+
+/// The primitive shape all voxels from a [`Voxels`] is given.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+pub enum VoxelPrimitiveGeometry {
+    /// Each voxel is modeled as a pseudo-ball, i.e., in flat areas it will act like a planar
+    /// surface but corners and edges will be rounded like a sphere.
+    ///
+    /// This is an approximation that is particularly relevant if the voxels are small and in large
+    /// number. This can significantly improve collision-detection performances (as well as solver
+    /// performances by generating less contacts points). However,this can introduce visual
+    /// artifacts around edges and corners where objects in contact with the voxel will appear to
+    /// slightly penetrate the corners/edges due to the spherical approximation.
+    PseudoBall,
+    /// Each voxel is modeled as a pseudo-cube, i.e., in flat areas it will act like a planar
+    /// surface but corner and edges will be sharp like a cube.
+    ///
+    /// This is what you would expect for the collision to match the rendered voxels. Use
+    /// [`VoxelPrimitiveGeometry::PseudoBall`] instead if some approximation around corners are acceptable
+    /// in exchange for better performances.
+    #[default]
+    PseudoCube,
+}
+
+/// Categorization of a voxel based on its neighbors.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum VoxelType {
+    /// The voxel is empty.
+    Empty,
+    /// The voxel is a vertex if all three coordinate axis directions have at
+    /// least one empty neighbor.
+    Vertex,
+    /// The voxel is on an edge if it has non-empty neighbors in both directions of
+    /// a single coordinate axis.
+    #[cfg(feature = "dim3")]
+    Edge,
+    /// The voxel is on an edge if it has non-empty neighbors in both directions of
+    /// two coordinate axes.
+    Face,
+    /// The voxel is on an edge if it has non-empty neighbors in both directions of
+    /// all coordinate axes.
+    Interior,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+/// The status of the cell of an heightfield.
+pub struct AxisMask(u8);
+
+bitflags::bitflags! {
+    /// Flags for identifying signed directions along coordinate axes, or faces of a voxel.
+    impl AxisMask: u8 {
+        /// The direction or face along the `+x` coordinate axis.
+        const X_POS = 1 << 0;
+        /// The direction or face along the `-x` coordinate axis.
+        const X_NEG = 1 << 1;
+        /// The direction or face along the `+y` coordinate axis.
+        const Y_POS = 1 << 2;
+        /// The direction or face along the `-y` coordinate axis.
+        const Y_NEG = 1 << 3;
+        /// The direction or face along the `+z` coordinate axis.
+        #[cfg(feature= "dim3")]
+        const Z_POS = 1 << 4;
+        /// The direction or face along the `-z` coordinate axis.
+        #[cfg(feature= "dim3")]
+        const Z_NEG = 1 << 5;
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct OctantPattern;
+
+// NOTE: it is important that the max value of any OctantPattern variant
+//       is 7 because we don’t allocate more than 3 bits to store it in
+//      `FACES_TO_OCTANT_MASKS`.
+/// Indicates the local shape of a voxel on each octant.
+///
+/// This provides geometric information of the shape’s exposed features on each octant.
+/// This is an alternative to `FACES_TO_FEATURE_MASKS` that can be more convenient for some
+/// collision-detection algorithms.
+#[cfg(feature = "dim3")]
+impl OctantPattern {
+    /// The voxel doesn't have any exposed feature on the octant with this mask.
+    pub const INTERIOR: u32 = 0;
+    /// The voxel has an exposed vertex on the octant with this mask.
+    pub const VERTEX: u32 = 1;
+    /// The voxel has an exposed edges with direction X on the octant with this mask.
+    pub const EDGE_X: u32 = 2;
+    /// The voxel has an exposed edges with direction Y on the octant with this mask.
+    pub const EDGE_Y: u32 = 3;
+    /// The voxel has an exposed edges with direction Z on the octant with this mask.
+    pub const EDGE_Z: u32 = 4;
+    /// The voxel has an exposed face with normal X on the octant with this mask.
+    pub const FACE_X: u32 = 5;
+    /// The voxel has an exposed face with normal Y on the octant with this mask.
+    pub const FACE_Y: u32 = 6;
+    /// The voxel has an exposed face with normal Z on the octant with this mask.
+    pub const FACE_Z: u32 = 7;
+}
+
+// NOTE: it is important that the max value of any OctantPattern variant
+//       is 7 because we don’t allocate more than 3 bits to store it in
+//      `FACES_TO_OCTANT_MASKS`.
+/// Indicates the local shape of a voxel on each octant.
+///
+/// This provides geometric information of the shape’s exposed features on each octant.
+/// This is an alternative to `FACES_TO_FEATURE_MASKS` that can be more convenient for some
+/// collision-detection algorithms.
+#[cfg(feature = "dim2")]
+impl OctantPattern {
+    /// The voxel doesn't have any exposed feature on the octant with this mask.
+    pub const INTERIOR: u32 = 0;
+    /// The voxel has an exposed vertex on the octant with this mask.
+    pub const VERTEX: u32 = 1;
+    /// The voxel has an exposed face with normal X on the octant with this mask.
+    pub const FACE_X: u32 = 2;
+    /// The voxel has an exposed face with normal Y on the octant with this mask.
+    pub const FACE_Y: u32 = 3;
+}
+
+// The local neighborhood information is encoded in a 8-bits number in groups of two bits
+// per coordinate axis: `0bwwzzyyxx`. In each group of two bits, e.g. `xx`, the rightmost (resp.
+// leftmost) bit set to 1 means that the neighbor voxel with coordinate `+1` (resp `-1`) relative
+// to the current voxel along the `x` axis is filled. If the bit is 0, then the corresponding
+// neighbor is empty. See the `AxisMask` bitflags.
+// For example, in 2D, the mask `0b00_00_10_01` matches the following configuration (assuming +y goes
+// up, and +x goes right):
+//
+// ```txt
+//  0 0 0
+//  0 x 1
+//  0 1 0
+// ```
+//
+// The special value `0b01000000` indicates that the voxel is empty.
+// And the value `0b00111111` (`0b00001111` in 2D) indicates that the voxel is an interior voxel (its whole neighborhood
+// is filled).
+/// A description of the local neighborhood of a voxel.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+pub struct VoxelData(u8);
+
+impl VoxelData {
+    /// The value of empty voxels.
+    pub const EMPTY: VoxelData = VoxelData(EMPTY_FACE_MASK);
+    /// The value of a voxel with non-empty neighbors in all directions.
+    pub const INTERIOR: VoxelData = VoxelData(INTERIOR_FACE_MASK);
+
+    /// Is this voxel empty?
+    pub const fn is_empty(self) -> bool {
+        self.0 == EMPTY_FACE_MASK
+    }
+
+    /// A bit mask indicating which faces of the voxel don’t have any
+    /// adjacent non-empty voxel.
+
+    pub const fn free_faces(self) -> AxisMask {
+        if self.0 == INTERIOR_FACE_MASK || self.0 == EMPTY_FACE_MASK {
+            AxisMask::empty()
+        } else {
+            AxisMask::from_bits_truncate((!self.0) & INTERIOR_FACE_MASK)
+        }
+    }
+    pub const fn voxel_type(self) -> VoxelType {
+        FACES_TO_VOXEL_TYPES[self.0 as usize]
+    }
+
+    // Bitmask indicating what vertices, edges, or faces of the voxel are "free".
+    pub const fn feature_mask(self) -> u16 {
+        FACES_TO_FEATURE_MASKS[self.0 as usize]
+    }
+    pub const fn octant_mask(self) -> u32 {
+        FACES_TO_OCTANT_MASKS[self.0 as usize]
+    }
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+pub struct Voxels {
+    pub(crate) dimensions: [u32; DIM],
+    pub(crate) data: Vec<VoxelData>, // TODO: use a Vob?
+    primitive_geometry: VoxelPrimitiveGeometry,
+    pub scale: Real,
+    pub origin: Point<Real>,
+}
+
+impl Voxels {
+    /// Computes a voxels shape from the set of `points`.
+    ///
+    /// The points are mapped to a regular grid centered at the provided point with smallest
+    /// coordinates, and with grid cell size equal to `scale`. It is OK if multiple points
+    /// fall into the same grid cell.
+    pub fn from_points(
+        primitive_geometry: VoxelPrimitiveGeometry,
+        points: &[Point<Real>],
+        scale: Real,
+    ) -> Self {
+        let mut aabb = Aabb::from_points(points);
+        aabb.mins -= Vector::repeat(scale / 2.0);
+        aabb.maxs += Vector::repeat(scale / 2.0); // NOTE: is this + necessary?
+
+        // Discretize the points on the grid.
+        let dimensions = ((aabb.maxs - aabb.mins) / scale).map(|x| x.ceil() as u32);
+        let len = dimensions.product();
+        let mut result = Self {
+            dimensions: dimensions.into(),
+            data: vec![VoxelData::EMPTY; len as usize],
+            primitive_geometry,
+            scale,
+            origin: aabb.mins,
+        };
+
+        for pt in points {
+            let coords = (pt - aabb.mins).map(|x| (x / scale).floor() as u32);
+            let index = result.linear_index(coords.into());
+            // The precise voxel data will be computed in `recompute_voxels_data` below.
+            result.data[index as usize] = VoxelData::INTERIOR;
+        }
+
+        result.recompute_voxels_data();
+        result
+    }
+
+    /// The total axis-aligned volume covered by this [`Voxels`] shape.
+    ///
+    /// This accounts for all the voxels in `self`, including empty ones.
+    pub fn extents(&self) -> Vector<Real> {
+        Vector::from(self.dimensions).cast::<Real>() * self.scale
+    }
+
+    /// The size of each voxel part this [`Voxels`] shape.
+    pub fn voxel_size(&self) -> Real {
+        self.scale
+    }
+
+    pub fn primitive_geometry(&self) -> VoxelPrimitiveGeometry {
+        self.primitive_geometry
+    }
+
+    fn recompute_voxels_data(&mut self) {
+        for i in 0..self.data.len() {
+            let key = self.to_key(i as u32);
+            self.data[i] = self.compute_voxel_data(key);
+        }
+    }
+
+    /// Scale this shape. Returns `None` if the scale is non-uniform (not supported yet).
+    pub fn scaled(mut self, scale: &Vector<Real>) -> Option<Self> {
+        #[cfg(feature = "dim2")]
+        let scale_is_uniform = scale.x == scale.y;
+        #[cfg(feature = "dim3")]
+        let scale_is_uniform = scale.x == scale.y && scale.y == scale.z;
+        if !scale_is_uniform {
+            // TODO: what about non-uniform scale?
+            None
+        } else {
+            self.scale *= scale.x;
+            self.origin *= scale.x;
+            Some(self)
+        }
+    }
+
+    fn quantify_point(&self, pt: Point<Real>) -> Vector<u32> {
+        ((pt - self.origin) / self.scale).map(|x| x.floor().max(0.0) as u32)
+    }
+
+    pub fn voxels_intersecting_local_aabb(
+        &self,
+        aabb: &Aabb,
+    ) -> impl Iterator<Item = (Point<Real>, VoxelData)> + '_ {
+        let dims = Vector::from(self.dimensions);
+        let mins = ((aabb.mins - self.origin) / self.scale)
+            .map(|x| x.floor().max(0.0) as u32)
+            .inf(&dims);
+        let maxs = ((aabb.maxs - self.origin) / self.scale)
+            .map(|x| x.ceil().max(0.0) as u32)
+            .inf(&dims);
+
+        self.centers_range(mins.into(), maxs.into())
+    }
+
+    /// The center point of all the voxels in this shape (including empty ones).
+    ///
+    /// The voxel data associated to each center is provided to determine what kind of voxel
+    /// it is (and, in particular, if it is empty or full).
+    pub fn centers(&self) -> impl Iterator<Item = (Point<Real>, VoxelData)> + '_ {
+        self.centers_range([0; DIM], self.dimensions)
+    }
+
+    /// Splits this voxels shape into two subshapes.
+    ///
+    /// The first subshape contains all the voxels which centers are inside the `aabb`.
+    /// The second subshape contains all the remaining voxels.
+    pub fn split_with_box(&self, aabb: &Aabb) -> (Option<Self>, Option<Self>) {
+        // TODO: optimize this?
+        let mut in_box = vec![];
+        let mut rest = vec![];
+        for (center, voxel) in self.centers() {
+            if !voxel.is_empty() {
+                if aabb.contains_local_point(&center) {
+                    in_box.push(center);
+                } else {
+                    rest.push(center);
+                }
+            }
+        }
+
+        let in_box = if !in_box.is_empty() {
+            Some(Voxels::from_points(
+                self.primitive_geometry,
+                &in_box,
+                self.scale,
+            ))
+        } else {
+            None
+        };
+
+        let rest = if !rest.is_empty() {
+            Some(Voxels::from_points(
+                self.primitive_geometry,
+                &rest,
+                self.scale,
+            ))
+        } else {
+            None
+        };
+
+        (in_box, rest)
+    }
+
+    #[cfg(feature = "dim2")]
+    fn centers_range(
+        &self,
+        mins: [u32; DIM],
+        maxs: [u32; DIM],
+    ) -> impl Iterator<Item = (Point<Real>, VoxelData)> + '_ {
+        (mins[0]..maxs[0]).flat_map(move |ix| {
+            (mins[1]..maxs[1]).map(move |iy| {
+                let vid = self.linear_index([ix, iy]);
+                let center =
+                    self.origin + Vector::new(ix as Real + 0.5, iy as Real + 0.5) * self.scale;
+                (center, self.data[vid as usize])
+            })
+        })
+    }
+
+    #[cfg(feature = "dim3")]
+    fn centers_range(
+        &self,
+        mins: [u32; DIM],
+        maxs: [u32; DIM],
+    ) -> impl Iterator<Item = (Point<Real>, VoxelData)> + '_ {
+        (mins[0]..maxs[0]).flat_map(move |ix| {
+            (mins[1]..maxs[1]).flat_map(move |iy| {
+                (mins[2]..maxs[2]).map(move |iz| {
+                    let vid = self.linear_index([ix, iy, iz]);
+                    let center = self.origin
+                        + Vector::new(ix as Real + 0.5, iy as Real + 0.5, iz as Real + 0.5)
+                            * self.scale;
+                    (center, self.data[vid as usize])
+                })
+            })
+        })
+    }
+
+    #[cfg(feature = "dim2")]
+    fn linear_index(&self, voxel_id: [u32; DIM]) -> u32 {
+        voxel_id[0] + voxel_id[1] * self.dimensions[0]
+    }
+
+    #[cfg(feature = "dim3")]
+    fn linear_index(&self, voxel_id: [u32; DIM]) -> u32 {
+        voxel_id[0]
+            + voxel_id[1] * self.dimensions[0]
+            + voxel_id[2] * self.dimensions[0] * self.dimensions[1]
+    }
+
+    #[cfg(feature = "dim2")]
+    fn to_key(&self, linear_index: u32) -> [u32; DIM] {
+        let y = linear_index / self.dimensions[0];
+        let x = linear_index % self.dimensions[0];
+        [x, y]
+    }
+
+    #[cfg(feature = "dim3")]
+    fn to_key(&self, linear_index: u32) -> [u32; DIM] {
+        let d0d1 = self.dimensions[0] * self.dimensions[1];
+        let z = linear_index / d0d1;
+        let y = (linear_index - z * d0d1) / self.dimensions[0];
+        let x = linear_index % self.dimensions[0];
+        [x, y, z]
+    }
+
+    fn compute_voxel_data(&self, key: [u32; DIM]) -> VoxelData {
+        if self.data[self.linear_index(key) as usize].is_empty() {
+            return VoxelData::EMPTY;
+        }
+
+        let mut occupied_faces = 0;
+
+        for k in 0..DIM {
+            let (mut prev, mut next) = (key, key);
+            prev[k] = prev[k].saturating_sub(1);
+            next[k] += 1;
+
+            if key[k] < self.dimensions[k] - 1
+                && !self.data[self.linear_index(next) as usize].is_empty()
+            {
+                occupied_faces |= 1 << (k * 2);
+            }
+            if key[k] > 0 && !self.data[self.linear_index(prev) as usize].is_empty() {
+                occupied_faces |= 1 << (k * 2 + 1);
+            }
+        }
+
+        VoxelData(occupied_faces)
+    }
+}
+
+// NOTE: this code is used to generate the constant tables
+// FACES_TO_VOXEL_TYPES, FACES_TO_FEATURE_MASKS, FACES_TO_OCTANT_MASKS.
+#[allow(dead_code)]
+#[cfg(feature = "dim2")]
+fn gen_const_tables() {
+    // The `j-th` bit of `faces_adj_to_vtx[i]` is set to 1, if the j-th face of the AABB (based on
+    // the face order depicted in `AABB::FACES_VERTEX_IDS`) is adjacent to the `i` vertex of the AABB
+    // (vertices are indexed as per the diagram depicted in the `FACES_VERTEX_IDS` doc.
+    // Each entry of this will always have exactly 3 bits set.
+    let mut faces_adj_to_vtx = [0usize; 4];
+
+    for fid in 0..4 {
+        let vids = Aabb::FACES_VERTEX_IDS[fid];
+        let key = 1 << fid;
+        faces_adj_to_vtx[vids.0] |= key;
+        faces_adj_to_vtx[vids.1] |= key;
+    }
+
+    /*
+     * FACES_TO_VOXEL_TYPES
+     */
+    println!("const FACES_TO_VOXEL_TYPES: [VoxelType; 17] = [");
+    'outer: for i in 0usize..16 {
+        // If any vertex of the voxel has three faces with no adjacent voxels,
+        // then the voxel type is Vertex.
+        for adjs in faces_adj_to_vtx.iter() {
+            if (*adjs & i) == 0 {
+                println!("VoxelType::Vertex,");
+                continue 'outer;
+            }
+        }
+
+        // If one face doesn’t have any adjacent voxel,
+        // then the voxel type is Face.
+        for fid in 0..4 {
+            if ((1 << fid) & i) == 0 {
+                println!("VoxelType::Face,");
+                continue 'outer;
+            }
+        }
+    }
+
+    // Add final entries for special values.
+    println!("VoxelType::Interior,");
+    println!("VoxelType::Empty,");
+    println!("];");
+
+    /*
+     * FACES_TO_FEATURE_MASKS
+     */
+    println!("const FACES_TO_FEATURE_MASKS: [u16; 17] = [");
+    for i in 0usize..16 {
+        // Each bit set indicates a convex vertex that can lead to collisions.
+        // The result will be nonzero only for `VoxelType::Vertex` voxels.
+        let mut vtx_key = 0;
+        for (vid, adjs) in faces_adj_to_vtx.iter().enumerate() {
+            if (*adjs & i) == 0 {
+                vtx_key |= 1 << vid;
+            }
+        }
+
+        if vtx_key != 0 {
+            println!("0b{:b},", vtx_key as u16);
+            continue;
+        }
+
+        // Each bit set indicates an exposed face that can lead to collisions.
+        // The result will be nonzero only for `VoxelType::Face` voxels.
+        let mut face_key = 0;
+        for fid in 0..4 {
+            if ((1 << fid) & i) == 0 {
+                face_key |= 1 << fid;
+            }
+        }
+
+        if face_key != 0 {
+            println!("0b{:b},", face_key as u16);
+            continue;
+        }
+    }
+
+    println!("0b{:b},", u16::MAX);
+    println!("0,");
+    println!("];");
+
+    /*
+     * Faces to octant masks.
+     */
+    println!("const FACES_TO_OCTANT_MASKS: [u32; 17] = [");
+    for i in 0usize..16 {
+        // First test if we have vertices.
+        let mut octant_mask = 0;
+        let mut set_mask = |mask, octant| {
+            // NOTE: we don’t overwrite any mask already set for the octant.
+            if (octant_mask >> (octant * 3)) & 0b0111 == 0 {
+                octant_mask |= mask << (octant * 3);
+            }
+        };
+
+        for (vid, adjs) in faces_adj_to_vtx.iter().enumerate() {
+            if (*adjs & i) == 0 {
+                set_mask(1, vid);
+            }
+        }
+
+        // This is the index of the normal of the faces given by
+        // Aabb::FACES_VERTEX_IDS.
+        const FX: u32 = OctantPattern::FACE_X;
+        const FY: u32 = OctantPattern::FACE_Y;
+        const FACE_NORMALS: [u32; 4] = [FX, FX, FY, FY];
+        for fid in 0..4 {
+            if ((1 << fid) & i) == 0 {
+                let vid = Aabb::FACES_VERTEX_IDS[fid];
+                let mask = FACE_NORMALS[fid];
+
+                set_mask(mask, vid.0);
+                set_mask(mask, vid.1);
+            }
+        }
+        println!("0b{:b},", octant_mask);
+    }
+    println!("0,");
+    println!("];");
+}
+
+// NOTE: this code is used to generate the constant tables
+// FACES_TO_VOXEL_TYPES, FACES_TO_FEATURE_MASKS, FACES_TO_OCTANT_MASKS.
+#[allow(dead_code)]
+#[cfg(feature = "dim3")]
+fn gen_const_tables() {
+    // The `j-th` bit of `faces_adj_to_vtx[i]` is set to 1, if the j-th face of the AABB (based on
+    // the face order depicted in `AABB::FACES_VERTEX_IDS`) is adjacent to the `i` vertex of the AABB
+    // (vertices are indexed as per the diagram depicted in the `FACES_VERTEX_IDS` doc.
+    // Each entry of this will always have exactly 3 bits set.
+    let mut faces_adj_to_vtx = [0usize; 8];
+
+    // The `j-th` bit of `faces_adj_to_vtx[i]` is set to 1, if the j-th edge of the AABB (based on
+    // the edge order depicted in `AABB::EDGES_VERTEX_IDS`) is adjacent to the `i` vertex of the AABB
+    // (vertices are indexed as per the diagram depicted in the `FACES_VERTEX_IDS` doc.
+    // Each entry of this will always have exactly 2 bits set.
+    let mut faces_adj_to_edge = [0usize; 12];
+
+    for fid in 0..6 {
+        let vids = Aabb::FACES_VERTEX_IDS[fid];
+        let key = 1 << fid;
+        faces_adj_to_vtx[vids.0] |= key;
+        faces_adj_to_vtx[vids.1] |= key;
+        faces_adj_to_vtx[vids.2] |= key;
+        faces_adj_to_vtx[vids.3] |= key;
+    }
+
+    for eid in 0..12 {
+        let evids = Aabb::EDGES_VERTEX_IDS[eid];
+        for fid in 0..6 {
+            let fvids = Aabb::FACES_VERTEX_IDS[fid];
+            if (fvids.0 == evids.0
+                || fvids.1 == evids.0
+                || fvids.2 == evids.0
+                || fvids.3 == evids.0)
+                && (fvids.0 == evids.1
+                    || fvids.1 == evids.1
+                    || fvids.2 == evids.1
+                    || fvids.3 == evids.1)
+            {
+                let key = 1 << fid;
+                faces_adj_to_edge[eid] |= key;
+            }
+        }
+    }
+
+    /*
+     * FACES_TO_VOXEL_TYPES
+     */
+    println!("const FACES_TO_VOXEL_TYPES: [VoxelType; 65] = [");
+    'outer: for i in 0usize..64 {
+        // If any vertex of the voxel has three faces with no adjacent voxels,
+        // then the voxel type is Vertex.
+        for adjs in faces_adj_to_vtx.iter() {
+            if (*adjs & i) == 0 {
+                println!("VoxelType::Vertex,");
+                continue 'outer;
+            }
+        }
+
+        // If any vertex of the voxel has three faces with no adjacent voxels,
+        // then the voxel type is Edge.
+        for adjs in faces_adj_to_edge.iter() {
+            if (*adjs & i) == 0 {
+                println!("VoxelType::Edge,");
+                continue 'outer;
+            }
+        }
+
+        // If one face doesn’t have any adjacent voxel,
+        // then the voxel type is Face.
+        for fid in 0..6 {
+            if ((1 << fid) & i) == 0 {
+                println!("VoxelType::Face,");
+                continue 'outer;
+            }
+        }
+    }
+
+    // Add final entries for special values.
+    println!("VoxelType::Interior,");
+    println!("VoxelType::Empty,");
+    println!("];");
+
+    /*
+     * FACES_TO_FEATURE_MASKS
+     */
+    println!("const FACES_TO_FEATURE_MASKS: [u16; 65] = [");
+    for i in 0usize..64 {
+        // Each bit set indicates a convex vertex that can lead to collisions.
+        // The result will be nonzero only for `VoxelType::Vertex` voxels.
+        let mut vtx_key = 0;
+        for (vid, adjs) in faces_adj_to_vtx.iter().enumerate() {
+            if (*adjs & i) == 0 {
+                vtx_key |= 1 << vid;
+            }
+        }
+
+        if vtx_key != 0 {
+            println!("0b{:b},", vtx_key as u16);
+            continue;
+        }
+
+        // Each bit set indicates a convex edge that can lead to collisions.
+        // The result will be nonzero only for `VoxelType::Edge` voxels.
+        let mut edge_key = 0;
+        for (eid, adjs) in faces_adj_to_edge.iter().enumerate() {
+            if (*adjs & i) == 0 {
+                edge_key |= 1 << eid;
+            }
+        }
+
+        if edge_key != 0 {
+            println!("0b{:b},", edge_key as u16);
+            continue;
+        }
+
+        // Each bit set indicates an exposed face that can lead to collisions.
+        // The result will be nonzero only for `VoxelType::Face` voxels.
+        let mut face_key = 0;
+        for fid in 0..6 {
+            if ((1 << fid) & i) == 0 {
+                face_key |= 1 << fid;
+            }
+        }
+
+        if face_key != 0 {
+            println!("0b{:b},", face_key as u16);
+            continue;
+        }
+    }
+
+    println!("0b{:b},", u16::MAX);
+    println!("0,");
+    println!("];");
+
+    /*
+     * Faces to octant masks.
+     */
+    println!("const FACES_TO_OCTANT_MASKS: [u32; 65] = [");
+    for i in 0usize..64 {
+        // First test if we have vertices.
+        let mut octant_mask = 0;
+        let mut set_mask = |mask, octant| {
+            // NOTE: we don’t overwrite any mask already set for the octant.
+            if (octant_mask >> (octant * 3)) & 0b0111 == 0 {
+                octant_mask |= mask << (octant * 3);
+            }
+        };
+
+        for (vid, adjs) in faces_adj_to_vtx.iter().enumerate() {
+            if (*adjs & i) == 0 {
+                set_mask(1, vid);
+            }
+        }
+
+        // This is the index of the axis porting the edges given by
+        // Aabb::EDGES_VERTEX_IDS.
+        const EX: u32 = OctantPattern::EDGE_X;
+        const EY: u32 = OctantPattern::EDGE_Y;
+        const EZ: u32 = OctantPattern::EDGE_Z;
+        const EDGE_AXIS: [u32; 12] = [EX, EY, EX, EY, EX, EY, EX, EY, EZ, EZ, EZ, EZ];
+        for (eid, adjs) in faces_adj_to_edge.iter().enumerate() {
+            if (*adjs & i) == 0 {
+                let vid = Aabb::EDGES_VERTEX_IDS[eid];
+                let mask = EDGE_AXIS[eid];
+
+                set_mask(mask, vid.0);
+                set_mask(mask, vid.1);
+            }
+        }
+
+        // This is the index of the normal of the faces given by
+        // Aabb::FACES_VERTEX_IDS.
+        const FX: u32 = OctantPattern::FACE_X;
+        const FY: u32 = OctantPattern::FACE_Y;
+        const FZ: u32 = OctantPattern::FACE_Z;
+        const FACE_NORMALS: [u32; 6] = [FX, FX, FY, FY, FZ, FZ];
+        for fid in 0..6 {
+            if ((1 << fid) & i) == 0 {
+                let vid = Aabb::FACES_VERTEX_IDS[fid];
+                let mask = FACE_NORMALS[fid];
+
+                set_mask(mask, vid.0);
+                set_mask(mask, vid.1);
+                set_mask(mask, vid.2);
+                set_mask(mask, vid.3);
+            }
+        }
+        println!("0b{:b},", octant_mask);
+    }
+    println!("0,");
+    println!("];");
+}
+
+// Index to the item of FACES_TO_VOXEL_TYPES which identifies interior voxels.
+#[cfg(feature = "dim2")]
+const INTERIOR_FACE_MASK: u8 = 0b0000_1111;
+#[cfg(feature = "dim3")]
+const INTERIOR_FACE_MASK: u8 = 0b0011_1111;
+// Index to the item of FACES_TO_VOXEL_TYPES which identifies empty voxels.
+
+#[cfg(feature = "dim2")]
+const EMPTY_FACE_MASK: u8 = 0b0001_0000;
+#[cfg(feature = "dim3")]
+const EMPTY_FACE_MASK: u8 = 0b0100_0000;
+
+/// The voxel type deduced from adjacency information.
+///
+/// See the documentation of [`VoxelType`] for additional information on what each enum variant
+/// means.
+///
+/// In 3D there are 6 neighbor faces => 64 cases + 1 empty case.
+#[cfg(feature = "dim3")]
+const FACES_TO_VOXEL_TYPES: [VoxelType; 65] = [
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Edge,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Edge,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Face,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Edge,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Edge,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Face,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Edge,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Edge,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Face,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Face,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Face,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Edge,
+    VoxelType::Face,
+    VoxelType::Face,
+    VoxelType::Face,
+    VoxelType::Face,
+    VoxelType::Interior,
+    VoxelType::Empty,
+];
+
+/// Indicates the convex features of each voxel that can lead to collisions.
+///
+/// The interpretation of each bit differs depending on the corresponding voxel type in
+/// `FACES_TO_VOXEL_TYPES`:
+/// - For `VoxelType::Vertex`: the i-th bit set to `1` indicates that the i-th AABB vertex is convex
+///                            and might lead to collisions.
+/// - For `VoxelType::Edge`: the i-th bit set to `1` indicates that the i-th edge from `Aabb::EDGES_VERTEX_IDS`
+///                          is convex and might lead to collisions.
+/// - For `VoxelType::Face`: the i-th bit set to `1` indicates that the i-th face from `Aabb::FACES_VERTEX_IDS`
+///                          is exposed and might lead to collisions.
+#[cfg(feature = "dim3")]
+const FACES_TO_FEATURE_MASKS: [u16; 65] = [
+    0b11111111,
+    0b10011001,
+    0b1100110,
+    0b1010101,
+    0b110011,
+    0b10001,
+    0b100010,
+    0b10001,
+    0b11001100,
+    0b10001000,
+    0b1000100,
+    0b1000100,
+    0b10101010,
+    0b10001000,
+    0b100010,
+    0b110000,
+    0b1111,
+    0b1001,
+    0b110,
+    0b101,
+    0b11,
+    0b1,
+    0b10,
+    0b1,
+    0b1100,
+    0b1000,
+    0b100,
+    0b100,
+    0b1010,
+    0b1000,
+    0b10,
+    0b100000,
+    0b11110000,
+    0b10010000,
+    0b1100000,
+    0b1010000,
+    0b110000,
+    0b10000,
+    0b100000,
+    0b10000,
+    0b11000000,
+    0b10000000,
+    0b1000000,
+    0b1000000,
+    0b10100000,
+    0b10000000,
+    0b100000,
+    0b10000,
+    0b111100000000,
+    0b100100000000,
+    0b11000000000,
+    0b1100,
+    0b1100000000,
+    0b100000000,
+    0b1000000000,
+    0b1000,
+    0b110000000000,
+    0b100000000000,
+    0b10000000000,
+    0b100,
+    0b11,
+    0b10,
+    0b1,
+    0b1111111111111111,
+    0,
+];
+
+/// Each octant is assigned three contiguous bits.
+#[cfg(feature = "dim3")]
+const FACES_TO_OCTANT_MASKS: [u32; 65] = [
+    0b1001001001001001001001,
+    0b1010010001001010010001,
+    0b10001001010010001001010,
+    0b10010010010010010010010,
+    0b11011001001011011001001,
+    0b11111010001011111010001,
+    0b111011001010111011001010,
+    0b111111010010111111010010,
+    0b1001011011001001011011,
+    0b1010111011001010111011,
+    0b10001011111010001011111,
+    0b10010111111010010111111,
+    0b11011011011011011011011,
+    0b11111111011011111111011,
+    0b111011011111111011011111,
+    0b111111111111111111111111,
+    0b100100100100001001001001,
+    0b100110110100001010010001,
+    0b110100100110010001001010,
+    0b110110110110010010010010,
+    0b101101100100011011001001,
+    0b101000110100011111010001,
+    0b101100110111011001010,
+    0b110110111111010010,
+    0b100100101101001001011011,
+    0b100110000101001010111011,
+    0b110100101000010001011111,
+    0b110110000000010010111111,
+    0b101101101101011011011011,
+    0b101000000101011111111011,
+    0b101101000111011011111,
+    0b111111111111,
+    0b1001001001100100100100,
+    0b1010010001100110110100,
+    0b10001001010110100100110,
+    0b10010010010110110110110,
+    0b11011001001101101100100,
+    0b11111010001101000110100,
+    0b111011001010000101100110,
+    0b111111010010000000110110,
+    0b1001011011100100101101,
+    0b1010111011100110000101,
+    0b10001011111110100101000,
+    0b10010111111110110000000,
+    0b11011011011101101101101,
+    0b11111111011101000000101,
+    0b111011011111000101101000,
+    0b111111111111000000000000,
+    0b100100100100100100100100,
+    0b100110110100100110110100,
+    0b110100100110110100100110,
+    0b110110110110110110110110,
+    0b101101100100101101100100,
+    0b101000110100101000110100,
+    0b101100110000101100110,
+    0b110110000000110110,
+    0b100100101101100100101101,
+    0b100110000101100110000101,
+    0b110100101000110100101000,
+    0b110110000000110110000000,
+    0b101101101101101101101101,
+    0b101000000101101000000101,
+    0b101101000000101101000,
+    0b0,
+    0,
+];
+
+#[cfg(feature = "dim2")]
+const FACES_TO_VOXEL_TYPES: [VoxelType; 17] = [
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Face,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Face,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Vertex,
+    VoxelType::Face,
+    VoxelType::Face,
+    VoxelType::Face,
+    VoxelType::Face,
+    VoxelType::Interior,
+    VoxelType::Empty,
+];
+
+#[cfg(feature = "dim2")]
+const FACES_TO_FEATURE_MASKS: [u16; 17] = [
+    0b1111,
+    0b1001,
+    0b110,
+    0b1100,
+    0b11,
+    0b1,
+    0b10,
+    0b1000,
+    0b1100,
+    0b1000,
+    0b100,
+    0b100,
+    0b11,
+    0b10,
+    0b1,
+    0b1111111111111111,
+    0,
+];
+
+// NOTE: in 2D we are also using 3 bits per octant even though we technically only need two.
+//       This keeps some collision-detection easier by avoiding some special-casing.
+#[cfg(feature = "dim2")]
+const FACES_TO_OCTANT_MASKS: [u32; 17] = [
+    0b1001001001,
+    0b1011011001,
+    0b11001001011,
+    0b11011011011,
+    0b10010001001,
+    0b10000011001,
+    0b10001011,
+    0b11011,
+    0b1001010010,
+    0b1011000010,
+    0b11001010000,
+    0b11011000000,
+    0b10010010010,
+    0b10000000010,
+    0b10010000,
+    0b0,
+    0,
+];
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn gen_const_tables() {
+        super::gen_const_tables();
+    }
+}

--- a/src/shape/voxels.rs
+++ b/src/shape/voxels.rs
@@ -801,13 +801,13 @@ fn gen_const_tables() {
     /*
      * FACES_TO_VOXEL_TYPES
      */
-    println!("const FACES_TO_VOXEL_TYPES: [VoxelType; 17] = [");
+    std::println!("const FACES_TO_VOXEL_TYPES: [VoxelType; 17] = [");
     'outer: for i in 0usize..16 {
         // If any vertex of the voxel has three faces with no adjacent voxels,
         // then the voxel type is Vertex.
         for adjs in faces_adj_to_vtx.iter() {
             if (*adjs & i) == 0 {
-                println!("VoxelType::Vertex,");
+                std::println!("VoxelType::Vertex,");
                 continue 'outer;
             }
         }
@@ -816,21 +816,21 @@ fn gen_const_tables() {
         // then the voxel type is Face.
         for fid in 0..4 {
             if ((1 << fid) & i) == 0 {
-                println!("VoxelType::Face,");
+                std::println!("VoxelType::Face,");
                 continue 'outer;
             }
         }
     }
 
     // Add final entries for special values.
-    println!("VoxelType::Interior,");
-    println!("VoxelType::Empty,");
-    println!("];");
+    std::println!("VoxelType::Interior,");
+    std::println!("VoxelType::Empty,");
+    std::println!("];");
 
     /*
      * FACES_TO_FEATURE_MASKS
      */
-    println!("const FACES_TO_FEATURE_MASKS: [u16; 17] = [");
+    std::println!("const FACES_TO_FEATURE_MASKS: [u16; 17] = [");
     for i in 0usize..16 {
         // Each bit set indicates a convex vertex that can lead to collisions.
         // The result will be nonzero only for `VoxelType::Vertex` voxels.
@@ -842,7 +842,7 @@ fn gen_const_tables() {
         }
 
         if vtx_key != 0 {
-            println!("0b{:b},", vtx_key as u16);
+            std::println!("0b{:b},", vtx_key as u16);
             continue;
         }
 
@@ -856,19 +856,19 @@ fn gen_const_tables() {
         }
 
         if face_key != 0 {
-            println!("0b{:b},", face_key as u16);
+            std::println!("0b{:b},", face_key as u16);
             continue;
         }
     }
 
-    println!("0b{:b},", u16::MAX);
-    println!("0,");
-    println!("];");
+    std::println!("0b{:b},", u16::MAX);
+    std::println!("0,");
+    std::println!("];");
 
     /*
      * Faces to octant masks.
      */
-    println!("const FACES_TO_OCTANT_MASKS: [u32; 17] = [");
+    std::println!("const FACES_TO_OCTANT_MASKS: [u32; 17] = [");
     for i in 0usize..16 {
         // First test if we have vertices.
         let mut octant_mask = 0;
@@ -901,10 +901,10 @@ fn gen_const_tables() {
                 set_mask(mask, vid.1);
             }
         }
-        println!("0b{:b},", octant_mask);
+        std::println!("0b{:b},", octant_mask);
     }
-    println!("0,");
-    println!("];");
+    std::println!("0,");
+    std::println!("];");
 }
 
 // NOTE: this code is used to generate the constant tables
@@ -957,13 +957,13 @@ fn gen_const_tables() {
     /*
      * FACES_TO_VOXEL_TYPES
      */
-    println!("const FACES_TO_VOXEL_TYPES: [VoxelType; 65] = [");
+    std::println!("const FACES_TO_VOXEL_TYPES: [VoxelType; 65] = [");
     'outer: for i in 0usize..64 {
         // If any vertex of the voxel has three faces with no adjacent voxels,
         // then the voxel type is Vertex.
         for adjs in faces_adj_to_vtx.iter() {
             if (*adjs & i) == 0 {
-                println!("VoxelType::Vertex,");
+                std::println!("VoxelType::Vertex,");
                 continue 'outer;
             }
         }
@@ -972,7 +972,7 @@ fn gen_const_tables() {
         // then the voxel type is Edge.
         for adjs in faces_adj_to_edge.iter() {
             if (*adjs & i) == 0 {
-                println!("VoxelType::Edge,");
+                std::println!("VoxelType::Edge,");
                 continue 'outer;
             }
         }
@@ -981,21 +981,21 @@ fn gen_const_tables() {
         // then the voxel type is Face.
         for fid in 0..6 {
             if ((1 << fid) & i) == 0 {
-                println!("VoxelType::Face,");
+                std::println!("VoxelType::Face,");
                 continue 'outer;
             }
         }
     }
 
     // Add final entries for special values.
-    println!("VoxelType::Interior,");
-    println!("VoxelType::Empty,");
-    println!("];");
+    std::println!("VoxelType::Interior,");
+    std::println!("VoxelType::Empty,");
+    std::println!("];");
 
     /*
      * FACES_TO_FEATURE_MASKS
      */
-    println!("const FACES_TO_FEATURE_MASKS: [u16; 65] = [");
+    std::println!("const FACES_TO_FEATURE_MASKS: [u16; 65] = [");
     for i in 0usize..64 {
         // Each bit set indicates a convex vertex that can lead to collisions.
         // The result will be nonzero only for `VoxelType::Vertex` voxels.
@@ -1007,7 +1007,7 @@ fn gen_const_tables() {
         }
 
         if vtx_key != 0 {
-            println!("0b{:b},", vtx_key as u16);
+            std::println!("0b{:b},", vtx_key as u16);
             continue;
         }
 
@@ -1021,7 +1021,7 @@ fn gen_const_tables() {
         }
 
         if edge_key != 0 {
-            println!("0b{:b},", edge_key as u16);
+            std::println!("0b{:b},", edge_key as u16);
             continue;
         }
 
@@ -1035,19 +1035,19 @@ fn gen_const_tables() {
         }
 
         if face_key != 0 {
-            println!("0b{:b},", face_key as u16);
+            std::println!("0b{:b},", face_key as u16);
             continue;
         }
     }
 
-    println!("0b{:b},", u16::MAX);
-    println!("0,");
-    println!("];");
+    std::println!("0b{:b},", u16::MAX);
+    std::println!("0,");
+    std::println!("];");
 
     /*
      * Faces to octant masks.
      */
-    println!("const FACES_TO_OCTANT_MASKS: [u32; 65] = [");
+    std::println!("const FACES_TO_OCTANT_MASKS: [u32; 65] = [");
     for i in 0usize..64 {
         // First test if we have vertices.
         let mut octant_mask = 0;
@@ -1099,10 +1099,10 @@ fn gen_const_tables() {
                 set_mask(mask, vid.3);
             }
         }
-        println!("0b{:b},", octant_mask);
+        std::println!("0b{:b},", octant_mask);
     }
-    println!("0,");
-    println!("];");
+    std::println!("0,");
+    std::println!("];");
 }
 
 // Index to the item of FACES_TO_VOXEL_TYPES which identifies interior voxels.
@@ -1197,11 +1197,11 @@ const FACES_TO_VOXEL_TYPES: [VoxelType; 65] = [
 /// The interpretation of each bit differs depending on the corresponding voxel type in
 /// `FACES_TO_VOXEL_TYPES`:
 /// - For `VoxelType::Vertex`: the i-th bit set to `1` indicates that the i-th AABB vertex is convex
-///                            and might lead to collisions.
+///   and might lead to collisions.
 /// - For `VoxelType::Edge`: the i-th bit set to `1` indicates that the i-th edge from `Aabb::EDGES_VERTEX_IDS`
-///                          is convex and might lead to collisions.
+///   is convex and might lead to collisions.
 /// - For `VoxelType::Face`: the i-th bit set to `1` indicates that the i-th face from `Aabb::FACES_VERTEX_IDS`
-///                          is exposed and might lead to collisions.
+///   is exposed and might lead to collisions.
 #[cfg(feature = "dim3")]
 const FACES_TO_FEATURE_MASKS: [u16; 65] = [
     0b11111111,

--- a/src/transformation/to_outline/mod.rs
+++ b/src/transformation/to_outline/mod.rs
@@ -8,5 +8,6 @@ mod round_cone_to_outline;
 mod round_convex_polyhedron_to_outline;
 mod round_cuboid_to_outline;
 mod round_cylinder_to_outline;
+mod voxels_to_outline;
 // mod round_triangle_to_outline;
 // mod heightfield_to_outline;

--- a/src/transformation/to_outline/voxels_to_outline.rs
+++ b/src/transformation/to_outline/voxels_to_outline.rs
@@ -1,0 +1,88 @@
+use crate::bounding_volume::Aabb;
+use crate::math::{Point, Real, Vector};
+use crate::shape::{VoxelType, Voxels};
+use crate::transformation::utils;
+use na::{self, Point3, Vector3};
+
+impl Voxels {
+    pub fn to_outline(&self) -> (Vec<Point<Real>>, Vec<[u32; 2]>) {
+        let mut points = vec![];
+        self.iter_outline(|a, b| {
+            points.push(a);
+            points.push(b);
+        });
+        let indices = (0..points.len() as u32 / 2)
+            .map(|i| [i * 2, i * 2 + 1])
+            .collect();
+        (points, indices)
+    }
+
+    /// Outlines this voxels shape using polylines.
+    pub fn iter_outline(&self, mut f: impl FnMut(Point<Real>, Point<Real>)) {
+        // TODO: move this as a new method: Voxels::to_outline?
+        let radius = self.voxel_size() / 2.0;
+        let aabb = Aabb::from_half_extents(Point::origin(), Vector::repeat(radius));
+        let vtx = aabb.vertices();
+
+        /*
+        let aabb_oct = Aabb::from_half_extents(Point::origin(), Vector::repeat(radius / 2.0));
+        let vtx_oct = aabb_oct.vertices();
+
+        for (center, vox_data) in self.centers() {
+            for k in 0..8 {
+                let mask = (vox_data.octant_mask() >> (3 * k)) & 0b0111;
+                match mask {
+                    OctantPattern::EDGE_X | OctantPattern::EDGE_Y | OctantPattern::EDGE_Z => {
+                        let i = mask - OctantPattern::EDGE_X;
+                        let axis = Vector::ith(i as usize, 1.0);
+                        f(
+                            center + vtx_oct[k].coords + axis * radius / 2.0,
+                            center + vtx_oct[k].coords - axis * radius / 2.0,
+                        );
+                    }
+                    _ => {}
+                }
+            }
+
+            for (i, edge) in Aabb::EDGES_VERTEX_IDS.iter().enumerate() {
+                let mask0 = (vox_data.octant_mask() >> (3 * edge.0)) & 0b0111;
+                let mask1 = (vox_data.octant_mask() >> (3 * edge.1)) & 0b0111;
+                let mid = na::center(&vtx_oct[edge.0], &vtx_oct[edge.1]);
+
+                if mask0 == OctantPattern::VERTEX {
+                    f(center + vtx_oct[edge.0].coords, center + mid.coords);
+                }
+
+                if mask1 == OctantPattern::VERTEX {
+                    f(center + mid.coords, center + vtx_oct[edge.1].coords);
+                }
+            }
+        }
+        */
+
+        for (center, vox_data) in self.centers() {
+            match vox_data.voxel_type() {
+                VoxelType::Vertex => {
+                    let mask = vox_data.feature_mask();
+
+                    for edge in Aabb::EDGES_VERTEX_IDS {
+                        if mask & (1 << edge.0) != 0 || mask & (1 << edge.1) != 0 {
+                            f(center + vtx[edge.0].coords, center + vtx[edge.1].coords);
+                        }
+                    }
+                }
+                VoxelType::Edge => {
+                    let vtx = aabb.vertices();
+                    let mask = vox_data.feature_mask();
+
+                    for (i, edge) in Aabb::EDGES_VERTEX_IDS.iter().enumerate() {
+                        if mask & (1 << i) != 0 {
+                            f(center + vtx[edge.0].coords, center + vtx[edge.1].coords);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/src/transformation/to_outline/voxels_to_outline.rs
+++ b/src/transformation/to_outline/voxels_to_outline.rs
@@ -1,10 +1,11 @@
 use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 use crate::shape::{VoxelType, Voxels};
-use crate::transformation::utils;
-use na::{self, Point3, Vector3};
 
 impl Voxels {
+    /// Outlines this voxels shape as a set of polylines.
+    ///
+    /// The outline is such that only convex edges are output in the polyline.
     pub fn to_outline(&self) -> (Vec<Point<Real>>, Vec<[u32; 2]>) {
         let mut points = vec![];
         self.iter_outline(|a, b| {
@@ -17,7 +18,9 @@ impl Voxels {
         (points, indices)
     }
 
-    /// Outlines this voxels shape using polylines.
+    /// Outlines this voxels shape using segments.
+    ///
+    /// The outline is such that only convex edges are output in the polyline.
     pub fn iter_outline(&self, mut f: impl FnMut(Point<Real>, Point<Real>)) {
         // TODO: move this as a new method: Voxels::to_outline?
         let radius = self.voxel_size() / 2.0;

--- a/src/transformation/to_outline/voxels_to_outline.rs
+++ b/src/transformation/to_outline/voxels_to_outline.rs
@@ -1,6 +1,7 @@
 use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 use crate::shape::{VoxelType, Voxels};
+use alloc::{vec, vec::Vec};
 
 impl Voxels {
     /// Outlines this voxels shape as a set of polylines.

--- a/src/transformation/to_outline/voxels_to_outline.rs
+++ b/src/transformation/to_outline/voxels_to_outline.rs
@@ -60,7 +60,7 @@ impl Voxels {
         }
         */
 
-        for (center, vox_data) in self.centers() {
+        for (_, center, vox_data) in self.centers() {
             match vox_data.voxel_type() {
                 VoxelType::Vertex => {
                     let mask = vox_data.feature_mask();

--- a/src/transformation/to_outline/voxels_to_outline.rs
+++ b/src/transformation/to_outline/voxels_to_outline.rs
@@ -1,5 +1,5 @@
 use crate::bounding_volume::Aabb;
-use crate::math::{Point, Real, Vector};
+use crate::math::{Point, Real};
 use crate::shape::{VoxelType, Voxels};
 use alloc::{vec, vec::Vec};
 
@@ -25,44 +25,8 @@ impl Voxels {
     pub fn iter_outline(&self, mut f: impl FnMut(Point<Real>, Point<Real>)) {
         // TODO: move this as a new method: Voxels::to_outline?
         let radius = self.voxel_size() / 2.0;
-        let aabb = Aabb::from_half_extents(Point::origin(), Vector::repeat(radius));
+        let aabb = Aabb::from_half_extents(Point::origin(), radius);
         let vtx = aabb.vertices();
-
-        /*
-        let aabb_oct = Aabb::from_half_extents(Point::origin(), Vector::repeat(radius / 2.0));
-        let vtx_oct = aabb_oct.vertices();
-
-        for (center, vox_data) in self.centers() {
-            for k in 0..8 {
-                let mask = (vox_data.octant_mask() >> (3 * k)) & 0b0111;
-                match mask {
-                    OctantPattern::EDGE_X | OctantPattern::EDGE_Y | OctantPattern::EDGE_Z => {
-                        let i = mask - OctantPattern::EDGE_X;
-                        let axis = Vector::ith(i as usize, 1.0);
-                        f(
-                            center + vtx_oct[k].coords + axis * radius / 2.0,
-                            center + vtx_oct[k].coords - axis * radius / 2.0,
-                        );
-                    }
-                    _ => {}
-                }
-            }
-
-            for (i, edge) in Aabb::EDGES_VERTEX_IDS.iter().enumerate() {
-                let mask0 = (vox_data.octant_mask() >> (3 * edge.0)) & 0b0111;
-                let mask1 = (vox_data.octant_mask() >> (3 * edge.1)) & 0b0111;
-                let mid = na::center(&vtx_oct[edge.0], &vtx_oct[edge.1]);
-
-                if mask0 == OctantPattern::VERTEX {
-                    f(center + vtx_oct[edge.0].coords, center + mid.coords);
-                }
-
-                if mask1 == OctantPattern::VERTEX {
-                    f(center + mid.coords, center + vtx_oct[edge.1].coords);
-                }
-            }
-        }
-        */
 
         for (_, center, vox_data) in self.centers() {
             match vox_data.voxel_type() {

--- a/src/transformation/to_polyline/mod.rs
+++ b/src/transformation/to_polyline/mod.rs
@@ -4,3 +4,4 @@ mod cuboid_to_polyline;
 mod heightfield_to_polyline;
 mod round_convex_polygon_to_polyline;
 mod round_cuboid_to_polyline;
+mod voxels_to_polyline;

--- a/src/transformation/to_polyline/voxels_to_polyline.rs
+++ b/src/transformation/to_polyline/voxels_to_polyline.rs
@@ -24,7 +24,7 @@ impl Voxels {
         let aabb = Aabb::from_half_extents(Point::origin(), Vector::repeat(radius));
         let vtx = aabb.vertices();
 
-        for (center, vox_data) in self.centers() {
+        for (_, center, vox_data) in self.centers() {
             match vox_data.voxel_type() {
                 VoxelType::Vertex => {
                     let mask = vox_data.feature_mask();

--- a/src/transformation/to_polyline/voxels_to_polyline.rs
+++ b/src/transformation/to_polyline/voxels_to_polyline.rs
@@ -1,6 +1,7 @@
 use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 use crate::shape::{VoxelType, Voxels};
+use alloc::{vec, vec::Vec};
 use na::{self, Point2};
 
 impl Voxels {

--- a/src/transformation/to_polyline/voxels_to_polyline.rs
+++ b/src/transformation/to_polyline/voxels_to_polyline.rs
@@ -1,5 +1,5 @@
 use crate::bounding_volume::Aabb;
-use crate::math::{Point, Real, Vector};
+use crate::math::{Point, Real};
 use crate::shape::{VoxelType, Voxels};
 use alloc::{vec, vec::Vec};
 use na::{self, Point2};
@@ -22,7 +22,7 @@ impl Voxels {
     pub fn iter_outline(&self, mut f: impl FnMut(Point<Real>, Point<Real>)) {
         // TODO: move this as a new method: Voxels::to_outline?
         let radius = self.voxel_size() / 2.0;
-        let aabb = Aabb::from_half_extents(Point::origin(), Vector::repeat(radius));
+        let aabb = Aabb::from_half_extents(Point::origin(), radius);
         let vtx = aabb.vertices();
 
         for (_, center, vox_data) in self.centers() {

--- a/src/transformation/to_polyline/voxels_to_polyline.rs
+++ b/src/transformation/to_polyline/voxels_to_polyline.rs
@@ -1,10 +1,10 @@
 use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 use crate::shape::{VoxelType, Voxels};
-use crate::transformation::utils;
-use na::{self, Point2, Point3, Vector3};
+use na::{self, Point2};
 
 impl Voxels {
+    /// Converts the outlines of this set of voxels as a polyline.
     pub fn to_polyline(&self) -> (Vec<Point2<Real>>, Vec<[u32; 2]>) {
         let mut points = vec![];
         self.iter_outline(|a, b| {
@@ -17,7 +17,7 @@ impl Voxels {
         (points, indices)
     }
 
-    /// Outlines this voxels shape using polylines.
+    /// Outlines this voxels shape with segments.
     pub fn iter_outline(&self, mut f: impl FnMut(Point<Real>, Point<Real>)) {
         // TODO: move this as a new method: Voxels::to_outline?
         let radius = self.voxel_size() / 2.0;

--- a/src/transformation/to_polyline/voxels_to_polyline.rs
+++ b/src/transformation/to_polyline/voxels_to_polyline.rs
@@ -1,0 +1,52 @@
+use crate::bounding_volume::Aabb;
+use crate::math::{Point, Real, Vector};
+use crate::shape::{VoxelType, Voxels};
+use crate::transformation::utils;
+use na::{self, Point2, Point3, Vector3};
+
+impl Voxels {
+    pub fn to_polyline(&self) -> (Vec<Point2<Real>>, Vec<[u32; 2]>) {
+        let mut points = vec![];
+        self.iter_outline(|a, b| {
+            points.push(a);
+            points.push(b);
+        });
+        let indices = (0..points.len() as u32 / 2)
+            .map(|i| [i * 2, i * 2 + 1])
+            .collect();
+        (points, indices)
+    }
+
+    /// Outlines this voxels shape using polylines.
+    pub fn iter_outline(&self, mut f: impl FnMut(Point<Real>, Point<Real>)) {
+        // TODO: move this as a new method: Voxels::to_outline?
+        let radius = self.voxel_size() / 2.0;
+        let aabb = Aabb::from_half_extents(Point::origin(), Vector::repeat(radius));
+        let vtx = aabb.vertices();
+
+        for (center, vox_data) in self.centers() {
+            match vox_data.voxel_type() {
+                VoxelType::Vertex => {
+                    let mask = vox_data.feature_mask();
+
+                    for edge in Aabb::FACES_VERTEX_IDS {
+                        if mask & (1 << edge.0) != 0 || mask & (1 << edge.1) != 0 {
+                            f(center + vtx[edge.0].coords, center + vtx[edge.1].coords);
+                        }
+                    }
+                }
+                VoxelType::Face => {
+                    let vtx = aabb.vertices();
+                    let mask = vox_data.feature_mask();
+
+                    for (i, edge) in Aabb::FACES_VERTEX_IDS.iter().enumerate() {
+                        if mask & (1 << i) != 0 {
+                            f(center + vtx[edge.0].coords, center + vtx[edge.1].coords);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/src/transformation/to_trimesh/mod.rs
+++ b/src/transformation/to_trimesh/mod.rs
@@ -11,3 +11,5 @@ mod cuboid_to_trimesh;
 mod cylinder_to_trimesh;
 #[cfg(feature = "dim3")]
 mod heightfield_to_trimesh;
+#[cfg(feature = "dim3")]
+mod voxels_to_trimesh;

--- a/src/transformation/to_trimesh/voxels_to_trimesh.rs
+++ b/src/transformation/to_trimesh/voxels_to_trimesh.rs
@@ -12,7 +12,7 @@ impl Voxels {
 
         let mut vtx = vec![];
         let mut idx = vec![];
-        for (center, data) in self.centers() {
+        for (_, center, data) in self.centers() {
             let mask = data.free_faces();
             for i in 0..6 {
                 if mask.bits() & (1 << i) != 0 {

--- a/src/transformation/to_trimesh/voxels_to_trimesh.rs
+++ b/src/transformation/to_trimesh/voxels_to_trimesh.rs
@@ -1,0 +1,39 @@
+use crate::bounding_volume::Aabb;
+use crate::math::{Point, Real, Vector};
+use crate::shape::Voxels;
+use crate::transformation::utils;
+use na::{self, RealField};
+
+impl Voxels {
+    pub fn to_trimesh(&self) -> (Vec<Point<Real>>, Vec<[u32; 3]>) {
+        let aabb =
+            Aabb::from_half_extents(Point::origin(), Vector::repeat(self.voxel_size() / 2.0));
+        let aabb_vtx = aabb.vertices();
+
+        let mut vtx = vec![];
+        let mut idx = vec![];
+        for (center, data) in self.centers() {
+            let mask = data.free_faces();
+            for i in 0..6 {
+                if mask.bits() & (1 << i) != 0 {
+                    let fvid = Aabb::FACES_VERTEX_IDS[i];
+                    let base_id = vtx.len() as u32;
+                    vtx.push(center + aabb_vtx[fvid.0].coords);
+                    vtx.push(center + aabb_vtx[fvid.1].coords);
+                    vtx.push(center + aabb_vtx[fvid.2].coords);
+                    vtx.push(center + aabb_vtx[fvid.3].coords);
+
+                    if i % 2 == 0 {
+                        idx.push([base_id, base_id + 1, base_id + 2]);
+                        idx.push([base_id + 0, base_id + 2, base_id + 3]);
+                    } else {
+                        idx.push([base_id, base_id + 2, base_id + 1]);
+                        idx.push([base_id + 0, base_id + 3, base_id + 2]);
+                    }
+                }
+            }
+        }
+
+        (vtx, idx)
+    }
+}

--- a/src/transformation/to_trimesh/voxels_to_trimesh.rs
+++ b/src/transformation/to_trimesh/voxels_to_trimesh.rs
@@ -1,10 +1,12 @@
 use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 use crate::shape::Voxels;
-use crate::transformation::utils;
-use na::{self, RealField};
 
 impl Voxels {
+    /// Computes an unoptimized mesh representation of this shape.
+    ///
+    /// Each free face of each voxel will result in two triangles. No effort is made to merge
+    /// adjacent triangles on large flat areas.
     pub fn to_trimesh(&self) -> (Vec<Point<Real>>, Vec<[u32; 3]>) {
         let aabb =
             Aabb::from_half_extents(Point::origin(), Vector::repeat(self.voxel_size() / 2.0));
@@ -25,10 +27,10 @@ impl Voxels {
 
                     if i % 2 == 0 {
                         idx.push([base_id, base_id + 1, base_id + 2]);
-                        idx.push([base_id + 0, base_id + 2, base_id + 3]);
+                        idx.push([base_id, base_id + 2, base_id + 3]);
                     } else {
                         idx.push([base_id, base_id + 2, base_id + 1]);
-                        idx.push([base_id + 0, base_id + 3, base_id + 2]);
+                        idx.push([base_id, base_id + 3, base_id + 2]);
                     }
                 }
             }

--- a/src/transformation/to_trimesh/voxels_to_trimesh.rs
+++ b/src/transformation/to_trimesh/voxels_to_trimesh.rs
@@ -9,8 +9,7 @@ impl Voxels {
     /// Each free face of each voxel will result in two triangles. No effort is made to merge
     /// adjacent triangles on large flat areas.
     pub fn to_trimesh(&self) -> (Vec<Point<Real>>, Vec<[u32; 3]>) {
-        let aabb =
-            Aabb::from_half_extents(Point::origin(), self.voxel_size() / 2.0);
+        let aabb = Aabb::from_half_extents(Point::origin(), self.voxel_size() / 2.0);
         let aabb_vtx = aabb.vertices();
 
         let mut vtx = vec![];

--- a/src/transformation/to_trimesh/voxels_to_trimesh.rs
+++ b/src/transformation/to_trimesh/voxels_to_trimesh.rs
@@ -1,5 +1,5 @@
 use crate::bounding_volume::Aabb;
-use crate::math::{Point, Real, Vector};
+use crate::math::{Point, Real};
 use crate::shape::Voxels;
 use alloc::{vec, vec::Vec};
 
@@ -10,7 +10,7 @@ impl Voxels {
     /// adjacent triangles on large flat areas.
     pub fn to_trimesh(&self) -> (Vec<Point<Real>>, Vec<[u32; 3]>) {
         let aabb =
-            Aabb::from_half_extents(Point::origin(), Vector::repeat(self.voxel_size() / 2.0));
+            Aabb::from_half_extents(Point::origin(), self.voxel_size() / 2.0);
         let aabb_vtx = aabb.vertices();
 
         let mut vtx = vec![];

--- a/src/transformation/to_trimesh/voxels_to_trimesh.rs
+++ b/src/transformation/to_trimesh/voxels_to_trimesh.rs
@@ -1,6 +1,7 @@
 use crate::bounding_volume::Aabb;
 use crate::math::{Point, Real, Vector};
 use crate::shape::Voxels;
+use alloc::{vec, vec::Vec};
 
 impl Voxels {
     /// Computes an unoptimized mesh representation of this shape.

--- a/src/transformation/voxelization/voxel_set.rs
+++ b/src/transformation/voxelization/voxel_set.rs
@@ -104,6 +104,33 @@ impl VoxelSet {
     /// # Parameters
     /// * `points` - The vertex buffer of the boundary of the shape to voxelize.
     /// * `indices` - The index buffer of the boundary of the shape to voxelize.
+    /// * `voxel_size` - The size of each voxel.
+    /// * `fill_mode` - Controls what is being voxelized.
+    /// * `keep_voxel_to_primitives_map` - If set to `true` a map between the voxels
+    ///   and the primitives (3D triangles or 2D segments) it intersects will be computed.
+    pub fn with_voxel_size(
+        points: &[Point<Real>],
+        indices: &[[u32; DIM]],
+        voxel_size: Real,
+        fill_mode: FillMode,
+        keep_voxel_to_primitives_map: bool,
+    ) -> Self {
+        VoxelizedVolume::with_voxel_size(
+            points,
+            indices,
+            voxel_size,
+            fill_mode,
+            keep_voxel_to_primitives_map,
+        )
+        .into()
+    }
+
+    /// Voxelizes the given shape described by its boundary:
+    /// a triangle mesh (in 3D) or polyline (in 2D).
+    ///
+    /// # Parameters
+    /// * `points` - The vertex buffer of the boundary of the shape to voxelize.
+    /// * `indices` - The index buffer of the boundary of the shape to voxelize.
     /// * `resolution` - Controls the number of subdivision done along each axis. This number
     ///   is the number of subdivisions along the axis where the input shape has the largest extent.
     ///   The other dimensions will have a different automatically-determined resolution (in order to
@@ -143,7 +170,8 @@ impl VoxelSet {
         self.voxel_volume() * self.voxels.len() as Real
     }
 
-    fn get_voxel_point(&self, voxel: &Voxel) -> Point<Real> {
+    /// Gets the coordinates of the center of the given voxel.
+    pub fn get_voxel_point(&self, voxel: &Voxel) -> Point<Real> {
         self.get_point(na::convert(voxel.coords))
     }
 

--- a/src/transformation/voxelization/voxelized_volume.rs
+++ b/src/transformation/voxelization/voxelized_volume.rs
@@ -177,9 +177,9 @@ impl VoxelizedVolume {
     /// * `points` - The vertex buffer of the boundary of the shape to voxelize.
     /// * `indices` - The index buffer of the boundary of the shape to voxelize.
     /// * `resolution` - Controls the number of subdivision done along each axis. This number
-    ///    is the number of subdivisions along the axis where the input shape has the largest extent.
-    ///    The other dimensions will have a different automatically-determined resolution (in order to
-    ///    keep the voxels cubic).
+    ///   is the number of subdivisions along the axis where the input shape has the largest extent.
+    ///   The other dimensions will have a different automatically-determined resolution (in order to
+    ///   keep the voxels cubic).
     /// * `fill_mode` - Controls what is being voxelized.
     /// * `keep_voxel_to_primitives_map` - If set to `true` a map between the voxels
     ///   and the primitives (3D triangles or 2D segments) it intersects will be computed.

--- a/src/transformation/voxelization/voxelized_volume.rs
+++ b/src/transformation/voxelization/voxelized_volume.rs
@@ -166,8 +166,6 @@ impl VoxelizedVolume {
             .map(|x| (x.ceil() as u32).max(2) + 1)
             .into();
 
-        dbg!(result.resolution);
-
         result.do_voxelize(points, indices, fill_mode, keep_voxel_to_primitives_map);
         result
     }

--- a/src/transformation/voxelization/voxelized_volume.rs
+++ b/src/transformation/voxelization/voxelized_volume.rs
@@ -43,6 +43,16 @@ pub enum FillMode {
     // RaycastFill
 }
 
+impl Default for FillMode {
+    fn default() -> Self {
+        Self::FloodFill {
+            detect_cavities: false,
+            #[cfg(feature = "dim2")]
+            detect_self_intersections: false,
+        }
+    }
+}
+
 impl FillMode {
     #[cfg(feature = "dim2")]
     pub(crate) fn detect_cavities(self) -> bool {
@@ -130,6 +140,51 @@ impl VoxelizedVolume {
     /// * `fill_mode` - Controls what is being voxelized.
     /// * `keep_voxel_to_primitives_map` - If set to `true` a map between the voxels
     ///   and the primitives (3D triangles or 2D segments) it intersects will be computed.
+    pub fn with_voxel_size(
+        points: &[Point<Real>],
+        indices: &[[u32; DIM]],
+        voxel_size: Real,
+        fill_mode: FillMode,
+        keep_voxel_to_primitives_map: bool,
+    ) -> Self {
+        let mut result = VoxelizedVolume {
+            resolution: [0; DIM],
+            origin: Point::origin(),
+            scale: voxel_size,
+            values: Vec::new(),
+            data: Vec::new(),
+            primitive_intersections: Vec::new(),
+        };
+
+        if points.is_empty() {
+            return result;
+        }
+
+        let aabb = crate::bounding_volume::details::local_point_cloud_aabb(points);
+        result.origin = aabb.mins;
+        result.resolution = (aabb.extents() / voxel_size)
+            .map(|x| (x.ceil() as u32).max(2) + 1)
+            .into();
+
+        dbg!(result.resolution);
+
+        result.do_voxelize(points, indices, fill_mode, keep_voxel_to_primitives_map);
+        result
+    }
+
+    /// Voxelizes the given shape described by its boundary:
+    /// a triangle mesh (in 3D) or polyline (in 2D).
+    ///
+    /// # Parameters
+    /// * `points` - The vertex buffer of the boundary of the shape to voxelize.
+    /// * `indices` - The index buffer of the boundary of the shape to voxelize.
+    /// * `resolution` - Controls the number of subdivision done along each axis. This number
+    ///    is the number of subdivisions along the axis where the input shape has the largest extent.
+    ///    The other dimensions will have a different automatically-determined resolution (in order to
+    ///    keep the voxels cubic).
+    /// * `fill_mode` - Controls what is being voxelized.
+    /// * `keep_voxel_to_primitives_map` - If set to `true` a map between the voxels
+    ///   and the primitives (3D triangles or 2D segments) it intersects will be computed.
     pub fn voxelize(
         points: &[Point<Real>],
         indices: &[[u32; DIM]],
@@ -186,8 +241,19 @@ impl VoxelizedVolume {
         }
 
         result.scale = r / (resolution as Real - 1.0);
-        let inv_scale = (resolution as Real - 1.0) / r;
-        result.allocate();
+        result.do_voxelize(points, indices, fill_mode, keep_voxel_to_primitives_map);
+        result
+    }
+
+    fn do_voxelize(
+        &mut self,
+        points: &[Point<Real>],
+        indices: &[[u32; DIM]],
+        fill_mode: FillMode,
+        keep_voxel_to_primitives_map: bool,
+    ) {
+        let inv_scale = 1.0 / self.scale;
+        self.allocate();
 
         let mut tri_pts = [Point::origin(); DIM];
         let box_half_size = Vector::repeat(0.5);
@@ -203,16 +269,16 @@ impl VoxelizedVolume {
             // Find the range of voxels potentially intersecting the triangle.
             for c in 0..DIM {
                 let pt = points[tri[c] as usize];
-                tri_pts[c] = (pt - result.origin.coords) * inv_scale;
+                tri_pts[c] = (pt - self.origin.coords) * inv_scale;
 
                 let i = (tri_pts[c].x + 0.5) as u32;
                 let j = (tri_pts[c].y + 0.5) as u32;
                 #[cfg(feature = "dim3")]
                 let k = (tri_pts[c].z + 0.5) as u32;
 
-                assert!(i < result.resolution[0] && j < result.resolution[1]);
+                assert!(i < self.resolution[0] && j < self.resolution[1]);
                 #[cfg(feature = "dim3")]
-                assert!(k < result.resolution[2]);
+                assert!(k < self.resolution[2]);
 
                 #[cfg(feature = "dim2")]
                 let ijk = Vector::new(i, j);
@@ -231,7 +297,7 @@ impl VoxelizedVolume {
             ijk0.apply(|e| *e = e.saturating_sub(1));
             ijk1 = ijk1
                 .map(|e| e + 1)
-                .inf(&Point::from(result.resolution).coords);
+                .inf(&Point::from(self.resolution).coords);
 
             #[cfg(feature = "dim2")]
             let range_k = 0..1;
@@ -247,9 +313,9 @@ impl VoxelizedVolume {
                         #[cfg(feature = "dim3")]
                         let pt = Point::new(i as Real, j as Real, k as Real);
 
-                        let id = result.voxel_index(i, j, k);
-                        let value = &mut result.values[id as usize];
-                        let data = &mut result.data[id as usize];
+                        let id = self.voxel_index(i, j, k);
+                        let value = &mut self.values[id as usize];
+                        let data = &mut self.data[id as usize];
 
                         if detect_self_intersections
                             || keep_voxel_to_primitives_map
@@ -266,7 +332,7 @@ impl VoxelizedVolume {
                                 if intersect {
                                     if keep_voxel_to_primitives_map {
                                         data.num_primitive_intersections += 1;
-                                        result.primitive_intersections.push((id, tri_id as u32));
+                                        self.primitive_intersections.push((id, tri_id as u32));
                                     }
 
                                     *value = VoxelValue::PrimitiveOnSurface;
@@ -281,18 +347,9 @@ impl VoxelizedVolume {
                                     continue;
                                 }
 
-                                data.multiplicity += ((params.0 >= -eps && params.0 <= eps)
-                                    || (params.0 >= 1.0 - eps && params.0 <= 1.0 + eps))
-                                    as u32;
-                                data.multiplicity += ((params.1 >= -eps && params.1 <= eps)
-                                    || (params.1 >= 1.0 - eps && params.1 <= 1.0 + eps))
-                                    as u32;
-                                data.multiplicity += (params.0 > eps) as u32 * 2;
-                                data.multiplicity += (params.1 < 1.0 - eps) as u32 * 2;
-
                                 if keep_voxel_to_primitives_map {
                                     data.num_primitive_intersections += 1;
-                                    result.primitive_intersections.push((id, tri_id as u32));
+                                    self.primitive_intersections.push((id, tri_id as u32));
                                 }
 
                                 if data.multiplicity > 4 && lock_high_multiplicities {
@@ -314,7 +371,7 @@ impl VoxelizedVolume {
 
                                     if keep_voxel_to_primitives_map {
                                         data.num_primitive_intersections += 1;
-                                        result.primitive_intersections.push((id, tri_id as u32));
+                                        self.primitive_intersections.push((id, tri_id as u32));
                                     }
                                 }
                             };
@@ -326,7 +383,7 @@ impl VoxelizedVolume {
 
         match fill_mode {
             FillMode::SurfaceOnly => {
-                for value in &mut result.values {
+                for value in &mut self.values {
                     if *value != VoxelValue::PrimitiveOnSurface {
                         *value = VoxelValue::PrimitiveOutsideSurface
                     }
@@ -337,76 +394,55 @@ impl VoxelizedVolume {
             } => {
                 #[cfg(feature = "dim2")]
                 {
-                    result.mark_outside_surface(0, 0, result.resolution[0], 1);
-                    result.mark_outside_surface(
+                    self.mark_outside_surface(0, 0, self.resolution[0], 1);
+                    self.mark_outside_surface(
                         0,
-                        result.resolution[1] - 1,
-                        result.resolution[0],
-                        result.resolution[1],
+                        self.resolution[1] - 1,
+                        self.resolution[0],
+                        self.resolution[1],
                     );
-                    result.mark_outside_surface(0, 0, 1, result.resolution[1]);
-                    result.mark_outside_surface(
-                        result.resolution[0] - 1,
+                    self.mark_outside_surface(0, 0, 1, self.resolution[1]);
+                    self.mark_outside_surface(
+                        self.resolution[0] - 1,
                         0,
-                        result.resolution[0],
-                        result.resolution[1],
+                        self.resolution[0],
+                        self.resolution[1],
                     );
                 }
 
                 #[cfg(feature = "dim3")]
                 {
-                    result.mark_outside_surface(
+                    self.mark_outside_surface(0, 0, 0, self.resolution[0], self.resolution[1], 1);
+                    self.mark_outside_surface(
                         0,
                         0,
-                        0,
-                        result.resolution[0],
-                        result.resolution[1],
-                        1,
+                        self.resolution[2] - 1,
+                        self.resolution[0],
+                        self.resolution[1],
+                        self.resolution[2],
                     );
-                    result.mark_outside_surface(
+                    self.mark_outside_surface(0, 0, 0, self.resolution[0], 1, self.resolution[2]);
+                    self.mark_outside_surface(
                         0,
+                        self.resolution[1] - 1,
                         0,
-                        result.resolution[2] - 1,
-                        result.resolution[0],
-                        result.resolution[1],
-                        result.resolution[2],
+                        self.resolution[0],
+                        self.resolution[1],
+                        self.resolution[2],
                     );
-                    result.mark_outside_surface(
+                    self.mark_outside_surface(0, 0, 0, 1, self.resolution[1], self.resolution[2]);
+                    self.mark_outside_surface(
+                        self.resolution[0] - 1,
                         0,
                         0,
-                        0,
-                        result.resolution[0],
-                        1,
-                        result.resolution[2],
-                    );
-                    result.mark_outside_surface(
-                        0,
-                        result.resolution[1] - 1,
-                        0,
-                        result.resolution[0],
-                        result.resolution[1],
-                        result.resolution[2],
-                    );
-                    result.mark_outside_surface(
-                        0,
-                        0,
-                        0,
-                        1,
-                        result.resolution[1],
-                        result.resolution[2],
-                    );
-                    result.mark_outside_surface(
-                        result.resolution[0] - 1,
-                        0,
-                        0,
-                        result.resolution[0],
-                        result.resolution[1],
-                        result.resolution[2],
+                        self.resolution[0],
+                        self.resolution[1],
+                        self.resolution[2],
                     );
                 }
 
                 if detect_cavities {
-                    let _ = result.propagate_values(
+                    let _ = self.propagate_values(
                         VoxelValue::PrimitiveOutsideSurfaceToWalk,
                         VoxelValue::PrimitiveOutsideSurface,
                         None,
@@ -414,7 +450,7 @@ impl VoxelizedVolume {
                     );
 
                     loop {
-                        if !result.propagate_values(
+                        if !self.propagate_values(
                             VoxelValue::PrimitiveInsideSurfaceToWalk,
                             VoxelValue::PrimitiveInsideSurface,
                             Some(VoxelValue::PrimitiveOnSurfaceToWalk1),
@@ -423,7 +459,7 @@ impl VoxelizedVolume {
                             break;
                         }
 
-                        if !result.propagate_values(
+                        if !self.propagate_values(
                             VoxelValue::PrimitiveOutsideSurfaceToWalk,
                             VoxelValue::PrimitiveOutsideSurface,
                             Some(VoxelValue::PrimitiveOnSurfaceToWalk2),
@@ -433,7 +469,7 @@ impl VoxelizedVolume {
                         }
                     }
 
-                    for voxel in &mut result.values {
+                    for voxel in &mut self.values {
                         if *voxel == VoxelValue::PrimitiveOnSurfaceToWalk1
                             || *voxel == VoxelValue::PrimitiveOnSurfaceToWalk2
                             || *voxel == VoxelValue::PrimitiveOnSurfaceNoWalk
@@ -442,22 +478,20 @@ impl VoxelizedVolume {
                         }
                     }
                 } else {
-                    let _ = result.propagate_values(
+                    let _ = self.propagate_values(
                         VoxelValue::PrimitiveOutsideSurfaceToWalk,
                         VoxelValue::PrimitiveOutsideSurface,
                         None,
                         VoxelValue::PrimitiveOnSurface,
                     );
 
-                    result.replace_value(
+                    self.replace_value(
                         VoxelValue::PrimitiveUndefined,
                         VoxelValue::PrimitiveInsideSurface,
                     );
                 }
             }
         }
-
-        result
     }
 
     /// The number of voxel subdivisions along each coordinate axis.

--- a/src/transformation/voxelization/voxelized_volume.rs
+++ b/src/transformation/voxelization/voxelized_volume.rs
@@ -110,7 +110,7 @@ pub enum VoxelValue {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-struct VoxelData {
+struct VoxelState {
     #[cfg(feature = "dim2")]
     multiplicity: u32,
     num_primitive_intersections: u32,
@@ -122,7 +122,7 @@ pub struct VoxelizedVolume {
     scale: Real,
     resolution: [u32; DIM],
     values: Vec<VoxelValue>,
-    data: Vec<VoxelData>,
+    data: Vec<VoxelState>,
     primitive_intersections: Vec<(u32, u32)>,
 }
 
@@ -514,7 +514,7 @@ impl VoxelizedVolume {
             .resize(len as usize, VoxelValue::PrimitiveUndefined);
         self.data.resize(
             len as usize,
-            VoxelData {
+            VoxelState {
                 #[cfg(feature = "dim2")]
                 multiplicity: 0,
                 num_primitive_intersections: 0,


### PR DESCRIPTION
This PRs adds partial support of a new `Voxels` shape. This shape type is designed to handle efficiently, and without "internal edges" artifacts, collision detection with objects defined as a set of voxels. Each `Voxels` shape is free to have their own voxel size; and can be rotated/translated arbitrarily as a whole. The voxel size can be different along each axis (i.e. it can be a rectangle instead of just a cube).

This feature is still experimental as it is missing some elements. The following is supported:
- Ray-casting.
- Point-projection (very unoptimized).
- Contact-manifold generation with convex shapes.
- Conversion from and to meshes/polylines.
- Conversion to outlines for debug-rendering.
- Dynamic addition or removal of individual voxels.

Notable features that are currently missing are:
- Collision-detection with non-convex shapes (or compound shapes).
- Shape-casting.

<img width="1648" alt="image" src="https://github.com/user-attachments/assets/fd2517dd-28df-43bd-bc9f-8715d6ea2fbd" />
<img width="1136" alt="image" src="https://github.com/user-attachments/assets/8a79f22e-16f6-49f7-a933-44a59b2c81da" />