### PR TITLE
feat: add trimesh raycasting that account for backface/frontface culling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+- Add `TriMesh::cast_ray_with_culling` and `TriMesh::cast_local_ray_with_culling` for casting rays on a triangle mesh
+  but with the possibility to prevents hits on front-faces or back-faces.
+
 ## v0.20.2
 
 ### Fixed

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -44,6 +44,9 @@ pub use self::ray::{Ray, RayCast, RayIntersection, SimdRay};
 pub use self::shape_cast::{cast_shapes, ShapeCastHit, ShapeCastOptions, ShapeCastStatus};
 pub use self::split::{IntersectResult, SplitResult};
 
+#[cfg(feature = "dim3")]
+pub use self::ray::RayCullingMode;
+
 mod clip;
 pub mod closest_points;
 pub mod contact;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -44,7 +44,7 @@ pub use self::ray::{Ray, RayCast, RayIntersection, SimdRay};
 pub use self::shape_cast::{cast_shapes, ShapeCastHit, ShapeCastOptions, ShapeCastStatus};
 pub use self::split::{IntersectResult, SplitResult};
 
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "alloc"))]
 pub use self::ray::RayCullingMode;
 
 mod clip;

--- a/src/query/ray/mod.rs
+++ b/src/query/ray/mod.rs
@@ -9,11 +9,11 @@ pub use self::ray_composite_shape::{
 };
 pub use self::ray_halfspace::{line_toi_with_halfspace, ray_toi_with_halfspace};
 pub use self::ray_support_map::local_ray_intersection_with_support_map_with_params;
-pub use self::simd_ray::SimdRay;
 #[cfg(feature = "dim3")]
-pub use {
-    self::ray_triangle::local_ray_intersection_with_triangle, self::ray_trimesh::RayCullingMode,
-};
+pub use self::ray_triangle::local_ray_intersection_with_triangle;
+#[cfg(all(feature = "dim3", feature = "alloc"))]
+pub use self::ray_trimesh::RayCullingMode;
+pub use self::simd_ray::SimdRay;
 
 #[doc(hidden)]
 pub mod ray;

--- a/src/query/ray/mod.rs
+++ b/src/query/ray/mod.rs
@@ -28,5 +28,7 @@ mod ray_round_shape;
 mod ray_support_map;
 mod ray_triangle;
 #[cfg(feature = "alloc")]
+mod ray_trimesh;
+#[cfg(feature = "alloc")]
 mod ray_voxels;
 mod simd_ray;

--- a/src/query/ray/mod.rs
+++ b/src/query/ray/mod.rs
@@ -9,9 +9,11 @@ pub use self::ray_composite_shape::{
 };
 pub use self::ray_halfspace::{line_toi_with_halfspace, ray_toi_with_halfspace};
 pub use self::ray_support_map::local_ray_intersection_with_support_map_with_params;
-#[cfg(feature = "dim3")]
-pub use self::ray_triangle::local_ray_intersection_with_triangle;
 pub use self::simd_ray::SimdRay;
+#[cfg(feature = "dim3")]
+pub use {
+    self::ray_triangle::local_ray_intersection_with_triangle, self::ray_trimesh::RayCullingMode,
+};
 
 #[doc(hidden)]
 pub mod ray;

--- a/src/query/ray/ray_composite_shape.rs
+++ b/src/query/ray/ray_composite_shape.rs
@@ -2,48 +2,8 @@ use crate::bounding_volume::SimdAabb;
 use crate::math::{Real, SimdBool, SimdReal, SIMD_WIDTH};
 use crate::partitioning::{SimdBestFirstVisitStatus, SimdBestFirstVisitor};
 use crate::query::{Ray, RayCast, RayIntersection, SimdRay};
-use crate::shape::{Compound, FeatureId, Polyline, TriMesh, TypedSimdCompositeShape};
+use crate::shape::{Compound, Polyline, TypedSimdCompositeShape};
 use simba::simd::{SimdBool as _, SimdPartialOrd, SimdValue};
