### PR TITLE
Fix infinite loop in Voxels::set_voxel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.20.2
+
+### Fixed
+
+- Fix infinite loop in `Voxels::set_voxel`.
+
 ## v0.20.1
 
 ### Added

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."

--- a/src/shape/voxels.rs
+++ b/src/shape/voxels.rs
@@ -447,9 +447,9 @@ impl Voxels {
 
             self.resize_domain(new_domain_mins, new_domain_maxs);
 
-            self.set_voxel(key, is_filled)
+            self.try_set_voxel(key, is_filled)
         } else {
-            self.set_voxel(key, is_filled)
+            self.try_set_voxel(key, is_filled)
         }
     }
 


### PR DESCRIPTION
Calling `Voxels::set_voxel` would immediately result in an infinite recursion due to a typo.
This is fixed in this PR.