### PR TITLE
Release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Change Log
 
-## Unreleased
+## v0.20.0
 
 ### Added
 
 - Added the `Voxels` type: a dedicated shape for voxel models. This is currently experimental because some features are
   still missing (in particular: shape-casting, mass properties, and collision-detection against non-convex shapes).
-- Added `SharedShape::voxels` and `::voxelized_mesh` for creating a voxels shape from centroids or automatic
-  voxelization of a triangle mesh.
+- Added `SharedShape::voxels`, `SharedShape::voxels_from_points`, and `::voxelized_mesh` for creating a voxels shape
+  from grid coordinates, points, or automatic voxelization of a triangle mesh.
 
 ## v0.19.0
 

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."
@@ -82,7 +82,6 @@ indexmap = { version = "2", features = ["serde"], optional = true }
 hashbrown = { version = "0.15", optional = true, default-features = false, features = [
     "default-hasher",
 ] }
-cust_core = { version = "0.1", optional = true }
 spade = { version = "2", optional = true, default-features = false }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."
@@ -82,7 +82,6 @@ indexmap = { version = "2", features = ["serde"], optional = true }
 hashbrown = { version = "0.15", optional = true, default-features = false, features = [
     "default-hasher",
 ] }
-cust_core = { version = "0.1", optional = true }
 spade = { version = "2", optional = true, default-features = false }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."
@@ -83,7 +83,6 @@ hashbrown = { version = "0.15", optional = true, default-features = false, featu
     "default-hasher",
 ] }
 foldhash = { version = "0.1", optional = true, default-features = false }
-cust_core = { version = "0.1", optional = true }
 spade = { version = "2.9", optional = true, default-features = false }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."
@@ -83,7 +83,6 @@ indexmap = { version = "2", features = ["serde"], optional = true }
 hashbrown = { version = "0.15", optional = true, default-features = false, features = [
     "default-hasher",
 ] }
-cust_core = { version = "0.1", optional = true }
 spade = { version = "2.9", optional = true, default-features = false }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }

--- a/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
@@ -49,7 +49,7 @@ pub fn contact_manifolds_voxels_ball<'a, ManifoldData, ContactData>(
 
     let radius2 = ball2.radius;
     let center2 = Point::origin(); // The ball’s center.
-    let radius1 = voxels1.voxel_size / 2.0;
+    let radius1 = voxels1.voxel_size() / 2.0;
 
     // FIXME: optimize this.
     let aabb1 = voxels1.local_aabb().loosened(prediction / 2.0);

--- a/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
@@ -141,8 +141,8 @@ pub fn contact_manifolds_voxels_shape<ManifoldData, ContactData>(
             let key_voxel = voxels1.voxel_key_at(vid);
             let mut key_low = key_voxel;
             let mut key_high = key_low;
-            let mins = voxels1.domain_mins;
-            let maxs = voxels1.domain_maxs - Vector::repeat(1);
+            let mins = voxels1.domain()[0];
+            let maxs = voxels1.domain()[1] - Vector::repeat(1);
             let mask1 = data1.free_faces();
 
             let adjust_canon = |axis: AxisMask, i: usize, key: &mut Point<i32>, val: i32| {

--- a/src/query/ray/ray_voxels.rs
+++ b/src/query/ray/ray_voxels.rs
@@ -28,6 +28,7 @@ impl RayCast for Voxels {
         let clip_ray_a = ray.point_at(min_t);
         let voxel_key_signed = self.key_at_point_unchecked(clip_ray_a);
         let mut voxel_key = self.clamp_key(voxel_key_signed);
+        let [domain_mins, domain_maxs] = self.domain();
 
         loop {
             let voxel = self.voxel_data_at_key(voxel_key);
@@ -82,13 +83,13 @@ impl RayCast for Voxels {
             let imin = Vector::from(toi.map(|t| t.0)).imin();
 
             if toi[imin].1 {
-                if voxel_key[imin] < self.domain_maxs[imin] - 1 {
+                if voxel_key[imin] < domain_maxs[imin] - 1 {
                     voxel_key[imin] += 1;
                 } else {
                     // Leaving the shape’s bounds.
                     break;
                 }
-            } else if voxel_key[imin] > self.domain_mins[imin] {
+            } else if voxel_key[imin] > domain_mins[imin] {
                 voxel_key[imin] -= 1;
             } else {
                 // Leaving the shape’s bounds.

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -1554,7 +1554,7 @@ impl Shape for Voxels {
     }
 
     fn ccd_thickness(&self) -> Real {
-        self.voxel_size.min()
+        self.voxel_size().min()
     }
 
     fn ccd_angular_thickness(&self) -> Real {

--- a/src/shape/voxels.rs
+++ b/src/shape/voxels.rs
@@ -195,12 +195,11 @@ impl VoxelState {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct Voxels {
-    pub(crate) domain_mins: Point<i32>,
-    pub(crate) domain_maxs: Point<i32>,
-    pub(crate) data: Vec<VoxelState>, // Somehow switch to a sparse representation?
+    domain_mins: Point<i32>,
+    domain_maxs: Point<i32>,
+    data: Vec<VoxelState>, // Somehow switch to a sparse representation?
     primitive_geometry: VoxelPrimitiveGeometry,
-    /// The size of each voxel along all dimensions.
-    pub voxel_size: Vector<Real>,
+    voxel_size: Vector<Real>,
 }
 
 impl Voxels {
@@ -314,6 +313,26 @@ impl Voxels {
             .component_mul(&self.voxel_size)
             + self.extents() / 2.0)
             .into()
+    }
+
+    /// Sets the size of each voxel along each local coordinate axis.
+    ///
+    /// If [`Self::primitive_geometry`] is [`VoxelPrimitiveGeometry::PseudoBall`], then all voxels
+    /// must be square, and only `size.x` is taken into account for setting the size.
+    pub fn set_voxel_size(&mut self, size: Vector<Real>) {
+        match self.primitive_geometry {
+            VoxelPrimitiveGeometry::PseudoBall => {
+                self.voxel_size = Vector::repeat(size.x);
+            }
+            VoxelPrimitiveGeometry::PseudoCube => {
+                self.voxel_size = size;
+            }
+        }
+    }
+
+    /// The valid range of voxel grid indices.
+    pub fn domain(&self) -> [&Point<i32>; 2] {
+        [&self.domain_mins, &self.domain_maxs]
     }
 
     /// The domain covered by this voxels shape.


### PR DESCRIPTION
## v0.20.0

### Added

- Added the `Voxels` type: a dedicated shape for voxel models. This is currently experimental because some features are
  still missing (in particular: shape-casting, mass properties, and collision-detection against non-convex shapes).
- Added `SharedShape::voxels`, `SharedShape::voxels_from_points`, and `::voxelized_mesh` for creating a voxels shape
  from grid coordinates, points, or automatic voxelization of a triangle mesh.