### PR TITLE
feat: implement shape-casting for voxels shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
-## v0.20.0
+## v0.20.1
+
+### Added
+
+- Rework the `Voxels` shape API to use better method names.
+- Added implementations for linear and non-linear shape-casting involving `Voxels` shapes.
+
+## v0.20.0 (yanked)
 
 ### Added
 

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."

--- a/src/bounding_volume/aabb_voxels.rs
+++ b/src/bounding_volume/aabb_voxels.rs
@@ -6,7 +6,7 @@ impl Voxels {
     /// Computes the world-space Aabb of this set of voxels, transformed by `pos`.
     #[inline]
     pub fn aabb(&self, pos: &Isometry<Real>) -> Aabb {
-        let shift = Translation::from(self.center());
+        let shift = Translation::from(self.domain_center());
         Cuboid::new(self.extents() / 2.0).aabb(&(pos * shift))
     }
 
@@ -15,6 +15,6 @@ impl Voxels {
     pub fn local_aabb(&self) -> Aabb {
         Cuboid::new(self.extents() / 2.0)
             .local_aabb()
-            .translated(&self.center().coords)
+            .translated(&self.domain_center().coords)
     }
 }

--- a/src/bounding_volume/bounding_sphere_voxels.rs
+++ b/src/bounding_volume/bounding_sphere_voxels.rs
@@ -6,7 +6,7 @@ impl Voxels {
     /// Computes the world-space bounding sphere of this set of voxels, transformed by `pos`.
     #[inline]
     pub fn bounding_sphere(&self, pos: &Isometry<Real>) -> BoundingSphere {
-        let shift = Translation::from(self.center().coords);
+        let shift = Translation::from(self.domain_center().coords);
         Cuboid::new(self.extents() / 2.0).bounding_sphere(&(pos * shift))
     }
 
@@ -15,6 +15,6 @@ impl Voxels {
     pub fn local_bounding_sphere(&self) -> BoundingSphere {
         Cuboid::new(self.extents() / 2.0)
             .local_bounding_sphere()
-            .translated(&(self.center().coords))
+            .translated(&(self.domain_center().coords))
     }
 }

--- a/src/partitioning/qbvh/qbvh.rs
+++ b/src/partitioning/qbvh/qbvh.rs
@@ -255,12 +255,12 @@ impl<LeafData: IndexedData> Qbvh<LeafData> {
     // TODO: support a crate like get_size2 (will require support on nalgebra too)?
     /// An approximation of the memory usage (in bytes) for this struct plus
     /// the memory it allocates dynamically.
-    pub fn get_size(&self) -> usize {
-        size_of::<Self>() + self.get_heap_size()
+    pub fn total_memory_size(&self) -> usize {
+        size_of::<Self>() + self.heap_memory_size()
     }
 
     /// An approximation of the memory dynamically-allocated by this struct.
-    pub fn get_heap_size(&self) -> usize {
+    pub fn heap_memory_size(&self) -> usize {
         let Self {
             root_aabb: _,
             nodes,

--- a/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
@@ -66,7 +66,15 @@ pub fn contact_manifolds_voxels_ball<'a, ManifoldData, ContactData>(
             }
 
             detect_hit_voxel_ball(
-                *pos12, vox1.center, radius1, vox1.state, geometry1, center2, radius2, prediction, flipped,
+                *pos12,
+                vox1.center,
+                radius1,
+                vox1.state,
+                geometry1,
+                center2,
+                radius2,
+                prediction,
+                flipped,
                 manifolds,
             );
         }

--- a/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
@@ -56,9 +56,8 @@ pub fn contact_manifolds_voxels_ball<'a, ManifoldData, ContactData>(
     let aabb2 = ball2.aabb(pos12).loosened(prediction / 2.0);
     let geometry1 = voxels1.primitive_geometry();
     if let Some(aabb_intersection) = aabb1.intersection(&aabb2) {
-        for (_, center1, data1) in voxels1.voxels_intersecting_local_aabb(&aabb_intersection) {
-            let voxel1 = data1.voxel_type();
-            match voxel1 {
+        for vox1 in voxels1.voxels_intersecting_local_aabb(&aabb_intersection) {
+            match vox1.state.voxel_type() {
                 #[cfg(feature = "dim2")]
                 VoxelType::Vertex | VoxelType::Face => { /* Ok */ }
                 #[cfg(feature = "dim3")]
@@ -67,7 +66,7 @@ pub fn contact_manifolds_voxels_ball<'a, ManifoldData, ContactData>(
             }
 
             detect_hit_voxel_ball(
-                *pos12, center1, radius1, data1, geometry1, center2, radius2, prediction, flipped,
+                *pos12, vox1.center, radius1, vox1.state, geometry1, center2, radius2, prediction, flipped,
                 manifolds,
             );
         }

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -354,6 +354,19 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                     c2,
                     options,
                 ));
+            } else if let Some(v1) = shape1.as_voxels() {
+                return Ok(query::details::cast_shapes_voxels_shape(
+                    self, pos12, local_vel12, v1, shape2, options
+                ))
+            } else if let Some(v2) = shape2.as_voxels() {
+                return Ok(query::details::cast_shapes_shape_voxels(
+                    self,
+                    pos12,
+                    local_vel12,
+                    shape1,
+                    v2,
+                    options,
+                ));
             }
 
             Err(Unsupported)
@@ -406,6 +419,14 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                     end_time,
                     stop_at_penetration,
                 ));
+            } else if let Some(c1) = shape1.as_voxels() {
+                return Ok(query::details::cast_shapes_nonlinear_voxels_shape(
+                    self, motion1, c1, motion2, shape2, start_time, end_time, stop_at_penetration
+                ))
+            } else if let Some(c2) = shape2.as_voxels() {
+                return Ok(query::details::cast_shapes_nonlinear_shape_voxels(
+                    self, motion1, shape1, motion2, c2, start_time, end_time, stop_at_penetration
+                ))
             }
             /* } else if let (Some(p1), Some(s2)) = (shape1.as_shape::<HalfSpace>(), shape2.as_support_map()) {
             //        query::details::cast_shapes_nonlinear_halfspace_support_map(m1, vel1, p1, m2, vel2, s2)

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -356,8 +356,13 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 ));
             } else if let Some(v1) = shape1.as_voxels() {
                 return Ok(query::details::cast_shapes_voxels_shape(
-                    self, pos12, local_vel12, v1, shape2, options
-                ))
+                    self,
+                    pos12,
+                    local_vel12,
+                    v1,
+                    shape2,
+                    options,
+                ));
             } else if let Some(v2) = shape2.as_voxels() {
                 return Ok(query::details::cast_shapes_shape_voxels(
                     self,
@@ -421,12 +426,26 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 ));
             } else if let Some(c1) = shape1.as_voxels() {
                 return Ok(query::details::cast_shapes_nonlinear_voxels_shape(
-                    self, motion1, c1, motion2, shape2, start_time, end_time, stop_at_penetration
-                ))
+                    self,
+                    motion1,
+                    c1,
+                    motion2,
+                    shape2,
+                    start_time,
+                    end_time,
+                    stop_at_penetration,
+                ));
             } else if let Some(c2) = shape2.as_voxels() {
                 return Ok(query::details::cast_shapes_nonlinear_shape_voxels(
-                    self, motion1, shape1, motion2, c2, start_time, end_time, stop_at_penetration
-                ))
+                    self,
+                    motion1,
+                    shape1,
+                    motion2,
+                    c2,
+                    start_time,
+                    end_time,
+                    stop_at_penetration,
+                ));
             }
             /* } else if let (Some(p1), Some(s2)) = (shape1.as_shape::<HalfSpace>(), shape2.as_support_map()) {
             //        query::details::cast_shapes_nonlinear_halfspace_support_map(m1, vel1, p1, m2, vel2, s2)

--- a/src/query/nonlinear_shape_cast/mod.rs
+++ b/src/query/nonlinear_shape_cast/mod.rs
@@ -5,6 +5,10 @@ pub use self::nonlinear_shape_cast_composite_shape_shape::{
     cast_shapes_nonlinear_composite_shape_shape, cast_shapes_nonlinear_shape_composite_shape,
     NonlinearTOICompositeShapeShapeBestFirstVisitor,
 };
+#[cfg(feature = "alloc")]
+pub use self::nonlinear_shape_cast_voxels_shape::{
+    cast_shapes_nonlinear_voxels_shape, cast_shapes_nonlinear_shape_voxels
+};
 //pub use self::nonlinear_shape_cast_halfspace_support_map::{cast_shapes_nonlinear_halfspace_support_map, cast_shapes_nonlinear_support_map_halfspace};
 pub use self::nonlinear_rigid_motion::NonlinearRigidMotion;
 pub use self::nonlinear_shape_cast::cast_shapes_nonlinear;
@@ -14,6 +18,8 @@ pub use self::nonlinear_shape_cast_support_map_support_map::{
 
 #[cfg(feature = "alloc")]
 mod nonlinear_shape_cast_composite_shape_shape;
+#[cfg(feature = "alloc")]
+mod nonlinear_shape_cast_voxels_shape;
 //mod cast_shapes_nonlinear_halfspace_support_map;
 mod nonlinear_rigid_motion;
 mod nonlinear_shape_cast;

--- a/src/query/nonlinear_shape_cast/mod.rs
+++ b/src/query/nonlinear_shape_cast/mod.rs
@@ -7,7 +7,7 @@ pub use self::nonlinear_shape_cast_composite_shape_shape::{
 };
 #[cfg(feature = "alloc")]
 pub use self::nonlinear_shape_cast_voxels_shape::{
-    cast_shapes_nonlinear_voxels_shape, cast_shapes_nonlinear_shape_voxels
+    cast_shapes_nonlinear_shape_voxels, cast_shapes_nonlinear_voxels_shape,
 };
 //pub use self::nonlinear_shape_cast_halfspace_support_map::{cast_shapes_nonlinear_halfspace_support_map, cast_shapes_nonlinear_support_map_halfspace};
 pub use self::nonlinear_rigid_motion::NonlinearRigidMotion;

--- a/src/query/nonlinear_shape_cast/nonlinear_shape_cast_voxels_shape.rs
+++ b/src/query/nonlinear_shape_cast/nonlinear_shape_cast_voxels_shape.rs
@@ -1,0 +1,195 @@
+use crate::bounding_volume::BoundingVolume;
+use crate::math::{Point, Real, Vector};
+use crate::query::{
+    NonlinearRigidMotion, QueryDispatcher, ShapeCastHit,
+};
+use crate::shape::{Cuboid, Shape, Voxels};
+
+/// Time Of Impact of a voxels shape with any other shape, under a rigid motion (translation + rotation).
+pub fn cast_shapes_nonlinear_voxels_shape<D>(
+    dispatcher: &D,
+    motion1: &NonlinearRigidMotion,
+    g1: &Voxels,
+    motion2: &NonlinearRigidMotion,
+    g2: &dyn Shape,
+    start_time: Real,
+    end_time: Real,
+    stop_at_penetration: bool,
+) -> Option<ShapeCastHit>
+where
+    D: ?Sized + QueryDispatcher,
+{
+    use num_traits::Bounded;
+
+    // HACK: really supporting nonlinear shape-casting on a rotating voxels shape would
+    //       be extremely inefficient without any sort of hierarchical traversal on the voxel.
+    //       So for now we assume that the voxels shape only has a translational motion.
+    //       We can fix that once we introduce a sparse representation (and its accompanying
+    //       acceleration structure) for the voxels shape.
+    let mut motion2 = *motion2;
+    let mut motion1 = *motion1;
+    motion2.linvel -= motion1.linvel;
+    motion1.freeze(start_time);
+    let pos1 = motion1.position_at_time(start_time);
+
+
+    // Search for the smallest time of impact.
+    //
+    // 1. Check all the cells in the AABB at time `start_time`.
+    // 2. Check which wall of unchecked voxels is hit first.
+    // 3. Check one additional layer of voxels behind that wall.
+    // 4. Continue, with a new AABB taken at the position at the time we hit the
+    //    wall.
+    // 5. Continue until `curr_t` is bigger than `smallest_t`.
+    //
+    // PERF: This will be fairly efficient if the shape being cast has a size in the same order
+    // of magnitude as the voxels, and if it doesn’t have a significant off-center angular
+    // motion. Otherwise, this method will be fairly slow, and would require an acceleration
+    // structure to improve.
+
+    let mut hit = None;
+    let mut smallest_t = end_time;
+
+    // NOTE: we approximate the AABB of the shape using its orientation at the start and
+    //       end time. It might miss some cases if the object is rotating fast.
+    let start_pos2_1 = pos1.inv_mul(&motion2.position_at_time(start_time));
+    let mut end_pos2_1 = pos1.inv_mul(&motion2.position_at_time(end_time));
+    end_pos2_1.translation = start_pos2_1.translation;
+    let start_aabb2_1 = g2.compute_aabb(&start_pos2_1)
+        .merged(&g2.compute_aabb(&end_pos2_1));
+
+
+    let mut check_voxels_in_range = |search_domain: [Point<i32>; 2]| {
+        for vox in g1.voxels_in_range(search_domain[0], search_domain[1]) {
+            if !vox.state.is_empty() {
+                // PERF: could we check the canonical shape instead, and deduplicate accordingly?
+                let center = g1.voxel_center(vox.grid_coords);
+                let cuboid = Cuboid::new(g1.voxel_size() / 2.0);
+                let vox_motion1 = motion1.prepend_translation(center.coords);
+                if let Some(new_hit) = dispatcher.cast_shapes_nonlinear(
+                    &vox_motion1, &cuboid, &motion2, g2, start_time, end_time, stop_at_penetration
+                ).ok().flatten() {
+                    if new_hit.time_of_impact < smallest_t {
+                        smallest_t = new_hit.time_of_impact;
+                        hit = Some(new_hit);
+                    }
+                }
+            }
+        }
+    };
+
+    let mut search_domain = g1.voxel_range_intersecting_local_aabb(&start_aabb2_1);
+    check_voxels_in_range(search_domain);
+
+    // Run the propagation.
+    let [domain_mins, domain_maxs] = g1.domain();
+
+    loop {
+        let search_domain_aabb = g1.voxel_range_aabb(search_domain[0], search_domain[1]);
+
+        // Figure out if we should move the aabb up/down/right/left.
+        #[cfg(feature = "dim2")]
+        let ii = [0, 1];
+        #[cfg(feature = "dim3")]
+        let ii = [0, 1, 2];
+
+        let toi = ii.map(|i| {
+            if motion2.linvel[i] > 0.0 {
+                let t = (search_domain_aabb.maxs[i] - start_aabb2_1.maxs[i]) / motion2.linvel[i];
+                if t < 0.0 {
+                    (Real::max_value(), true)
+                } else {
+                    (t, true)
+                }
+            } else if motion2.linvel[i] < 0.0 {
+                let t = (search_domain_aabb.mins[i] - start_aabb2_1.mins[i]) / motion2.linvel[i];
+                if t < 0.0 {
+                    (Real::max_value(), false)
+                } else {
+                    (t, false)
+                }
+            } else {
+                (Real::max_value(), false)
+            }
+        });
+
+        #[cfg(feature = "dim2")]
+        if toi[0].0 > end_time && toi[1].0 > end_time {
+            break;
+        }
+
+        #[cfg(feature = "dim3")]
+        if toi[0].0 > end_time && toi[1].0 > end_time && toi[2].0 > end_time {
+            break;
+        }
+
+        let imin = Vector::from(toi.map(|t| t.0)).imin();
+
+        if toi[imin].1 {
+            search_domain[0][imin] += 1;
+            search_domain[1][imin] += 1;
+
+            if search_domain[1][imin] <= domain_maxs[imin] {
+                // Check the voxels on the added row.
+                let mut prev_row = search_domain[0];
+                prev_row[imin] = search_domain[1][imin] - 1;
+
+                let range_to_check = [
+                    prev_row,
+                    search_domain[1]
+                ];
+                check_voxels_in_range(range_to_check);
+            } else if search_domain[0][imin] >= domain_maxs[imin] {
+                // Leaving the shape’s bounds.
+                break;
+            }
+        } else {
+            search_domain[0][imin] -= 1;
+            search_domain[1][imin] -= 1;
+
+            if search_domain[0][imin] >= domain_mins[imin] {
+                // Check the voxels on the added row.
+                let mut next_row = search_domain[1];
+                next_row[imin] = search_domain[0][imin] + 1;
+
+                let range_to_check = [
+                    search_domain[0],
+                    next_row,
+                ];
+                check_voxels_in_range(range_to_check);
+            } else if search_domain[1][imin] <= domain_mins[imin] {
+                // Leaving the shape’s bounds.
+                break;
+            }
+        }
+    }
+
+    hit
+}
+
+/// Time Of Impact of any shape with a composite shape, under a rigid motion (translation + rotation).
+pub fn cast_shapes_nonlinear_shape_voxels<D>(
+    dispatcher: &D,
+    motion1: &NonlinearRigidMotion,
+    g1: &dyn Shape,
+    motion2: &NonlinearRigidMotion,
+    g2: &Voxels,
+    start_time: Real,
+    end_time: Real,
+    stop_at_penetration: bool,
+) -> Option<ShapeCastHit>
+where
+    D: ?Sized + QueryDispatcher,
+{
+    cast_shapes_nonlinear_voxels_shape(
+        dispatcher,
+        motion2,
+        g2,
+        motion1,
+        g1,
+        start_time,
+        end_time,
+        stop_at_penetration,
+    )
+        .map(|hit| hit.swapped())
+}

--- a/src/query/nonlinear_shape_cast/nonlinear_shape_cast_voxels_shape.rs
+++ b/src/query/nonlinear_shape_cast/nonlinear_shape_cast_voxels_shape.rs
@@ -1,8 +1,6 @@
 use crate::bounding_volume::BoundingVolume;
 use crate::math::{Point, Real, Vector};
-use crate::query::{
-    NonlinearRigidMotion, QueryDispatcher, ShapeCastHit,
-};
+use crate::query::{NonlinearRigidMotion, QueryDispatcher, ShapeCastHit};
 use crate::shape::{Cuboid, Shape, Voxels};
 
 /// Time Of Impact of a voxels shape with any other shape, under a rigid motion (translation + rotation).
@@ -32,7 +30,6 @@ where
     motion1.freeze(start_time);
     let pos1 = motion1.position_at_time(start_time);
 
-
     // Search for the smallest time of impact.
     //
     // 1. Check all the cells in the AABB at time `start_time`.
@@ -55,9 +52,9 @@ where
     let start_pos2_1 = pos1.inv_mul(&motion2.position_at_time(start_time));
     let mut end_pos2_1 = pos1.inv_mul(&motion2.position_at_time(end_time));
     end_pos2_1.translation = start_pos2_1.translation;
-    let start_aabb2_1 = g2.compute_aabb(&start_pos2_1)
+    let start_aabb2_1 = g2
+        .compute_aabb(&start_pos2_1)
         .merged(&g2.compute_aabb(&end_pos2_1));
-
 
     let mut check_voxels_in_range = |search_domain: [Point<i32>; 2]| {
         for vox in g1.voxels_in_range(search_domain[0], search_domain[1]) {
@@ -66,9 +63,19 @@ where
                 let center = g1.voxel_center(vox.grid_coords);
                 let cuboid = Cuboid::new(g1.voxel_size() / 2.0);
                 let vox_motion1 = motion1.prepend_translation(center.coords);
-                if let Some(new_hit) = dispatcher.cast_shapes_nonlinear(
-                    &vox_motion1, &cuboid, &motion2, g2, start_time, end_time, stop_at_penetration
-                ).ok().flatten() {
+                if let Some(new_hit) = dispatcher
+                    .cast_shapes_nonlinear(
+                        &vox_motion1,
+                        &cuboid,
+                        &motion2,
+                        g2,
+                        start_time,
+                        end_time,
+                        stop_at_penetration,
+                    )
+                    .ok()
+                    .flatten()
+                {
                     if new_hit.time_of_impact < smallest_t {
                         smallest_t = new_hit.time_of_impact;
                         hit = Some(new_hit);
@@ -134,10 +141,7 @@ where
                 let mut prev_row = search_domain[0];
                 prev_row[imin] = search_domain[1][imin] - 1;
 
-                let range_to_check = [
-                    prev_row,
-                    search_domain[1]
-                ];
+                let range_to_check = [prev_row, search_domain[1]];
                 check_voxels_in_range(range_to_check);
             } else if search_domain[0][imin] >= domain_maxs[imin] {
                 // Leaving the shape’s bounds.
@@ -152,10 +156,7 @@ where
                 let mut next_row = search_domain[1];
                 next_row[imin] = search_domain[0][imin] + 1;
 
-                let range_to_check = [
-                    search_domain[0],
-                    next_row,
-                ];
+                let range_to_check = [search_domain[0], next_row];
                 check_voxels_in_range(range_to_check);
             } else if search_domain[1][imin] <= domain_mins[imin] {
                 // Leaving the shape’s bounds.
@@ -191,5 +192,5 @@ where
         end_time,
         stop_at_penetration,
     )
-        .map(|hit| hit.swapped())
+    .map(|hit| hit.swapped())
 }

--- a/src/query/point/point_voxels.rs
+++ b/src/query/point/point_voxels.rs
@@ -12,7 +12,8 @@ impl PointQuery for Voxels {
 
         for vox in self.voxels() {
             if vox.state.voxel_type() != VoxelType::Empty {
-                let mut candidate = base_cuboid.project_local_point(&(pt - vox.center.coords), solid);
+                let mut candidate =
+                    base_cuboid.project_local_point(&(pt - vox.center.coords), solid);
                 candidate.point += vox.center.coords;
 
                 let candidate_dist = (candidate.point - pt).norm();

--- a/src/query/point/point_voxels.rs
+++ b/src/query/point/point_voxels.rs
@@ -10,10 +10,10 @@ impl PointQuery for Voxels {
         let mut smallest_dist = Real::MAX;
         let mut result = PointProjection::new(false, *pt);
 
-        for (_, center, data) in self.centers() {
-            if data.voxel_type() != VoxelType::Empty {
-                let mut candidate = base_cuboid.project_local_point(&(pt - center.coords), solid);
-                candidate.point += center.coords;
+        for vox in self.voxels() {
+            if vox.state.voxel_type() != VoxelType::Empty {
+                let mut candidate = base_cuboid.project_local_point(&(pt - vox.center.coords), solid);
+                candidate.point += vox.center.coords;
 
                 let candidate_dist = (candidate.point - pt).norm();
                 if candidate_dist < smallest_dist {

--- a/src/query/ray/ray_voxels.rs
+++ b/src/query/ray/ray_voxels.rs
@@ -26,13 +26,13 @@ impl RayCast for Voxels {
 
         max_t = max_t.min(max_time_of_impact);
         let clip_ray_a = ray.point_at(min_t);
-        let voxel_key_signed = self.key_at_point_unchecked(clip_ray_a);
-        let mut voxel_key = self.clamp_key(voxel_key_signed);
+        let voxel_key_signed = self.voxel_at_point_unchecked(clip_ray_a);
+        let mut voxel_key = self.clamp_voxel(voxel_key_signed);
         let [domain_mins, domain_maxs] = self.domain();
 
         loop {
-            let voxel = self.voxel_data_at_key(voxel_key);
-            let aabb = self.voxel_aabb_at_key(voxel_key);
+            let voxel = self.voxel_state(voxel_key);
+            let aabb = self.voxel_aabb(voxel_key);
 
             if !voxel.is_empty() {
                 // We hit a voxel!

--- a/src/query/shape_cast/mod.rs
+++ b/src/query/shape_cast/mod.rs
@@ -13,6 +13,7 @@ pub use self::{
     },
     shape_cast_heightfield_shape::{cast_shapes_heightfield_shape, cast_shapes_shape_heightfield},
     shape_cast_support_map_support_map::cast_shapes_support_map_support_map,
+    shape_cast_voxels_shape::{cast_shapes_shape_voxels, cast_shapes_voxels_shape},
 };
 
 mod shape_cast;
@@ -24,3 +25,5 @@ mod shape_cast_halfspace_support_map;
 mod shape_cast_heightfield_shape;
 #[cfg(feature = "alloc")]
 mod shape_cast_support_map_support_map;
+#[cfg(feature = "alloc")]
+mod shape_cast_voxels_shape;

--- a/src/query/shape_cast/shape_cast_voxels_shape.rs
+++ b/src/query/shape_cast/shape_cast_voxels_shape.rs
@@ -1,0 +1,154 @@
+use crate::math::{Isometry, Point, Real, Vector, Translation};
+use crate::query::{QueryDispatcher, ShapeCastHit, ShapeCastOptions};
+use crate::shape::{Cuboid, Shape, Voxels};
+
+
+/// Time Of Impact of a voxels shape with any other shape, under a translational movement.
+pub fn cast_shapes_voxels_shape<D>(
+    dispatcher: &D,
+    pos12: &Isometry<Real>,
+    vel12: &Vector<Real>,
+    g1: &Voxels,
+    g2: &dyn Shape,
+    options: ShapeCastOptions,
+) -> Option<ShapeCastHit>
+where
+    D: ?Sized + QueryDispatcher,
+{
+    use num_traits::Bounded;
+
+    let mut hit = None;
+    let mut smallest_t = options.max_time_of_impact;
+    let start_aabb2_1 = g2.compute_aabb(pos12);
+
+
+    let mut check_voxels_in_range = |search_domain: [Point<i32>; 2]| {
+        for vox in g1.voxels_in_range(search_domain[0], search_domain[1]) {
+            if !vox.state.is_empty() {
+                // PERF: could we check the canonical shape instead, and deduplicate accordingly?
+                let center = g1.voxel_center(vox.grid_coords);
+                let cuboid = Cuboid::new(g1.voxel_size() / 2.0);
+                let vox_pos12 = Translation::from(center).inverse() * pos12;
+                if let Some(new_hit) = dispatcher.cast_shapes(
+                    &vox_pos12, vel12, &cuboid, g2, options,
+                ).ok().flatten() {
+                    if new_hit.time_of_impact < smallest_t {
+                        smallest_t = new_hit.time_of_impact;
+                        hit = Some(new_hit);
+                    }
+                }
+            }
+        }
+    };
+
+    let mut search_domain = g1.voxel_range_intersecting_local_aabb(&start_aabb2_1);
+    check_voxels_in_range(search_domain);
+
+    // Run the propagation.
+    let [domain_mins, domain_maxs] = g1.domain();
+
+    loop {
+        let search_domain_aabb = g1.voxel_range_aabb(search_domain[0], search_domain[1]);
+
+        // Figure out if we should move the aabb up/down/right/left.
+        #[cfg(feature = "dim2")]
+        let ii = [0, 1];
+        #[cfg(feature = "dim3")]
+        let ii = [0, 1, 2];
+
+        let toi = ii.map(|i| {
+            if vel12[i] > 0.0 {
+                let t = (search_domain_aabb.maxs[i] - start_aabb2_1.maxs[i]) / vel12[i];
+                if t < 0.0 {
+                    (Real::max_value(), true)
+                } else {
+                    (t, true)
+                }
+            } else if vel12[i] < 0.0 {
+                let t = (search_domain_aabb.mins[i] - start_aabb2_1.mins[i]) / vel12[i];
+                if t < 0.0 {
+                    (Real::max_value(), false)
+                } else {
+                    (t, false)
+                }
+            } else {
+                (Real::max_value(), false)
+            }
+        });
+
+        #[cfg(feature = "dim2")]
+        if toi[0].0 > options.max_time_of_impact && toi[1].0 > options.max_time_of_impact {
+            break;
+        }
+
+        #[cfg(feature = "dim3")]
+        if toi[0].0 > options.max_time_of_impact && toi[1].0 > options.max_time_of_impact && toi[2].0 > options.max_time_of_impact {
+            break;
+        }
+
+        let imin = Vector::from(toi.map(|t| t.0)).imin();
+
+        if toi[imin].1 {
+            search_domain[0][imin] += 1;
+            search_domain[1][imin] += 1;
+
+            if search_domain[1][imin] <= domain_maxs[imin] {
+                // Check the voxels on the added row.
+                let mut prev_row = search_domain[0];
+                prev_row[imin] = search_domain[1][imin] - 1;
+
+                let range_to_check = [
+                    prev_row,
+                    search_domain[1]
+                ];
+                check_voxels_in_range(range_to_check);
+            } else if search_domain[0][imin] >= domain_maxs[imin] {
+                // Leaving the shape’s bounds.
+                break;
+            }
+        } else {
+            search_domain[0][imin] -= 1;
+            search_domain[1][imin] -= 1;
+
+            if search_domain[0][imin] >= domain_mins[imin] {
+                // Check the voxels on the added row.
+                let mut next_row = search_domain[1];
+                next_row[imin] = search_domain[0][imin] + 1;
+
+                let range_to_check = [
+                    search_domain[0],
+                    next_row,
+                ];
+                check_voxels_in_range(range_to_check);
+            } else if search_domain[1][imin] <= domain_mins[imin] {
+                // Leaving the shape’s bounds.
+                break;
+            }
+        }
+    }
+
+    hit
+}
+
+/// Time Of Impact of any shape with a composite shape, under a rigid motion (translation + rotation).
+pub fn cast_shapes_shape_voxels<D>(
+    dispatcher: &D,
+    pos12: &Isometry<Real>,
+    vel12: &Vector<Real>,
+    g1: &dyn Shape,
+    g2: &Voxels,
+    options: ShapeCastOptions,
+) -> Option<ShapeCastHit>
+where
+    D: ?Sized + QueryDispatcher,
+{
+    cast_shapes_voxels_shape(
+        dispatcher,
+        &pos12.inverse(),
+        &-pos12.inverse_transform_vector(vel12),
+        g2,
+        g1,
+        options,
+    )
+        .map(|time_of_impact| time_of_impact.swapped())
+}

--- a/src/query/shape_cast/shape_cast_voxels_shape.rs
+++ b/src/query/shape_cast/shape_cast_voxels_shape.rs
@@ -1,7 +1,6 @@
-use crate::math::{Isometry, Point, Real, Vector, Translation};
+use crate::math::{Isometry, Point, Real, Translation, Vector};
 use crate::query::{QueryDispatcher, ShapeCastHit, ShapeCastOptions};
 use crate::shape::{Cuboid, Shape, Voxels};
-
 
 /// Time Of Impact of a voxels shape with any other shape, under a translational movement.
 pub fn cast_shapes_voxels_shape<D>(
@@ -21,7 +20,6 @@ where
     let mut smallest_t = options.max_time_of_impact;
     let start_aabb2_1 = g2.compute_aabb(pos12);
 
-
     let mut check_voxels_in_range = |search_domain: [Point<i32>; 2]| {
         for vox in g1.voxels_in_range(search_domain[0], search_domain[1]) {
             if !vox.state.is_empty() {
@@ -29,9 +27,11 @@ where
                 let center = g1.voxel_center(vox.grid_coords);
                 let cuboid = Cuboid::new(g1.voxel_size() / 2.0);
                 let vox_pos12 = Translation::from(center).inverse() * pos12;
-                if let Some(new_hit) = dispatcher.cast_shapes(
-                    &vox_pos12, vel12, &cuboid, g2, options,
-                ).ok().flatten() {
+                if let Some(new_hit) = dispatcher
+                    .cast_shapes(&vox_pos12, vel12, &cuboid, g2, options)
+                    .ok()
+                    .flatten()
+                {
                     if new_hit.time_of_impact < smallest_t {
                         smallest_t = new_hit.time_of_impact;
                         hit = Some(new_hit);
@@ -82,7 +82,10 @@ where
         }
 
         #[cfg(feature = "dim3")]
-        if toi[0].0 > options.max_time_of_impact && toi[1].0 > options.max_time_of_impact && toi[2].0 > options.max_time_of_impact {
+        if toi[0].0 > options.max_time_of_impact
+            && toi[1].0 > options.max_time_of_impact
+            && toi[2].0 > options.max_time_of_impact
+        {
             break;
         }
 
@@ -97,10 +100,7 @@ where
                 let mut prev_row = search_domain[0];
                 prev_row[imin] = search_domain[1][imin] - 1;
 
-                let range_to_check = [
-                    prev_row,
-                    search_domain[1]
-                ];
+                let range_to_check = [prev_row, search_domain[1]];
                 check_voxels_in_range(range_to_check);
             } else if search_domain[0][imin] >= domain_maxs[imin] {
                 // Leaving the shape’s bounds.
@@ -115,10 +115,7 @@ where
                 let mut next_row = search_domain[1];
                 next_row[imin] = search_domain[0][imin] + 1;
 
-                let range_to_check = [
-                    search_domain[0],
-                    next_row,
-                ];
+                let range_to_check = [search_domain[0], next_row];
                 check_voxels_in_range(range_to_check);
             } else if search_domain[1][imin] <= domain_mins[imin] {
                 // Leaving the shape’s bounds.
@@ -150,5 +147,5 @@ where
         g1,
         options,
     )
-        .map(|time_of_impact| time_of_impact.swapped())
+    .map(|time_of_impact| time_of_impact.swapped())
 }

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -22,7 +22,7 @@ pub use self::{
     compound::Compound,
     polyline::Polyline,
     shared_shape::SharedShape,
-    voxels::{AxisMask, OctantPattern, VoxelPrimitiveGeometry, VoxelState, VoxelType, Voxels},
+    voxels::{AxisMask, OctantPattern, VoxelPrimitiveGeometry, VoxelState, VoxelType, Voxels, VoxelData},
 };
 
 #[cfg(feature = "dim2")]

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -22,7 +22,9 @@ pub use self::{
     compound::Compound,
     polyline::Polyline,
     shared_shape::SharedShape,
-    voxels::{AxisMask, OctantPattern, VoxelPrimitiveGeometry, VoxelState, VoxelType, Voxels, VoxelData},
+    voxels::{
+        AxisMask, OctantPattern, VoxelData, VoxelPrimitiveGeometry, VoxelState, VoxelType, Voxels,
+    },
 };
 
 #[cfg(feature = "dim2")]

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -219,7 +219,7 @@ impl SharedShape {
 
     /// Initializes a shape made of voxels.
     ///
-    /// Each voxel has the size `voxel_size` and grid coordinate given by `centers`.
+    /// Each voxel has the size `voxel_size` and grid coordinate given by `grid_coords`.
     /// The `primitive_geometry` controls the behavior of collision detection at voxels boundaries.
     ///
     /// For initializing a voxels shape from points in space, see [`Self::voxels_from_points`].
@@ -229,9 +229,9 @@ impl SharedShape {
     pub fn voxels(
         primitive_geometry: VoxelPrimitiveGeometry,
         voxel_size: Vector<Real>,
-        centers: &[Point<i32>],
+        grid_coords: &[Point<i32>],
     ) -> Self {
-        let shape = Voxels::new(primitive_geometry, voxel_size, centers);
+        let shape = Voxels::new(primitive_geometry, voxel_size, grid_coords);
         SharedShape::new(shape)
     }
 

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -399,12 +399,12 @@ impl TriMesh {
     // TODO: support a crate like get_size2 (will require support on nalgebra too)?
     /// An approximation of the memory usage (in bytes) for this struct plus
     /// the memory it allocates dynamically.
-    pub fn get_size(&self) -> usize {
-        size_of::<Self>() + self.get_heap_size()
+    pub fn total_memory_size(&self) -> usize {
+        size_of::<Self>() + self.heap_memory_size()
     }
 
     /// An approximation of the memory dynamically-allocated by this struct.
-    pub fn get_heap_size(&self) -> usize {
+    pub fn heap_memory_size(&self) -> usize {
         // NOTE: if a new field is added to `Self`, adjust this function result.
         let Self {
             qbvh,
@@ -416,7 +416,7 @@ impl TriMesh {
             #[cfg(feature = "dim3")]
             pseudo_normals,
         } = self;
-        let sz_qbvh = qbvh.get_heap_size();
+        let sz_qbvh = qbvh.heap_memory_size();
         let sz_vertices = vertices.capacity() * size_of::<Point<Real>>();
         let sz_indices = indices.capacity() * size_of::<[u32; 3]>();
         #[cfg(feature = "dim3")]

--- a/src/shape/voxels.rs
+++ b/src/shape/voxels.rs
@@ -479,7 +479,11 @@ impl Voxels {
     /// If for any index `i`, `domain_maxs[i] <= domain_mins[i]`, then the new domain is invalid
     /// and this operation returns `None`.
     #[must_use]
-    pub fn with_resized_domain(&self, domain_mins: Point<i32>, domain_maxs: Point<i32>) -> Option<Self> {
+    pub fn with_resized_domain(
+        &self,
+        domain_mins: Point<i32>,
+        domain_maxs: Point<i32>,
+    ) -> Option<Self> {
         if self.domain_mins == domain_mins && self.domain_maxs == domain_maxs {
             // Nothing to change, just clone as-is.
             return Some(self.clone());
@@ -655,8 +659,16 @@ impl Voxels {
     /// the voxels contained within are empty or not.
     pub fn voxel_range_aabb(&self, mins: Point<i32>, maxs: Point<i32>) -> Aabb {
         Aabb {
-            mins: mins.cast::<Real>().coords.component_mul(&self.voxel_size).into(),
-            maxs: maxs.cast::<Real>().coords.component_mul(&self.voxel_size).into(),
+            mins: mins
+                .cast::<Real>()
+                .coords
+                .component_mul(&self.voxel_size)
+                .into(),
+            maxs: maxs
+                .cast::<Real>()
+                .coords
+                .component_mul(&self.voxel_size)
+                .into(),
         }
     }
 
@@ -665,11 +677,17 @@ impl Voxels {
     /// The aligned is calculated such that the returned AABB has corners lying at the grid
     /// intersections (i.e. matches voxel corners) and fully contains the input `aabb`.
     pub fn align_aabb_to_grid(&self, aabb: &Aabb) -> Aabb {
-        let mins = aabb.mins.coords.zip_map(&self.voxel_size, |m, sz| (m / sz).floor() * m).into();
-        let maxs = aabb.maxs.coords.zip_map(&self.voxel_size, |m, sz| (m / sz).ceil() * m).into();
-        Aabb {
-            mins, maxs
-        }
+        let mins = aabb
+            .mins
+            .coords
+            .zip_map(&self.voxel_size, |m, sz| (m / sz).floor() * m)
+            .into();
+        let maxs = aabb
+            .maxs
+            .coords
+            .zip_map(&self.voxel_size, |m, sz| (m / sz).ceil() * m)
+            .into();
+        Aabb { mins, maxs }
     }
 
     /// Iterates through every voxel intersecting the given aabb.

--- a/src/transformation/to_outline/voxels_to_outline.rs
+++ b/src/transformation/to_outline/voxels_to_outline.rs
@@ -35,7 +35,10 @@ impl Voxels {
 
                     for edge in Aabb::EDGES_VERTEX_IDS {
                         if mask & (1 << edge.0) != 0 || mask & (1 << edge.1) != 0 {
-                            f(vox.center + vtx[edge.0].coords, vox.center + vtx[edge.1].coords);
+                            f(
+                                vox.center + vtx[edge.0].coords,
+                                vox.center + vtx[edge.1].coords,
+                            );
                         }
                     }
                 }
@@ -45,7 +48,10 @@ impl Voxels {
 
                     for (i, edge) in Aabb::EDGES_VERTEX_IDS.iter().enumerate() {
                         if mask & (1 << i) != 0 {
-                            f(vox.center + vtx[edge.0].coords, vox.center + vtx[edge.1].coords);
+                            f(
+                                vox.center + vtx[edge.0].coords,
+                                vox.center + vtx[edge.1].coords,
+                            );
                         }
                     }
                 }

--- a/src/transformation/to_outline/voxels_to_outline.rs
+++ b/src/transformation/to_outline/voxels_to_outline.rs
@@ -28,24 +28,24 @@ impl Voxels {
         let aabb = Aabb::from_half_extents(Point::origin(), radius);
         let vtx = aabb.vertices();
 
-        for (_, center, vox_data) in self.centers() {
-            match vox_data.voxel_type() {
+        for vox in self.voxels() {
+            match vox.state.voxel_type() {
                 VoxelType::Vertex => {
-                    let mask = vox_data.feature_mask();
+                    let mask = vox.state.feature_mask();
 
                     for edge in Aabb::EDGES_VERTEX_IDS {
                         if mask & (1 << edge.0) != 0 || mask & (1 << edge.1) != 0 {
-                            f(center + vtx[edge.0].coords, center + vtx[edge.1].coords);
+                            f(vox.center + vtx[edge.0].coords, vox.center + vtx[edge.1].coords);
                         }
                     }
                 }
                 VoxelType::Edge => {
                     let vtx = aabb.vertices();
-                    let mask = vox_data.feature_mask();
+                    let mask = vox.state.feature_mask();
 
                     for (i, edge) in Aabb::EDGES_VERTEX_IDS.iter().enumerate() {
                         if mask & (1 << i) != 0 {
-                            f(center + vtx[edge.0].coords, center + vtx[edge.1].coords);
+                            f(vox.center + vtx[edge.0].coords, vox.center + vtx[edge.1].coords);
                         }
                     }
                 }

--- a/src/transformation/to_polyline/voxels_to_polyline.rs
+++ b/src/transformation/to_polyline/voxels_to_polyline.rs
@@ -32,7 +32,10 @@ impl Voxels {
 
                     for edge in Aabb::FACES_VERTEX_IDS {
                         if mask & (1 << edge.0) != 0 || mask & (1 << edge.1) != 0 {
-                            f(vox.center + vtx[edge.0].coords, vox.center + vtx[edge.1].coords);
+                            f(
+                                vox.center + vtx[edge.0].coords,
+                                vox.center + vtx[edge.1].coords,
+                            );
                         }
                     }
                 }
@@ -42,7 +45,10 @@ impl Voxels {
 
                     for (i, edge) in Aabb::FACES_VERTEX_IDS.iter().enumerate() {
                         if mask & (1 << i) != 0 {
-                            f(vox.center + vtx[edge.0].coords, vox.center + vtx[edge.1].coords);
+                            f(
+                                vox.center + vtx[edge.0].coords,
+                                vox.center + vtx[edge.1].coords,
+                            );
                         }
                     }
                 }

--- a/src/transformation/to_polyline/voxels_to_polyline.rs
+++ b/src/transformation/to_polyline/voxels_to_polyline.rs
@@ -25,24 +25,24 @@ impl Voxels {
         let aabb = Aabb::from_half_extents(Point::origin(), radius);
         let vtx = aabb.vertices();
 
-        for (_, center, vox_data) in self.centers() {
-            match vox_data.voxel_type() {
+        for vox in self.voxels() {
+            match vox.state.voxel_type() {
                 VoxelType::Vertex => {
-                    let mask = vox_data.feature_mask();
+                    let mask = vox.state.feature_mask();
 
                     for edge in Aabb::FACES_VERTEX_IDS {
                         if mask & (1 << edge.0) != 0 || mask & (1 << edge.1) != 0 {
-                            f(center + vtx[edge.0].coords, center + vtx[edge.1].coords);
+                            f(vox.center + vtx[edge.0].coords, vox.center + vtx[edge.1].coords);
                         }
                     }
                 }
                 VoxelType::Face => {
                     let vtx = aabb.vertices();
-                    let mask = vox_data.feature_mask();
+                    let mask = vox.state.feature_mask();
 
                     for (i, edge) in Aabb::FACES_VERTEX_IDS.iter().enumerate() {
                         if mask & (1 << i) != 0 {
-                            f(center + vtx[edge.0].coords, center + vtx[edge.1].coords);
+                            f(vox.center + vtx[edge.0].coords, vox.center + vtx[edge.1].coords);
                         }
                     }
                 }

--- a/src/transformation/to_trimesh/voxels_to_trimesh.rs
+++ b/src/transformation/to_trimesh/voxels_to_trimesh.rs
@@ -14,16 +14,16 @@ impl Voxels {
 
         let mut vtx = vec![];
         let mut idx = vec![];
-        for (_, center, data) in self.centers() {
-            let mask = data.free_faces();
+        for vox in self.voxels() {
+            let mask = vox.state.free_faces();
             for i in 0..6 {
                 if mask.bits() & (1 << i) != 0 {
                     let fvid = Aabb::FACES_VERTEX_IDS[i];
                     let base_id = vtx.len() as u32;
-                    vtx.push(center + aabb_vtx[fvid.0].coords);
-                    vtx.push(center + aabb_vtx[fvid.1].coords);
-                    vtx.push(center + aabb_vtx[fvid.2].coords);
-                    vtx.push(center + aabb_vtx[fvid.3].coords);
+                    vtx.push(vox.center + aabb_vtx[fvid.0].coords);
+                    vtx.push(vox.center + aabb_vtx[fvid.1].coords);
+                    vtx.push(vox.center + aabb_vtx[fvid.2].coords);
+                    vtx.push(vox.center + aabb_vtx[fvid.3].coords);
 
                     if i % 2 == 0 {
                         idx.push([base_id, base_id + 1, base_id + 2]);


### PR DESCRIPTION
## v0.20.1

### Added

- Rework the `Voxels` shape API to use better method names.
- Added implementations for linear and non-linear shape-casting involving `Voxels` shapes.