-
-impl RayCast for TriMesh {
-    #[inline]
-    fn cast_local_ray(&self, ray: &Ray, max_time_of_impact: Real, solid: bool) -> Option<Real> {
-        let mut visitor =
-            RayCompositeShapeToiBestFirstVisitor::new(self, ray, max_time_of_impact, solid);
-
-        self.qbvh()
-            .traverse_best_first(&mut visitor)
-            .map(|res| res.1 .1)
-    }
-
-    #[inline]
-    fn cast_local_ray_and_get_normal(
-        &self,
-        ray: &Ray,
-        max_time_of_impact: Real,
-        solid: bool,
-    ) -> Option<RayIntersection> {
-        let mut visitor = RayCompositeShapeToiAndNormalBestFirstVisitor::new(
-            self,
-            ray,
-            max_time_of_impact,
-            solid,
-        );
-
-        self.qbvh()
-            .traverse_best_first(&mut visitor)
-            .map(|(_, (best, mut res))| {
-                // We hit a backface.
-                // NOTE: we need this for `TriMesh::is_backface` to work properly.
-                if res.feature == FeatureId::Face(1) {
-                    res.feature = FeatureId::Face(best + self.indices().len() as u32)
-                } else {
-                    res.feature = FeatureId::Face(best);
-                }
-                res
-            })
-    }
-}
 
 impl RayCast for Polyline {
     #[inline]

--- a/src/query/ray/ray_trimesh.rs
+++ b/src/query/ray/ray_trimesh.rs
@@ -84,7 +84,7 @@ mod ray_cast_with_culling {
         ray: &'a Ray,
     }
 
-    impl<'a> TypedSimdCompositeShape for TriMeshWithCulling<'a> {
+    impl TypedSimdCompositeShape for TriMeshWithCulling<'_> {
         type PartShape = Triangle;
         type PartNormalConstraints = ();
         type PartId = u32;

--- a/src/query/ray/ray_trimesh.rs
+++ b/src/query/ray/ray_trimesh.rs
@@ -1,0 +1,44 @@
+use crate::math::Real;
+use crate::query::{Ray, RayCast, RayIntersection};
+use crate::shape::{FeatureId, TriMesh};
+use crate::query::ray::{RayCompositeShapeToiAndNormalBestFirstVisitor, RayCompositeShapeToiBestFirstVisitor};
+
+impl RayCast for TriMesh {
+    #[inline]
+    fn cast_local_ray(&self, ray: &Ray, max_time_of_impact: Real, solid: bool) -> Option<Real> {
+        let mut visitor =
+            RayCompositeShapeToiBestFirstVisitor::new(self, ray, max_time_of_impact, solid);
+
+        self.qbvh()
+            .traverse_best_first(&mut visitor)
+            .map(|res| res.1 .1)
+    }
+
+    #[inline]
+    fn cast_local_ray_and_get_normal(
+        &self,
+        ray: &Ray,
+        max_time_of_impact: Real,
+        solid: bool,
+    ) -> Option<RayIntersection> {
+        let mut visitor = RayCompositeShapeToiAndNormalBestFirstVisitor::new(
+            self,
+            ray,
+            max_time_of_impact,
+            solid,
+        );
+
+        self.qbvh()
+            .traverse_best_first(&mut visitor)
+            .map(|(_, (best, mut res))| {
+                // We hit a backface.
+                // NOTE: we need this for `TriMesh::is_backface` to work properly.
+                if res.feature == FeatureId::Face(1) {
+                    res.feature = FeatureId::Face(best + self.indices().len() as u32)
+                } else {
+                    res.feature = FeatureId::Face(best);
+                }
+                res
+            })
+    }
+}

--- a/src/query/ray/ray_trimesh.rs
+++ b/src/query/ray/ray_trimesh.rs
@@ -42,3 +42,144 @@ impl RayCast for TriMesh {
             })
     }
 }
+
+// NOTE: implement the ray-cast with culling on its own submodule to facilitate feature gating.
+#[cfg(feature = "dim3")]
+mod ray_cast_with_culling {
+    use crate::math::{Isometry, Real, Vector};
+    use crate::partitioning::{Qbvh};
+    use crate::query::{Ray, RayIntersection};
+    use crate::shape::{FeatureId, Shape, TriMesh, Triangle, TypedSimdCompositeShape};
+    use crate::query::details::NormalConstraints;
+    use crate::query::ray::{RayCompositeShapeToiAndNormalBestFirstVisitor};
+
+    /// Controls which side of a triangle a ray-cast is allowed to hit.
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+    pub enum RayCullingMode {
+        /// Ray-casting won’t hit back faces.
+        BackFacesCulling,
+        /// Ray-casting won’t hit front faces.
+        FrontFacesCulling,
+    }
+
+    impl RayCullingMode {
+        fn check(self, tri_normal: &Vector<Real>, ray_dir: &Vector<Real>) -> bool {
+            match self {
+                RayCullingMode::BackFacesCulling => tri_normal.dot(ray_dir) < 0.0,
+                RayCullingMode::FrontFacesCulling => tri_normal.dot(ray_dir) > 0.0
+            }
+        }
+    }
+
+    /// A utility shape with a `TypedSimdCompositeShape` implementation that skips triangles that
+    /// are back-faces or front-faces relative to a given ray and culling mode.
+    struct TriMeshWithCulling<'a> {
+        trimesh: &'a TriMesh,
+        culling: RayCullingMode,
+        ray: &'a Ray,
+    }
+
+    impl<'a> TypedSimdCompositeShape for TriMeshWithCulling<'a> {
+        type PartShape = Triangle;
+        type PartNormalConstraints = ();
+        type PartId = u32;
+
+        #[inline(always)]
+        fn map_typed_part_at(
+            &self,
+            i: u32,
+            mut f: impl FnMut(
+                Option<&Isometry<Real>>,
+                &Self::PartShape,
+                Option<&Self::PartNormalConstraints>,
+            ),
+        ) {
+            let tri = self.trimesh.triangle(i);
+            let tri_normal = tri.scaled_normal();
+
+            if self.culling.check(&tri_normal, &self.ray.dir) {
+                f(None, &tri, None)
+            }
+        }
+
+        #[inline(always)]
+        fn map_untyped_part_at(
+            &self,
+            i: u32,
+            mut f: impl FnMut(Option<&Isometry<Real>>, &dyn Shape, Option<&dyn NormalConstraints>),
+        ) {
+            let tri = self.trimesh.triangle(i);
+            let tri_normal = tri.scaled_normal();
+
+            if self.culling.check(&tri_normal, &self.ray.dir) {
+                f(
+                    None,
+                    &tri,
+                    None,
+                )
+            }
+        }
+
+        fn typed_qbvh(&self) -> &Qbvh<u32> {
+            self.trimesh.qbvh()
+        }
+    }
+
+    impl TriMesh {
+        /// Casts a ray on this triangle mesh transformed by `m`.
+        ///
+        /// Hits happening later than `max_time_of_impact` are ignored. In other words, hits are
+        /// only searched along the segment `[ray.origin, ray.origin + ray.dir * max_time_of_impact`].
+        ///
+        /// Hits on back-faces or front-faces are ignored, depending on the given `culling` mode.
+        #[inline]
+        pub fn cast_ray_with_culling(
+            &self,
+            m: &Isometry<Real>,
+            ray: &Ray,
+            max_time_of_impact: Real,
+            culling: RayCullingMode,
+        ) -> Option<RayIntersection> {
+            let ls_ray = ray.inverse_transform_by(m);
+            self.cast_local_ray_with_culling(&ls_ray, max_time_of_impact, culling)
+                .map(|inter| inter.transform_by(m))
+        }
+
+        /// Casts a ray on this triangle mesh.
+        ///
+        /// This is the same as [`TriMesh::cast_ray_with_culling`] except that the ray is given
+        /// in the mesh’s local-space.
+        pub fn cast_local_ray_with_culling(
+            &self,
+            ray: &Ray,
+            max_time_of_impact: Real,
+            culling: RayCullingMode,
+        ) -> Option<RayIntersection> {
+            let mesh_with_culling = TriMeshWithCulling {
+                trimesh: self,
+                culling,
+                ray,
+            };
+
+            let mut visitor = RayCompositeShapeToiAndNormalBestFirstVisitor::new(
+                &mesh_with_culling,
+                ray,
+                max_time_of_impact,
+                false,
+            );
+
+            self.qbvh()
+                .traverse_best_first(&mut visitor)
+                .map(|(_, (best, mut res))| {
+                    // We hit a backface.
+                    // NOTE: we need this for `TriMesh::is_backface` to work properly.
+                    if res.feature == FeatureId::Face(1) {
+                        res.feature = FeatureId::Face(best + self.indices().len() as u32)
+                    } else {
+                        res.feature = FeatureId::Face(best);
+                    }
+                    res
+                })
+        }
+    }
+}


### PR DESCRIPTION
This adds (in 3D only) `TriMesh::cast_ray_with_culling` and `TriMesh::cast_local_ray_with_culling` for casting rays on a triangle mesh but with the possibility to prevents hits on front-faces or back-faces.
