### PR TITLE
Release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   but with the possibility to prevents hits on front-faces or back-faces.
 - Add contact manifold calculation between two voxels shapes, or a voxels shape and compound shape.
 - Add intersection check between voxels and other shapes.
+- Add `MassProperties::from_voxels` to compute the mass and angular inertia tensor from a voxels shape.
 
 ### Modified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # Change Log
 
-## Unreleased
+## 0.21.0
 
 ### Added
 
 - Add `TriMesh::cast_ray_with_culling` and `TriMesh::cast_local_ray_with_culling` for casting rays on a triangle mesh
   but with the possibility to prevents hits on front-faces or back-faces.
+- Add contact manifold calculation between two voxels shapes, or a voxels shape and compound shape.
+- Add intersection check between voxels and other shapes.
+
+### Modified
+
+- Add new variants to `TypedWorkspaceData` for voxels-voxels and voxels-compound collision detection workspace
+  data.
+- The `Voxels` shape now only support cuboids as their leaf geometries (pseudo-balls were removed). 
 
 ## v0.20.2
 

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.20.2"
+version = "0.21.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.20.2"
+version = "0.21.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.20.2"
+version = "0.21.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.20.2"
+version = "0.21.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -477,6 +477,15 @@ impl Aabb {
         ]
     }
 
+    /// Enlarges this AABB on each side by the given `half_extents`.
+    #[must_use]
+    pub fn add_half_extents(&self, half_extents: &Vector<Real>) -> Self {
+        Self {
+            mins: self.mins - half_extents,
+            maxs: self.maxs + half_extents,
+        }
+    }
+
     /// Projects every point of `Aabb` on an arbitrary axis.
     pub fn project_on_axis(&self, axis: &UnitVector<Real>) -> (Real, Real) {
         let cuboid = Cuboid::new(self.half_extents());

--- a/src/mass_properties/mass_properties_voxels.rs
+++ b/src/mass_properties/mass_properties_voxels.rs
@@ -1,5 +1,5 @@
 use crate::mass_properties::MassProperties;
-use crate::math::{Point, Real, Vector};
+use crate::math::{Point, Real};
 use crate::shape::Voxels;
 
 impl MassProperties {
@@ -8,8 +8,7 @@ impl MassProperties {
         let mut com = Point::origin();
         let mut num_not_empty = 0;
         let mut angular_inertia = na::zero();
-        let block_ref_mprops =
-            MassProperties::from_cuboid(density, voxels.voxel_size() / 2.0);
+        let block_ref_mprops = MassProperties::from_cuboid(density, voxels.voxel_size() / 2.0);
 
         for vox in voxels.voxels() {
             if !vox.state.is_empty() {
@@ -22,7 +21,8 @@ impl MassProperties {
 
         for vox in voxels.voxels() {
             if !vox.state.is_empty() {
-                angular_inertia += block_ref_mprops.construct_shifted_inertia_matrix(vox.center - com);
+                angular_inertia +=
+                    block_ref_mprops.construct_shifted_inertia_matrix(vox.center - com);
             }
         }
 

--- a/src/mass_properties/mass_properties_voxels.rs
+++ b/src/mass_properties/mass_properties_voxels.rs
@@ -1,0 +1,36 @@
+use crate::mass_properties::MassProperties;
+use crate::math::{Point, Real, Vector};
+use crate::shape::Voxels;
+
+impl MassProperties {
+    /// Computes the mass properties of a set of voxels.
+    pub fn from_voxels(density: Real, voxels: &Voxels) -> Self {
+        let mut com = Point::origin();
+        let mut num_not_empty = 0;
+        let mut angular_inertia = na::zero();
+        let block_ref_mprops =
+            MassProperties::from_cuboid(density, voxels.voxel_size() / 2.0);
+
+        for vox in voxels.voxels() {
+            if !vox.state.is_empty() {
+                com += vox.center.coords;
+                num_not_empty += 1;
+            }
+        }
+
+        com.coords /= num_not_empty as Real;
+
+        for vox in voxels.voxels() {
+            if !vox.state.is_empty() {
+                angular_inertia += block_ref_mprops.construct_shifted_inertia_matrix(vox.center - com);
+            }
+        }
+
+        let mass = block_ref_mprops.mass() * num_not_empty as Real;
+
+        #[cfg(feature = "dim2")]
+        return Self::new(com, mass, angular_inertia);
+        #[cfg(feature = "dim3")]
+        return Self::with_inertia_matrix(com, mass, angular_inertia);
+    }
+}

--- a/src/mass_properties/mod.rs
+++ b/src/mass_properties/mod.rs
@@ -26,6 +26,8 @@ mod mass_properties_trimesh2d;
 #[cfg(feature = "alloc")]
 mod mass_properties_trimesh3d;
 
+mod mass_properties_voxels;
+
 /// Free functions for some special-cases of mass-properties computation.
 pub mod details {
     #[cfg(feature = "dim2")]

--- a/src/mass_properties/mod.rs
+++ b/src/mass_properties/mod.rs
@@ -26,6 +26,7 @@ mod mass_properties_trimesh2d;
 #[cfg(feature = "alloc")]
 mod mass_properties_trimesh3d;
 
+#[cfg(feature = "alloc")]
 mod mass_properties_voxels;
 
 /// Free functions for some special-cases of mass-properties computation.

--- a/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
@@ -2,8 +2,7 @@ use crate::bounding_volume::BoundingVolume;
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::query::{ContactManifold, PointQuery, TrackedContact};
 use crate::shape::{
-    Ball, Cuboid, OctantPattern, PackedFeatureId, Shape, VoxelState,
-    VoxelType, Voxels,
+    Ball, Cuboid, OctantPattern, PackedFeatureId, Shape, VoxelState, VoxelType, Voxels,
 };
 use alloc::vec::Vec;
 

--- a/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
@@ -2,7 +2,7 @@ use crate::bounding_volume::BoundingVolume;
 use crate::math::{Isometry, Point, Real, Vector};
 use crate::query::{ContactManifold, PointQuery, TrackedContact};
 use crate::shape::{
-    Ball, Cuboid, OctantPattern, PackedFeatureId, Shape, VoxelPrimitiveGeometry, VoxelState,
+    Ball, Cuboid, OctantPattern, PackedFeatureId, Shape, VoxelState,
     VoxelType, Voxels,
 };
 use alloc::vec::Vec;
@@ -54,7 +54,6 @@ pub fn contact_manifolds_voxels_ball<'a, ManifoldData, ContactData>(
     // FIXME: optimize this.
     let aabb1 = voxels1.local_aabb().loosened(prediction / 2.0);
     let aabb2 = ball2.aabb(pos12).loosened(prediction / 2.0);
-    let geometry1 = voxels1.primitive_geometry();
     if let Some(aabb_intersection) = aabb1.intersection(&aabb2) {
         for vox1 in voxels1.voxels_intersecting_local_aabb(&aabb_intersection) {
             match vox1.state.voxel_type() {
@@ -70,7 +69,6 @@ pub fn contact_manifolds_voxels_ball<'a, ManifoldData, ContactData>(
                 vox1.center,
                 radius1,
                 vox1.state,
-                geometry1,
                 center2,
                 radius2,
                 prediction,
@@ -86,7 +84,6 @@ pub(crate) fn detect_hit_voxel_ball<ManifoldData, ContactData>(
     center1: Point<Real>,
     radius1: Vector<Real>,
     data1: VoxelState,
-    geometry1: VoxelPrimitiveGeometry,
     center2: Point<Real>,
     radius2: Real,
     prediction: Real,
@@ -97,15 +94,7 @@ pub(crate) fn detect_hit_voxel_ball<ManifoldData, ContactData>(
     ContactData: Default + Copy,
 {
     let center2_1 = pos12 * center2;
-
-    let projection = match geometry1 {
-        VoxelPrimitiveGeometry::PseudoBall => {
-            project_point_on_pseudo_ball(center1, radius1.x, data1.octant_mask(), center2_1)
-        }
-        VoxelPrimitiveGeometry::PseudoCube => {
-            project_point_on_pseudo_cube(center1, radius1, data1.octant_mask(), center2_1)
-        }
-    };
+    let projection = project_point_on_pseudo_cube(center1, radius1, data1.octant_mask(), center2_1);
 
     if let Some((local_n1, dist_to_voxel)) = projection {
         let dist = dist_to_voxel - radius2;
@@ -137,90 +126,6 @@ pub(crate) fn detect_hit_voxel_ball<ManifoldData, ContactData>(
             manifolds.push(manifold);
         }
     }
-}
-
-pub fn project_point_on_pseudo_ball(
-    voxel_center: Point<Real>,
-    voxel_radius: Real,
-    voxel_mask: u32,
-    point: Point<Real>,
-) -> Option<(Vector<Real>, Real)> {
-    let dpos = point - voxel_center;
-
-    // This maps our easy-to map octant_key, to the vertex key as
-    // used by the Aabb::FACES_VERTEX_IDS and Aabb::EDGES_VERTEX_IDS
-    // arrays. Could we find a way to avoid this map by computing the
-    // correct key right away?
-    //
-    // NOTE: in 2D the array is [0, 1, 3, 2] which matches the one in 3D.
-    const AABB_OCTANT_KEYS: [u32; 8] = [0, 1, 3, 2, 4, 5, 7, 6];
-    #[cfg(feature = "dim2")]
-    let octant_key = (dpos.x >= 0.0) as usize | (((dpos.y >= 0.0) as usize) << 1);
-    #[cfg(feature = "dim3")]
-    let octant_key = (dpos.x >= 0.0) as usize
-        | (((dpos.y >= 0.0) as usize) << 1)
-        | (((dpos.z >= 0.0) as usize) << 2);
-    let aabb_octant_key = AABB_OCTANT_KEYS[octant_key];
-    let dpos_signs = dpos.map(|x| x.signum());
-    let unit_dpos = dpos.abs() / voxel_radius; // Project the point in "local unit octant space".
-                                               // Extract the feature pattern specific to the selected octant.
-    let pattern = (voxel_mask >> (aabb_octant_key * 3)) & 0b0111;
-
-    let unit_result = match pattern {
-        OctantPattern::INTERIOR => None,
-        OctantPattern::VERTEX => {
-            let mut normal = unit_dpos;
-            let dist = normal.try_normalize_mut(1.0e-8)?;
-            Some((normal, dist))
-        }
-        #[cfg(feature = "dim3")]
-        OctantPattern::EDGE_X | OctantPattern::EDGE_Y | OctantPattern::EDGE_Z => {
-            let i = pattern as usize - OctantPattern::EDGE_X as usize;
-
-            if unit_dpos[i] > 1.0 || unit_dpos[i] < 0.0 {
-                None
-            } else {
-                let mut normal = unit_dpos;
-                normal[i] = 0.0;
-                let dist = normal.try_normalize_mut(1.0e-8)?;
-                Some((normal, dist))
-            }
-        }
-        #[cfg(feature = "dim2")]
-        OctantPattern::FACE_X | OctantPattern::FACE_Y => {
-            let i1 = pattern as usize - OctantPattern::FACE_X as usize;
-            let i2 = (i1 + 1) % 2;
-
-            if unit_dpos[i2] > 1.0 || unit_dpos[i2] < 0.0 {
-                None
-            } else {
-                let dist = unit_dpos[i1];
-                Some((Vector::ith(i1, 1.0), dist))
-            }
-        }
-        #[cfg(feature = "dim3")]
-        OctantPattern::FACE_X | OctantPattern::FACE_Y | OctantPattern::FACE_Z => {
-            let i1 = pattern as usize - OctantPattern::FACE_X as usize;
-            let i2 = (i1 + 1) % 3;
-            let i3 = (i1 + 2) % 3;
-
-            if unit_dpos[i2] > 1.0
-                || unit_dpos[i2] < 0.0
-                || unit_dpos[i3] > 1.0
-                || unit_dpos[i3] < 0.0
-            {
-                None
-            } else {
-                let dist = unit_dpos[i1];
-                Some((Vector::ith(i1, 1.0), dist))
-            }
-        }
-        _ => unreachable!(),
-    };
-
-    // NOTE: the subtraction by 1 in `(d - 1.0)` is so that the distance is expressed relative
-    //       to the voxel boundary instead of its center.
-    unit_result.map(|(n, d)| (n.component_mul(&dpos_signs), (d - 1.0) * voxel_radius))
 }
 
 pub fn project_point_on_pseudo_cube(

--- a/src/query/contact_manifolds/contact_manifolds_voxels_composite_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_composite_shape.rs
@@ -1,0 +1,296 @@
+use crate::bounding_volume::Aabb;
+use crate::math::{Isometry, Real, Translation, Vector};
+use crate::query::details::{
+    CanonicalVoxelShape, VoxelsShapeContactManifoldsWorkspace, VoxelsShapeSubDetector,
+};
+use crate::query::visitors::BoundingVolumeIntersectionsVisitor;
+use crate::query::{
+    ContactManifold, ContactManifoldsWorkspace, PersistentQueryDispatcher, PointQuery,
+    TypedWorkspaceData, WorkspaceData,
+};
+use crate::shape::{Cuboid, Shape, SimdCompositeShape, SupportMap, VoxelType, Voxels};
+use crate::utils::hashmap::Entry;
+use crate::utils::IsometryOpt;
+use alloc::{boxed::Box, vec::Vec};
+use na::Vector3;
+
+impl WorkspaceData for VoxelsShapeContactManifoldsWorkspace<3> {
+    fn as_typed_workspace_data(&self) -> TypedWorkspaceData {
+        TypedWorkspaceData::VoxelsCompositeShapeContactManifoldsWorkspace(self)
+    }
+
+    fn clone_dyn(&self) -> Box<dyn WorkspaceData> {
+        Box::new(self.clone())
+    }
+}
+
+/// Computes the contact manifold between voxels and a composite shape, both represented as a `Shape` trait-object.
+pub fn contact_manifolds_voxels_composite_shape_shapes<ManifoldData, ContactData>(
+    dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
+    pos12: &Isometry<Real>,
+    shape1: &dyn Shape,
+    shape2: &dyn Shape,
+    prediction: Real,
+    manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+    workspace: &mut Option<ContactManifoldsWorkspace>,
+) where
+    ManifoldData: Default + Clone,
+    ContactData: Default + Copy,
+{
+    if let (Some(voxels1), Some(shape2)) = (shape1.as_voxels(), shape2.as_composite_shape()) {
+        contact_manifolds_voxels_composite_shape(
+            dispatcher, pos12, voxels1, shape2, prediction, manifolds, workspace, false,
+        );
+    } else if let (Some(shape1), Some(voxels2)) = (shape1.as_composite_shape(), shape2.as_voxels())
+    {
+        contact_manifolds_voxels_composite_shape(
+            dispatcher,
+            &pos12.inverse(),
+            voxels2,
+            shape1,
+            prediction,
+            manifolds,
+            workspace,
+            true,
+        );
+    }
+}
+
+/// Computes the contact manifold between voxels and a composite shape.
+pub fn contact_manifolds_voxels_composite_shape<ManifoldData, ContactData>(
+    dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
+    pos12: &Isometry<Real>,
+    voxels1: &Voxels,
+    shape2: &dyn SimdCompositeShape,
+    prediction: Real,
+    manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+    workspace: &mut Option<ContactManifoldsWorkspace>,
+    flipped: bool,
+) where
+    ManifoldData: Default + Clone,
+    ContactData: Default + Copy,
+{
+    VoxelsShapeContactManifoldsWorkspace::<3>::ensure_exists(workspace);
+    let workspace: &mut VoxelsShapeContactManifoldsWorkspace<3> =
+        workspace.as_mut().unwrap().0.downcast_mut().unwrap();
+    let new_timestamp = !workspace.timestamp;
+    workspace.timestamp = new_timestamp;
+
+    // TODO: avoid reallocating the new `manifolds` vec at each step.
+    let mut old_manifolds = core::mem::take(manifolds);
+    let qbvh2 = shape2.qbvh();
+    let mut stack2 = Vec::new();
+
+    let radius1 = voxels1.voxel_size() / 2.0;
+
+    let aabb1 = voxels1.local_aabb();
+    let aabb2_1 = shape2.qbvh().root_aabb().transform_by(pos12);
+    let domain2_1 = Aabb {
+        mins: aabb2_1.mins - radius1 * 10.0,
+        maxs: aabb2_1.maxs + radius1 * 10.0,
+    };
+
+    if let Some(intersection_aabb1) = aabb1.intersection(&aabb2_1) {
+        for vox1 in voxels1.voxels_intersecting_local_aabb(&intersection_aabb1) {
+            let vox_type1 = vox1.state.voxel_type();
+
+            // TODO: would be nice to have a strategy to handle interior voxels for depenetration.
+            if vox_type1 == VoxelType::Empty || vox_type1 == VoxelType::Interior {
+                continue;
+            }
+
+            // PERF: could we avoid repeated QBVH traversals involving the same canonical shape?
+            //       The issue is that we need to figure out what contact manifolds are associated
+            //       to that canonical shape so we can update the included contact bitmask (and
+            //       one way of figuring this out is to re-traverse the qbvh).
+            let canon1 = CanonicalVoxelShape::from_voxel(voxels1, &vox1);
+            let (canonical_center1, canonical_shape1) = canon1.cuboid(voxels1, &vox1, domain2_1);
+            let canonical_pose12 = Translation::from(-canonical_center1) * pos12;
+
+            let mut detect_hit = |leaf2: &u32| {
+                let key = Vector3::new(canon1.workspace_key.x, canon1.workspace_key.y, *leaf2);
+
+                // TODO: could we refactor the workspace system between Voxels, HeightField, and CompoundShape?
+                //       (and maybe TriMesh too but it’s using a different approach).
+                let (sub_detector, manifold_updated) = match workspace.sub_detectors.entry(key) {
+                    Entry::Occupied(entry) => {
+                        let sub_detector = entry.into_mut();
+
+                        if sub_detector.timestamp != new_timestamp {
+                            let manifold = old_manifolds[sub_detector.manifold_id].take();
+                            *sub_detector = VoxelsShapeSubDetector {
+                                manifold_id: manifolds.len(),
+                                timestamp: new_timestamp,
+                                selected_contacts: 0,
+                            };
+
+                            manifolds.push(manifold);
+                            (sub_detector, false)
+                        } else {
+                            (sub_detector, true)
+                        }
+                    }
+                    Entry::Vacant(entry) => {
+                        let sub_detector = VoxelsShapeSubDetector {
+                            manifold_id: manifolds.len(),
+                            selected_contacts: 0,
+                            timestamp: new_timestamp,
+                        };
+
+                        let vox_id = vox1.linear_id;
+                        let (id1, id2) = if flipped {
+                            (*leaf2, vox_id)
+                        } else {
+                            (vox_id, *leaf2)
+                        };
+                        manifolds.push(ContactManifold::with_data(
+                            id1,
+                            id2,
+                            ManifoldData::default(),
+                        ));
+
+                        (entry.insert(sub_detector), false)
+                    }
+                };
+
+                /*
+                 * Update the contact manifold if needed.
+                 */
+                let manifold = &mut manifolds[sub_detector.manifold_id];
+
+                shape2.map_part_at(*leaf2, &mut |part_pos2, part_shape2, _| {
+                    let relative_pos12 = part_pos2.prepend_to(&canonical_pose12);
+
+                    if !manifold_updated {
+                        // If we already computed contacts in the previous simulation step, their
+                        // local points are relative to the previously calculated canonical shape
+                        // which might not have the same local center as the one computed in this
+                        // step (because it’s based on the position of shape2 relative to voxels1).
+                        // So we need to adjust the local points to account for the position difference
+                        // and keep the point at the same "canonical-shape-space" location as in the previous frame.
+                        let prev_center = if flipped {
+                            manifold
+                                .subshape_pos2
+                                .as_ref()
+                                .map(|p| p.translation.vector)
+                                .unwrap_or_default()
+                        } else {
+                            manifold
+                                .subshape_pos1
+                                .as_ref()
+                                .map(|p| p.translation.vector)
+                                .unwrap_or_default()
+                        };
+                        let delta_center = canonical_center1.coords - prev_center;
+
+                        if flipped {
+                            for pt in &mut manifold.points {
+                                pt.local_p2 -= delta_center;
+                            }
+                        } else {
+                            for pt in &mut manifold.points {
+                                pt.local_p1 -= delta_center;
+                            }
+                        }
+
+                        // Update contacts.
+                        if flipped {
+                            manifold.subshape_pos1 = part_pos2.copied();
+                            manifold.subshape_pos2 = Some(Isometry::from(canonical_center1));
+                            let _ = dispatcher.contact_manifold_convex_convex(
+                                &relative_pos12.inverse(),
+                                part_shape2,
+                                &canonical_shape1,
+                                None,
+                                None,
+                                prediction,
+                                manifold,
+                            );
+                        } else {
+                            manifold.subshape_pos1 = Some(Isometry::from(canonical_center1));
+                            manifold.subshape_pos2 = part_pos2.copied();
+                            let _ = dispatcher.contact_manifold_convex_convex(
+                                &relative_pos12,
+                                &canonical_shape1,
+                                part_shape2,
+                                None,
+                                None,
+                                prediction,
+                                manifold,
+                            );
+                        }
+                    }
+
+                    /*
+                     * Filter-out points that don’t belong to this block.
+                     */
+                    let test_voxel = Cuboid::new(radius1 + Vector::repeat(1.0e-2));
+                    let penetration_dir1 = if flipped {
+                        manifold.local_n2
+                    } else {
+                        manifold.local_n1
+                    };
+
+                    for (i, pt) in manifold.points.iter().enumerate() {
+                        if pt.dist < 0.0 {
+                            // If this is a penetration, double-check that we are not hitting the
+                            // interior of the infinitely expanded canonical shape by checking if
+                            // the opposite normal had led to a better vector.
+                            let cuboid1 = Cuboid::new(radius1);
+                            let sp1 = cuboid1.local_support_point(&-penetration_dir1)
+                                + vox1.center.coords;
+                            let sm2 = part_shape2
+                                .as_support_map()
+                                .expect("Unsupported collision pair.");
+                            let sp2 = sm2.support_point(&relative_pos12, &penetration_dir1)
+                                + canonical_center1.coords;
+                            let test_dist = (sp2 - sp1).dot(&-penetration_dir1);
+                            let keep = test_dist < pt.dist;
+
+                            if !keep {
+                                // We don’t want to keep this point as it is an incorrect penetration
+                                // caused by the canonical shape expansion.
+                                continue;
+                            }
+                        }
+
+                        let pt_in_voxel_space = if flipped {
+                            manifold.subshape_pos2.transform_point(&pt.local_p2)
+                                - vox1.center.coords
+                        } else {
+                            manifold.subshape_pos1.transform_point(&pt.local_p1)
+                                - vox1.center.coords
+                        };
+                        sub_detector.selected_contacts |=
+                            (test_voxel.contains_local_point(&pt_in_voxel_space) as u32) << i;
+                    }
+                });
+
+                true
+            };
+
+            let canon_aabb1_2 = canonical_shape1.compute_aabb(&canonical_pose12.inverse());
+            let mut visitor2 =
+                BoundingVolumeIntersectionsVisitor::new(&canon_aabb1_2, &mut detect_hit);
+            let _ = qbvh2.traverse_depth_first_with_stack(&mut visitor2, &mut stack2);
+        }
+    }
+
+    // Remove contacts marked as ignored.
+    for sub_detector in workspace.sub_detectors.values() {
+        if sub_detector.timestamp == new_timestamp {
+            let manifold = &mut manifolds[sub_detector.manifold_id];
+            let mut k = 0;
+            manifold.points.retain(|_| {
+                let keep = (sub_detector.selected_contacts & (1 << k)) != 0;
+                k += 1;
+                keep
+            });
+        }
+    }
+
+    // Remove detectors which no longer index a valid manifold.
+    workspace
+        .sub_detectors
+        .retain(|_, detector| detector.timestamp == new_timestamp);
+}

--- a/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
@@ -4,10 +4,7 @@ use crate::query::{
     ContactManifold, ContactManifoldsWorkspace, PersistentQueryDispatcher, PointQuery,
     TypedWorkspaceData, WorkspaceData,
 };
-use crate::shape::{
-    AxisMask, Cuboid, Shape, SupportMap, VoxelData, VoxelType,
-    Voxels,
-};
+use crate::shape::{AxisMask, Cuboid, Shape, SupportMap, VoxelData, VoxelType, Voxels};
 use crate::utils::hashmap::{Entry, HashMap};
 use crate::utils::IsometryOpt;
 use alloc::{boxed::Box, vec::Vec};

--- a/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
@@ -5,7 +5,7 @@ use crate::query::{
     TypedWorkspaceData, WorkspaceData,
 };
 use crate::shape::{
-    AxisMask, Cuboid, RoundShape, Shape, SupportMap, VoxelData, VoxelPrimitiveGeometry, VoxelType,
+    AxisMask, Cuboid, Shape, SupportMap, VoxelData, VoxelType,
     Voxels,
 };
 use crate::utils::hashmap::{Entry, HashMap};
@@ -196,16 +196,7 @@ pub fn contact_manifolds_voxels_shape<ManifoldData, ContactData>(
                 let (canonical_center1, canonical_pseudo_cube1) =
                     canon1.cuboid(voxels1, &vox1, domain2_1);
 
-                let canonical_pseudo_ball1 = RoundShape {
-                    inner_shape: Cuboid::new(canonical_pseudo_cube1.half_extents - radius1),
-                    border_radius: radius1.x,
-                };
-
-                let canonical_shape1 = match voxels1.primitive_geometry() {
-                    VoxelPrimitiveGeometry::PseudoBall => &canonical_pseudo_ball1 as &dyn Shape,
-                    VoxelPrimitiveGeometry::PseudoCube => &canonical_pseudo_cube1 as &dyn Shape,
-                };
-
+                let canonical_shape1 = &canonical_pseudo_cube1 as &dyn Shape;
                 let canonical_pos12 = Translation::from(-canonical_center1) * pos12;
 
                 // If we already computed contacts in the previous simulation step, their

--- a/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
@@ -65,7 +65,7 @@ fn ensure_workspace_exists(workspace: &mut Option<ContactManifoldsWorkspace>) {
     )));
 }
 
-/// Computes the contact manifold between a convex shape and a ball, both represented as a `Shape` trait-object.
+/// Computes the contact manifold between a convex shape and a voxels shape, both represented as a `Shape` trait-object.
 pub fn contact_manifolds_voxels_shape_shapes<ManifoldData, ContactData>(
     dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
     pos12: &Isometry<Real>,
@@ -96,7 +96,7 @@ pub fn contact_manifolds_voxels_shape_shapes<ManifoldData, ContactData>(
     }
 }
 
-/// Computes the contact manifold between a convex shape and a ball.
+/// Computes the contact manifold between a convex shape and a voxels shape.
 pub fn contact_manifolds_voxels_shape<ManifoldData, ContactData>(
     dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
     pos12: &Isometry<Real>,

--- a/src/query/contact_manifolds/contact_manifolds_voxels_voxels.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_voxels.rs
@@ -1,4 +1,4 @@
-use crate::bounding_volume::{BoundingVolume};
+use crate::bounding_volume::BoundingVolume;
 use crate::math::{Isometry, Real, Translation, Vector};
 use crate::query::contact_manifolds::{CanonicalVoxelShape, VoxelsShapeContactManifoldsWorkspace};
 use crate::query::details::VoxelsShapeSubDetector;
@@ -7,7 +7,7 @@ use crate::query::{
     TypedWorkspaceData, WorkspaceData,
 };
 use crate::shape::{Cuboid, Shape, SupportMap, VoxelData, VoxelType, Voxels};
-use crate::utils::hashmap::{Entry};
+use crate::utils::hashmap::Entry;
 use crate::utils::IsometryOpt;
 use alloc::{boxed::Box, vec::Vec};
 use na::Vector4;
@@ -78,9 +78,7 @@ pub fn contact_manifolds_voxels_voxels<'a, ManifoldData, ContactData>(
         aabb1.aligned_intersections(pos12, &aabb2)
     {
         let domain_margin = (radius1 + radius2) * 10.0;
-        let full_domain2_1 = voxels2
-            .compute_aabb(pos12)
-            .add_half_extents(&domain_margin);
+        let full_domain2_1 = voxels2.compute_aabb(pos12).add_half_extents(&domain_margin);
         let domain2_1 = full_domain2_1
             .intersection(&aabb1.add_half_extents(&domain_margin))
             .unwrap_or(full_domain2_1);

--- a/src/query/contact_manifolds/contact_manifolds_voxels_voxels.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_voxels.rs
@@ -1,53 +1,238 @@
-use crate::bounding_volume::{Aabb, BoundingVolume};
-use crate::math::{Isometry, Real, Vector};
-use crate::query::ContactManifold;
-use crate::shape::{Shape, VoxelType, Voxels};
-use crate::query::contact_manifolds::contact_manifolds_voxels_ball::detect_hit_voxel_ball;
-use alloc::vec::Vec;
+use crate::bounding_volume::{BoundingVolume};
+use crate::math::{Isometry, Real, Translation, Vector};
+use crate::query::contact_manifolds::{CanonicalVoxelShape, VoxelsShapeContactManifoldsWorkspace};
+use crate::query::details::VoxelsShapeSubDetector;
+use crate::query::{
+    ContactManifold, ContactManifoldsWorkspace, PersistentQueryDispatcher, PointQuery,
+    TypedWorkspaceData, WorkspaceData,
+};
+use crate::shape::{Cuboid, Shape, SupportMap, VoxelData, VoxelType, Voxels};
+use crate::utils::hashmap::{Entry};
+use crate::utils::IsometryOpt;
+use alloc::{boxed::Box, vec::Vec};
+use na::Vector4;
+
+impl WorkspaceData for VoxelsShapeContactManifoldsWorkspace<4> {
+    fn as_typed_workspace_data(&self) -> TypedWorkspaceData {
+        TypedWorkspaceData::VoxelsVoxelsContactManifoldsWorkspace(self)
+    }
+
+    fn clone_dyn(&self) -> Box<dyn WorkspaceData> {
+        Box::new(self.clone())
+    }
+}
 
 /// Computes the contact manifold between a convex shape and a ball, both represented as a `Shape` trait-object.
 pub fn contact_manifolds_voxels_voxels_shapes<ManifoldData, ContactData>(
+    dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
     pos12: &Isometry<Real>,
     shape1: &dyn Shape,
     shape2: &dyn Shape,
     prediction: Real,
     manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+    workspace: &mut Option<ContactManifoldsWorkspace>,
 ) where
-    ManifoldData: Default,
+    ManifoldData: Default + Clone,
     ContactData: Default + Copy,
 {
     if let (Some(voxels1), Some(voxels2)) = (shape1.as_voxels(), shape2.as_voxels()) {
-        contact_manifolds_voxels_voxels(pos12, voxels1, voxels2, prediction, manifolds);
+        contact_manifolds_voxels_voxels(
+            dispatcher, pos12, voxels1, voxels2, prediction, manifolds, workspace,
+        );
     }
 }
 
 /// Computes the contact manifold between a convex shape and a ball.
 pub fn contact_manifolds_voxels_voxels<'a, ManifoldData, ContactData>(
+    dispatcher: &dyn PersistentQueryDispatcher<ManifoldData, ContactData>,
     pos12: &Isometry<Real>,
     voxels1: &'a Voxels,
     voxels2: &'a Voxels,
     prediction: Real,
     manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+    workspace: &mut Option<ContactManifoldsWorkspace>,
 ) where
-    ManifoldData: Default,
+    ManifoldData: Default + Clone,
     ContactData: Default + Copy,
 {
-    // TODO: don’t generate one manifold per voxel.
-    manifolds.clear();
+    VoxelsShapeContactManifoldsWorkspace::<4>::ensure_exists(workspace);
+    let workspace: &mut VoxelsShapeContactManifoldsWorkspace<4> =
+        workspace.as_mut().unwrap().0.downcast_mut().unwrap();
+    let new_timestamp = !workspace.timestamp;
+    workspace.timestamp = new_timestamp;
+
+    // TODO: avoid reallocating the new `manifolds` vec at each step.
+    let mut old_manifolds = core::mem::take(manifolds);
 
     let radius1 = voxels1.voxel_size() / 2.0;
     let radius2 = voxels2.voxel_size() / 2.0;
 
-    // FIXME: optimize this.
     let aabb1 = voxels1.local_aabb().loosened(prediction / 2.0);
     let aabb2 = voxels2.local_aabb().loosened(prediction / 2.0);
-    let geometry1 = voxels1.primitive_geometry();
-    let geometry2 = voxels2.primitive_geometry();
+
+    let pos21 = pos12.inverse();
+
+    let mut checked_hits = 0;
 
     if let Some((intersection_aabb1, intersection_aabb2)) =
         aabb1.aligned_intersections(pos12, &aabb2)
     {
-        let pos21 = pos12.inverse();
+        let domain_margin = (radius1 + radius2) * 10.0;
+        let full_domain2_1 = voxels2
+            .compute_aabb(pos12)
+            .add_half_extents(&domain_margin);
+        let domain2_1 = full_domain2_1
+            .intersection(&aabb1.add_half_extents(&domain_margin))
+            .unwrap_or(full_domain2_1);
+        let full_domain1_2 = voxels1
+            .compute_aabb(&pos21)
+            .add_half_extents(&domain_margin);
+        let domain1_2 = full_domain1_2
+            .intersection(&aabb2.add_half_extents(&domain_margin))
+            .unwrap_or(full_domain1_2);
+
+        let mut detect_hit = |canon1: CanonicalVoxelShape,
+                              canon2: CanonicalVoxelShape,
+                              vox1: &VoxelData,
+                              vox2: &VoxelData| {
+            // Compute canonical shapes and dispatch.
+            let workspace_key = Vector4::new(
+                canon1.workspace_key[0],
+                canon1.workspace_key[1],
+                canon2.workspace_key[0],
+                canon2.workspace_key[1],
+            );
+
+            checked_hits += 1;
+
+            // TODO: could we refactor the workspace system with the Voxels-Shape
+            //       collision detection system?
+            let (sub_detector, manifold_updated) =
+                match workspace.sub_detectors.entry(workspace_key) {
+                    Entry::Occupied(entry) => {
+                        let sub_detector = entry.into_mut();
+
+                        if sub_detector.timestamp != new_timestamp {
+                            let manifold = old_manifolds[sub_detector.manifold_id].take();
+                            *sub_detector = VoxelsShapeSubDetector {
+                                manifold_id: manifolds.len(),
+                                timestamp: new_timestamp,
+                                selected_contacts: 0,
+                            };
+
+                            manifolds.push(manifold);
+                            (sub_detector, false)
+                        } else {
+                            (sub_detector, true)
+                        }
+                    }
+                    Entry::Vacant(entry) => {
+                        let sub_detector = VoxelsShapeSubDetector {
+                            manifold_id: manifolds.len(),
+                            selected_contacts: 0,
+                            timestamp: new_timestamp,
+                        };
+
+                        manifolds.push(ContactManifold::with_data(
+                            vox1.linear_id,
+                            vox2.linear_id,
+                            ManifoldData::default(),
+                        ));
+
+                        (entry.insert(sub_detector), false)
+                    }
+                };
+
+            /*
+             * Update the contact manifold if needed.
+             */
+            let manifold = &mut manifolds[sub_detector.manifold_id];
+            let (canonical_center1, canonical_pseudo_cube1) =
+                canon1.cuboid(voxels1, vox1, domain2_1);
+            let (canonical_center2, canonical_pseudo_cube2) =
+                canon2.cuboid(voxels2, vox2, domain1_2);
+
+            if !manifold_updated {
+                let canonical_pos12 = Translation::from(-canonical_center1)
+                    * pos12
+                    * Translation::from(canonical_center2);
+
+                // If we already computed contacts in the previous simulation step, their
+                // local points are relative to the previously calculated canonical shape
+                // which might not have the same local center as the one computed in this
+                // step (because it’s based on the position of shape2 relative to voxels1).
+                // So we need to adjust the local points to account for the position difference
+                // and keep the point at the same "canonical-shape-space" location as in the previous frame.
+                let prev_center1 = manifold
+                    .subshape_pos1
+                    .as_ref()
+                    .map(|p| p.translation.vector)
+                    .unwrap_or_default();
+                let delta_center1 = canonical_center1.coords - prev_center1;
+                let prev_center2 = manifold
+                    .subshape_pos2
+                    .as_ref()
+                    .map(|p| p.translation.vector)
+                    .unwrap_or_default();
+                let delta_center2 = canonical_center2.coords - prev_center2;
+
+                for pt in &mut manifold.points {
+                    pt.local_p1 -= delta_center1;
+                    pt.local_p2 -= delta_center2;
+                }
+
+                // Update contacts.
+                manifold.subshape_pos1 = Some(Isometry::from(canonical_center1));
+                manifold.subshape_pos2 = Some(Isometry::from(canonical_center2));
+                let _ = dispatcher.contact_manifold_convex_convex(
+                    &canonical_pos12,
+                    &canonical_pseudo_cube1,
+                    &canonical_pseudo_cube2,
+                    None,
+                    None,
+                    prediction,
+                    manifold,
+                );
+            }
+
+            /*
+             * Filter-out points that don’t belong to this block.
+             */
+            let test_voxel1 = Cuboid::new(radius1 + Vector::repeat(1.0e-2));
+            let test_voxel2 = Cuboid::new(radius2 + Vector::repeat(1.0e-2));
+            let penetration_dir1 = manifold.local_n1;
+
+            for (i, pt) in manifold.points.iter().enumerate() {
+                if pt.dist < 0.0 {
+                    // If this is a penetration, double-check that we are not hitting the
+                    // interior of the infinitely expanded canonical shape by checking if
+                    // the opposite normal had led to a better vector.
+                    let cuboid1 = Cuboid::new(radius1);
+                    let cuboid2 = Cuboid::new(radius2);
+                    let sp1 = cuboid1.local_support_point(&-penetration_dir1) + vox1.center.coords;
+                    let sp2 = cuboid2.support_point(
+                        &(pos12 * Translation::from(vox2.center.coords)),
+                        &penetration_dir1,
+                    );
+                    let test_dist = (sp2 - sp1).dot(&-penetration_dir1);
+                    let keep = test_dist < pt.dist;
+
+                    if !keep {
+                        // We don’t want to keep this point as it is an incorrect penetration
+                        // caused by the canonical shape expansion.
+                        continue;
+                    }
+                }
+
+                let pt_in_voxel_space1 =
+                    manifold.subshape_pos1.transform_point(&pt.local_p1) - vox1.center.coords;
+                let pt_in_voxel_space2 =
+                    manifold.subshape_pos2.transform_point(&pt.local_p2) - vox2.center.coords;
+                sub_detector.selected_contacts |=
+                    ((test_voxel1.contains_local_point(&pt_in_voxel_space1) as u32) << i)
+                        & ((test_voxel2.contains_local_point(&pt_in_voxel_space2) as u32) << i);
+            }
+        };
 
         for vox1 in voxels1.voxels_intersecting_local_aabb(&intersection_aabb1) {
             let type1 = vox1.state.voxel_type();
@@ -59,26 +244,18 @@ pub fn contact_manifolds_voxels_voxels<'a, ManifoldData, ContactData>(
                 _ => continue,
             }
 
-            let centered_aabb1_2 =
-                Aabb::from_half_extents(pos21 * vox1.center, radius1 + Vector::repeat(prediction));
+            let canon1 = CanonicalVoxelShape::from_voxel(voxels1, &vox1);
+            let centered_aabb1_2 = Cuboid::new(radius1 + Vector::repeat(prediction))
+                .compute_aabb(&(pos21 * Translation::from(vox1.center)));
 
             for vox2 in voxels2.voxels_intersecting_local_aabb(&centered_aabb1_2) {
                 let type2 = vox2.state.voxel_type();
+
                 #[cfg(feature = "dim2")]
                 match (type1, type2) {
                     (VoxelType::Vertex, VoxelType::Vertex)
-                    | (VoxelType::Vertex, VoxelType::Face) => {
-                        detect_hit_voxel_ball(
-                            pos21, vox2.center, radius2, vox2.state, geometry2, vox1.center, radius1.x,
-                            prediction, true, manifolds,
-                        );
-                    }
-                    (VoxelType::Face, VoxelType::Vertex) => {
-                        detect_hit_voxel_ball(
-                            *pos12, vox1.center, radius1, vox1.state, geometry1, vox2.center, radius2.x,
-                            prediction, false, manifolds,
-                        );
-                    }
+                    | (VoxelType::Vertex, VoxelType::Face)
+                    | (VoxelType::Face, VoxelType::Vertex) => { /* OK */ }
                     _ => continue, /* Ignore */
                 }
 
@@ -86,43 +263,75 @@ pub fn contact_manifolds_voxels_voxels<'a, ManifoldData, ContactData>(
                 match (type1, type2) {
                     (VoxelType::Vertex, VoxelType::Vertex)
                     | (VoxelType::Vertex, VoxelType::Edge)
-                    | (VoxelType::Vertex, VoxelType::Face) => {
-                        detect_hit_voxel_ball(
-                            pos21, vox2.center, radius2, vox2.state, geometry2, vox1.center, radius1.x,
-                            prediction, true, manifolds,
-                        );
-                    }
-                    (VoxelType::Edge, VoxelType::Vertex)
-                    | (VoxelType::Face, VoxelType::Vertex)
-                    | (VoxelType::Edge, VoxelType::Edge) => {
-                        detect_hit_voxel_ball(
-                            *pos12, vox1.center, radius1, vox1.state, geometry1, vox2.center, radius2.x,
-                            prediction, false, manifolds,
-                        );
-                    }
+                    | (VoxelType::Vertex, VoxelType::Face)
+                    | (VoxelType::Edge, VoxelType::Vertex)
+                    | (VoxelType::Edge, VoxelType::Edge)
+                    | (VoxelType::Face, VoxelType::Vertex) => { /* OK */ }
                     _ => continue, /* Ignore */
                 }
+
+                let canon2 = CanonicalVoxelShape::from_voxel(voxels2, &vox2);
+                detect_hit(canon1, canon2, &vox1, &vox2);
             }
         }
 
         for vox2 in voxels2.voxels_intersecting_local_aabb(&intersection_aabb2) {
-            if vox2.state.voxel_type() != VoxelType::Vertex {
-                continue;
+            let type2 = vox2.state.voxel_type();
+            match type2 {
+                #[cfg(feature = "dim2")]
+                VoxelType::Vertex => { /* Ok */ }
+                #[cfg(feature = "dim3")]
+                VoxelType::Vertex | VoxelType::Edge => { /* Ok */ }
+                _ => continue,
             }
 
-            let centered_aabb2_1 =
-                Aabb::from_half_extents(pos12 * vox2.center, radius2 + Vector::repeat(prediction));
+            let canon2 = CanonicalVoxelShape::from_voxel(voxels2, &vox2);
+            let centered_aabb2_1 = Cuboid::new(radius2 + Vector::repeat(prediction))
+                .compute_aabb(&(pos12 * Translation::from(vox2.center)));
 
             for vox1 in voxels1.voxels_intersecting_local_aabb(&centered_aabb2_1) {
-                if vox1.state.voxel_type() != VoxelType::Face {
-                    continue;
+                let type1 = vox1.state.voxel_type();
+
+                #[cfg(feature = "dim2")]
+                match (type1, type2) {
+                    (VoxelType::Vertex, VoxelType::Vertex)
+                    | (VoxelType::Vertex, VoxelType::Face)
+                    | (VoxelType::Face, VoxelType::Vertex) => { /* OK */ }
+                    _ => continue, /* Ignore */
                 }
 
-                detect_hit_voxel_ball(
-                    *pos12, vox1.center, radius1, vox1.state, geometry1, vox2.center, radius2.x, prediction,
-                    false, manifolds,
-                );
+                #[cfg(feature = "dim3")]
+                match (type1, type2) {
+                    (VoxelType::Vertex, VoxelType::Vertex)
+                    | (VoxelType::Vertex, VoxelType::Edge)
+                    | (VoxelType::Vertex, VoxelType::Face)
+                    | (VoxelType::Edge, VoxelType::Vertex)
+                    | (VoxelType::Edge, VoxelType::Edge)
+                    | (VoxelType::Face, VoxelType::Vertex) => { /* OK */ }
+                    _ => continue, /* Ignore */
+                }
+
+                let canon1 = CanonicalVoxelShape::from_voxel(voxels1, &vox1);
+                detect_hit(canon1, canon2, &vox1, &vox2);
+            }
+        }
+
+        // Remove contacts marked as ignored.
+        for sub_detector in workspace.sub_detectors.values() {
+            if sub_detector.timestamp == new_timestamp {
+                let manifold = &mut manifolds[sub_detector.manifold_id];
+                let mut k = 0;
+                manifold.points.retain(|_| {
+                    let keep = (sub_detector.selected_contacts & (1 << k)) != 0;
+                    k += 1;
+                    keep
+                });
             }
         }
     }
+
+    // Remove detectors which no longer index a valid manifold.
+    workspace
+        .sub_detectors
+        .retain(|_, detector| detector.timestamp == new_timestamp);
 }

--- a/src/query/contact_manifolds/contact_manifolds_voxels_voxels.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_voxels.rs
@@ -1,0 +1,128 @@
+use crate::bounding_volume::{Aabb, BoundingVolume};
+use crate::math::{Isometry, Real, Vector};
+use crate::query::ContactManifold;
+use crate::shape::{Shape, VoxelType, Voxels};
+use crate::query::contact_manifolds::contact_manifolds_voxels_ball::detect_hit_voxel_ball;
+use alloc::vec::Vec;
+
+/// Computes the contact manifold between a convex shape and a ball, both represented as a `Shape` trait-object.
+pub fn contact_manifolds_voxels_voxels_shapes<ManifoldData, ContactData>(
+    pos12: &Isometry<Real>,
+    shape1: &dyn Shape,
+    shape2: &dyn Shape,
+    prediction: Real,
+    manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+) where
+    ManifoldData: Default,
+    ContactData: Default + Copy,
+{
+    if let (Some(voxels1), Some(voxels2)) = (shape1.as_voxels(), shape2.as_voxels()) {
+        contact_manifolds_voxels_voxels(pos12, voxels1, voxels2, prediction, manifolds);
+    }
+}
+
+/// Computes the contact manifold between a convex shape and a ball.
+pub fn contact_manifolds_voxels_voxels<'a, ManifoldData, ContactData>(
+    pos12: &Isometry<Real>,
+    voxels1: &'a Voxels,
+    voxels2: &'a Voxels,
+    prediction: Real,
+    manifolds: &mut Vec<ContactManifold<ManifoldData, ContactData>>,
+) where
+    ManifoldData: Default,
+    ContactData: Default + Copy,
+{
+    // TODO: don’t generate one manifold per voxel.
+    manifolds.clear();
+
+    let radius1 = voxels1.voxel_size() / 2.0;
+    let radius2 = voxels2.voxel_size() / 2.0;
+
+    // FIXME: optimize this.
+    let aabb1 = voxels1.local_aabb().loosened(prediction / 2.0);
+    let aabb2 = voxels2.local_aabb().loosened(prediction / 2.0);
+    let geometry1 = voxels1.primitive_geometry();
+    let geometry2 = voxels2.primitive_geometry();
+
+    if let Some((intersection_aabb1, intersection_aabb2)) =
+        aabb1.aligned_intersections(pos12, &aabb2)
+    {
+        let pos21 = pos12.inverse();
+
+        for vox1 in voxels1.voxels_intersecting_local_aabb(&intersection_aabb1) {
+            let type1 = vox1.state.voxel_type();
+            match type1 {
+                #[cfg(feature = "dim2")]
+                VoxelType::Vertex => { /* Ok */ }
+                #[cfg(feature = "dim3")]
+                VoxelType::Vertex | VoxelType::Edge => { /* Ok */ }
+                _ => continue,
+            }
+
+            let centered_aabb1_2 =
+                Aabb::from_half_extents(pos21 * vox1.center, radius1 + Vector::repeat(prediction));
+
+            for vox2 in voxels2.voxels_intersecting_local_aabb(&centered_aabb1_2) {
+                let type2 = vox2.state.voxel_type();
+                #[cfg(feature = "dim2")]
+                match (type1, type2) {
+                    (VoxelType::Vertex, VoxelType::Vertex)
+                    | (VoxelType::Vertex, VoxelType::Face) => {
+                        detect_hit_voxel_ball(
+                            pos21, vox2.center, radius2, vox2.state, geometry2, vox1.center, radius1.x,
+                            prediction, true, manifolds,
+                        );
+                    }
+                    (VoxelType::Face, VoxelType::Vertex) => {
+                        detect_hit_voxel_ball(
+                            *pos12, vox1.center, radius1, vox1.state, geometry1, vox2.center, radius2.x,
+                            prediction, false, manifolds,
+                        );
+                    }
+                    _ => continue, /* Ignore */
+                }
+
+                #[cfg(feature = "dim3")]
+                match (type1, type2) {
+                    (VoxelType::Vertex, VoxelType::Vertex)
+                    | (VoxelType::Vertex, VoxelType::Edge)
+                    | (VoxelType::Vertex, VoxelType::Face) => {
+                        detect_hit_voxel_ball(
+                            pos21, vox2.center, radius2, vox2.state, geometry2, vox1.center, radius1.x,
+                            prediction, true, manifolds,
+                        );
+                    }
+                    (VoxelType::Edge, VoxelType::Vertex)
+                    | (VoxelType::Face, VoxelType::Vertex)
+                    | (VoxelType::Edge, VoxelType::Edge) => {
+                        detect_hit_voxel_ball(
+                            *pos12, vox1.center, radius1, vox1.state, geometry1, vox2.center, radius2.x,
+                            prediction, false, manifolds,
+                        );
+                    }
+                    _ => continue, /* Ignore */
+                }
+            }
+        }
+
+        for vox2 in voxels2.voxels_intersecting_local_aabb(&intersection_aabb2) {
+            if vox2.state.voxel_type() != VoxelType::Vertex {
+                continue;
+            }
+
+            let centered_aabb2_1 =
+                Aabb::from_half_extents(pos12 * vox2.center, radius2 + Vector::repeat(prediction));
+
+            for vox1 in voxels1.voxels_intersecting_local_aabb(&centered_aabb2_1) {
+                if vox1.state.voxel_type() != VoxelType::Face {
+                    continue;
+                }
+
+                detect_hit_voxel_ball(
+                    *pos12, vox1.center, radius1, vox1.state, geometry1, vox2.center, radius2.x, prediction,
+                    false, manifolds,
+                );
+            }
+        }
+    }
+}

--- a/src/query/contact_manifolds/contact_manifolds_workspace.rs
+++ b/src/query/contact_manifolds/contact_manifolds_workspace.rs
@@ -30,6 +30,8 @@ pub enum TypedWorkspaceData<'a> {
     CompositeShapeShapeContactManifoldsWorkspace(&'a CompositeShapeShapeContactManifoldsWorkspace),
     /// A voxels vs. shape workspace.
     VoxelsShapeContactManifoldsWorkspace(&'a VoxelsShapeContactManifoldsWorkspace<2>),
+    /// A voxels vs. composite shape workspace.
+    VoxelsCompositeShapeContactManifoldsWorkspace(&'a VoxelsShapeContactManifoldsWorkspace<3>),
     /// A voxels vs. voxels workspace.
     VoxelsVoxelsContactManifoldsWorkspace(&'a VoxelsShapeContactManifoldsWorkspace<4>),
     /// A custom workspace.
@@ -50,6 +52,7 @@ enum DeserializableWorkspaceData {
     ),
     CompositeShapeShapeContactManifoldsWorkspace(CompositeShapeShapeContactManifoldsWorkspace),
     VoxelsShapeContactManifoldsWorkspace(VoxelsShapeContactManifoldsWorkspace<2>),
+    VoxelsCompositeShapeContactManifoldsWorkspace(VoxelsShapeContactManifoldsWorkspace<3>),
     VoxelsVoxelsContactManifoldsWorkspace(VoxelsShapeContactManifoldsWorkspace<4>),
     #[allow(dead_code)]
     Custom,
@@ -75,6 +78,9 @@ impl DeserializableWorkspaceData {
                 Some(ContactManifoldsWorkspace(Box::new(w)))
             }
             DeserializableWorkspaceData::VoxelsShapeContactManifoldsWorkspace(w) => {
+                Some(ContactManifoldsWorkspace(Box::new(w)))
+            }
+            DeserializableWorkspaceData::VoxelsCompositeShapeContactManifoldsWorkspace(w) => {
                 Some(ContactManifoldsWorkspace(Box::new(w)))
             }
             DeserializableWorkspaceData::VoxelsVoxelsContactManifoldsWorkspace(w) => {

--- a/src/query/contact_manifolds/contact_manifolds_workspace.rs
+++ b/src/query/contact_manifolds/contact_manifolds_workspace.rs
@@ -29,7 +29,9 @@ pub enum TypedWorkspaceData<'a> {
     /// A composite shape vs. shape workspace.
     CompositeShapeShapeContactManifoldsWorkspace(&'a CompositeShapeShapeContactManifoldsWorkspace),
     /// A voxels vs. shape workspace.
-    VoxelsShapeContactManifoldsWorkspace(&'a VoxelsShapeContactManifoldsWorkspace),
+    VoxelsShapeContactManifoldsWorkspace(&'a VoxelsShapeContactManifoldsWorkspace<2>),
+    /// A voxels vs. voxels workspace.
+    VoxelsVoxelsContactManifoldsWorkspace(&'a VoxelsShapeContactManifoldsWorkspace<4>),
     /// A custom workspace.
     Custom,
 }
@@ -47,6 +49,8 @@ enum DeserializableWorkspaceData {
         CompositeShapeCompositeShapeContactManifoldsWorkspace,
     ),
     CompositeShapeShapeContactManifoldsWorkspace(CompositeShapeShapeContactManifoldsWorkspace),
+    VoxelsShapeContactManifoldsWorkspace(VoxelsShapeContactManifoldsWorkspace<2>),
+    VoxelsVoxelsContactManifoldsWorkspace(VoxelsShapeContactManifoldsWorkspace<4>),
     #[allow(dead_code)]
     Custom,
 }
@@ -68,6 +72,12 @@ impl DeserializableWorkspaceData {
                 w,
             ) => Some(ContactManifoldsWorkspace(Box::new(w))),
             DeserializableWorkspaceData::CompositeShapeShapeContactManifoldsWorkspace(w) => {
+                Some(ContactManifoldsWorkspace(Box::new(w)))
+            }
+            DeserializableWorkspaceData::VoxelsShapeContactManifoldsWorkspace(w) => {
+                Some(ContactManifoldsWorkspace(Box::new(w)))
+            }
+            DeserializableWorkspaceData::VoxelsVoxelsContactManifoldsWorkspace(w) => {
                 Some(ContactManifoldsWorkspace(Box::new(w)))
             }
             DeserializableWorkspaceData::Custom => None,

--- a/src/query/contact_manifolds/mod.rs
+++ b/src/query/contact_manifolds/mod.rs
@@ -37,6 +37,9 @@ pub use self::contact_manifolds_voxels_shape::{
     contact_manifolds_voxels_shape, contact_manifolds_voxels_shape_shapes,
     VoxelsShapeContactManifoldsWorkspace,
 };
+pub use self::contact_manifolds_voxels_voxels::{
+    contact_manifolds_voxels_voxels, contact_manifolds_voxels_voxels_shapes,
+};
 pub use self::contact_manifolds_workspace::{
     ContactManifoldsWorkspace, TypedWorkspaceData, WorkspaceData,
 };
@@ -66,5 +69,6 @@ mod contact_manifolds_pfm_pfm;
 mod contact_manifolds_trimesh_shape;
 mod contact_manifolds_voxels_ball;
 mod contact_manifolds_voxels_shape;
+mod contact_manifolds_voxels_voxels;
 mod contact_manifolds_workspace;
 mod normals_constraint;

--- a/src/query/contact_manifolds/mod.rs
+++ b/src/query/contact_manifolds/mod.rs
@@ -33,6 +33,9 @@ pub use self::contact_manifolds_trimesh_shape::{
     contact_manifolds_trimesh_shape, contact_manifolds_trimesh_shape_shapes,
 };
 pub use self::contact_manifolds_voxels_ball::contact_manifolds_voxels_ball_shapes;
+pub use self::contact_manifolds_voxels_composite_shape::{
+    contact_manifolds_voxels_composite_shape, contact_manifolds_voxels_composite_shape_shapes,
+};
 pub use self::contact_manifolds_voxels_shape::{
     contact_manifolds_voxels_shape, contact_manifolds_voxels_shape_shapes,
     VoxelsShapeContactManifoldsWorkspace,
@@ -71,6 +74,7 @@ mod contact_manifolds_heightfield_shape;
 mod contact_manifolds_pfm_pfm;
 mod contact_manifolds_trimesh_shape;
 mod contact_manifolds_voxels_ball;
+mod contact_manifolds_voxels_composite_shape;
 mod contact_manifolds_voxels_shape;
 mod contact_manifolds_voxels_voxels;
 mod contact_manifolds_workspace;

--- a/src/query/contact_manifolds/mod.rs
+++ b/src/query/contact_manifolds/mod.rs
@@ -37,6 +37,9 @@ pub use self::contact_manifolds_voxels_shape::{
     contact_manifolds_voxels_shape, contact_manifolds_voxels_shape_shapes,
     VoxelsShapeContactManifoldsWorkspace,
 };
+pub(crate) use self::contact_manifolds_voxels_shape::{
+    CanonicalVoxelShape, VoxelsShapeSubDetector,
+};
 pub use self::contact_manifolds_voxels_voxels::{
     contact_manifolds_voxels_voxels, contact_manifolds_voxels_voxels_shapes,
 };

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -547,9 +547,15 @@ where
                 contact_manifolds_voxels_ball_shapes(pos12, shape1, shape2, prediction, manifolds)
             }
             (ShapeType::Voxels, _) | (_, ShapeType::Voxels) => {
-                contact_manifolds_voxels_shape_shapes(
-                    self, pos12, shape1, shape2, prediction, manifolds, workspace,
-                )
+                if composite1.is_some() || composite2.is_some() {
+                    contact_manifolds_voxels_composite_shape_shapes(
+                        self, pos12, shape1, shape2, prediction, manifolds, workspace,
+                    )
+                } else {
+                    contact_manifolds_voxels_shape_shapes(
+                        self, pos12, shape1, shape2, prediction, manifolds, workspace,
+                    )
+                }
             }
             _ => {
                 if let Some(composite1) = composite1 {

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -540,9 +540,9 @@ where
                     );
                 }
             }
-            (ShapeType::Voxels, ShapeType::Voxels) => {
-                contact_manifolds_voxels_voxels_shapes(pos12, shape1, shape2, prediction, manifolds)
-            }
+            (ShapeType::Voxels, ShapeType::Voxels) => contact_manifolds_voxels_voxels_shapes(
+                self, pos12, shape1, shape2, prediction, manifolds, workspace,
+            ),
             (ShapeType::Voxels, ShapeType::Ball) | (ShapeType::Ball, ShapeType::Voxels) => {
                 contact_manifolds_voxels_ball_shapes(pos12, shape1, shape2, prediction, manifolds)
             }

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -74,6 +74,14 @@ impl QueryDispatcher for DefaultQueryDispatcher {
                 return Ok(query::details::intersection_test_shape_composite_shape(
                     self, pos12, shape1, c2,
                 ));
+            } else if let Some(v1) = shape1.as_voxels() {
+                return Ok(query::details::intersection_test_voxels_shape(
+                    self, pos12, v1, shape2,
+                ));
+            } else if let Some(v2) = shape2.as_voxels() {
+                return Ok(query::details::intersection_test_shape_voxels(
+                    self, pos12, shape1, v2,
+                ));
             }
 
             Err(Unsupported)

--- a/src/query/default_query_dispatcher.rs
+++ b/src/query/default_query_dispatcher.rs
@@ -540,6 +540,9 @@ where
                     );
                 }
             }
+            (ShapeType::Voxels, ShapeType::Voxels) => {
+                contact_manifolds_voxels_voxels_shapes(pos12, shape1, shape2, prediction, manifolds)
+            }
             (ShapeType::Voxels, ShapeType::Ball) | (ShapeType::Ball, ShapeType::Voxels) => {
                 contact_manifolds_voxels_ball_shapes(pos12, shape1, shape2, prediction, manifolds)
             }

--- a/src/query/intersection_test/intersection_test_voxels_shape.rs
+++ b/src/query/intersection_test/intersection_test_voxels_shape.rs
@@ -1,0 +1,64 @@
+use crate::math::{Isometry, Real, Translation};
+use crate::query::PersistentQueryDispatcher;
+use crate::shape::{Cuboid, Shape, VoxelType, Voxels};
+
+/// Checks for any intersection between voxels and an arbitrary shape, both represented as a `Shape` trait-object.
+pub fn intersection_test_voxels_shape_shapes(
+    dispatcher: &dyn PersistentQueryDispatcher,
+    pos12: &Isometry<Real>,
+    shape1: &dyn Shape,
+    shape2: &dyn Shape,
+) -> bool {
+    if let Some(voxels1) = shape1.as_voxels() {
+        intersection_test_voxels_shape(dispatcher, pos12, voxels1, shape2)
+    } else if let Some(voxels2) = shape2.as_voxels() {
+        intersection_test_voxels_shape(dispatcher, &pos12.inverse(), voxels2, shape1)
+    } else {
+        false
+    }
+}
+
+/// Checks for any intersection between voxels and an arbitrary shape.
+pub fn intersection_test_voxels_shape(
+    dispatcher: &dyn PersistentQueryDispatcher,
+    pos12: &Isometry<Real>,
+    voxels1: &Voxels,
+    shape2: &dyn Shape,
+) -> bool {
+    let radius1 = voxels1.voxel_size() / 2.0;
+    let aabb1 = voxels1.local_aabb();
+    let aabb2_1 = shape2.compute_aabb(pos12);
+
+    if let Some(intersection_aabb1) = aabb1.intersection(&aabb2_1) {
+        for vox1 in voxels1.voxels_intersecting_local_aabb(&intersection_aabb1) {
+            let vox_type1 = vox1.state.voxel_type();
+
+            if vox_type1 == VoxelType::Empty {
+                continue;
+            }
+
+            let center1 = vox1.center;
+            let cuboid1 = Cuboid::new(radius1);
+            let cuboid_pose12 = Translation::from(-center1) * pos12;
+
+            if dispatcher
+                .intersection_test(&cuboid_pose12, &cuboid1, shape2)
+                .unwrap_or(false)
+            {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Checks for any intersection between voxels and an arbitrary shape.
+pub fn intersection_test_shape_voxels(
+    dispatcher: &dyn PersistentQueryDispatcher,
+    pos12: &Isometry<Real>,
+    shape1: &dyn Shape,
+    voxels2: &Voxels,
+) -> bool {
+    intersection_test_voxels_shape(dispatcher, &pos12.inverse(), voxels2, shape1)
+}

--- a/src/query/intersection_test/mod.rs
+++ b/src/query/intersection_test/mod.rs
@@ -26,7 +26,8 @@ pub use self::{
         IntersectionCompositeShapeShapeVisitor,
     },
     intersection_test_voxels_shape::{
-        intersection_test_voxels_shape, intersection_test_voxels_shape_shapes, intersection_test_shape_voxels
+        intersection_test_shape_voxels, intersection_test_voxels_shape,
+        intersection_test_voxels_shape_shapes,
     },
 };
 

--- a/src/query/intersection_test/mod.rs
+++ b/src/query/intersection_test/mod.rs
@@ -5,11 +5,6 @@ pub use self::intersection_test_ball_ball::intersection_test_ball_ball;
 pub use self::intersection_test_ball_point_query::{
     intersection_test_ball_point_query, intersection_test_point_query_ball,
 };
-#[cfg(feature = "alloc")]
-pub use self::intersection_test_composite_shape_shape::{
-    intersection_test_composite_shape_shape, intersection_test_shape_composite_shape,
-    IntersectionCompositeShapeShapeVisitor,
-};
 pub use self::intersection_test_cuboid_cuboid::intersection_test_cuboid_cuboid;
 pub use self::intersection_test_cuboid_segment::{
     intersection_test_aabb_segment, intersection_test_cuboid_segment,
@@ -24,6 +19,16 @@ pub use self::intersection_test_halfspace_support_map::{
 };
 pub use self::intersection_test_support_map_support_map::intersection_test_support_map_support_map;
 pub use self::intersection_test_support_map_support_map::intersection_test_support_map_support_map_with_params;
+#[cfg(feature = "alloc")]
+pub use self::{
+    intersection_test_composite_shape_shape::{
+        intersection_test_composite_shape_shape, intersection_test_shape_composite_shape,
+        IntersectionCompositeShapeShapeVisitor,
+    },
+    intersection_test_voxels_shape::{
+        intersection_test_voxels_shape, intersection_test_voxels_shape_shapes, intersection_test_shape_voxels
+    },
+};
 
 mod intersection_test;
 mod intersection_test_ball_ball;
@@ -35,3 +40,6 @@ mod intersection_test_cuboid_segment;
 mod intersection_test_cuboid_triangle;
 mod intersection_test_halfspace_support_map;
 mod intersection_test_support_map_support_map;
+
+#[cfg(feature = "alloc")]
+mod intersection_test_voxels_shape;

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
     polyline::Polyline,
     shared_shape::SharedShape,
     voxels::{
-        AxisMask, OctantPattern, VoxelData, VoxelPrimitiveGeometry, VoxelState, VoxelType, Voxels,
+        AxisMask, OctantPattern, VoxelData, VoxelState, VoxelType, Voxels,
     },
 };
 

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -22,9 +22,7 @@ pub use self::{
     compound::Compound,
     polyline::Polyline,
     shared_shape::SharedShape,
-    voxels::{
-        AxisMask, OctantPattern, VoxelData, VoxelState, VoxelType, Voxels,
-    },
+    voxels::{AxisMask, OctantPattern, VoxelData, VoxelState, VoxelType, Voxels},
 };
 
 #[cfg(feature = "dim2")]

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -1537,12 +1537,12 @@ impl Shape for Voxels {
         Box::new(self.clone())
     }
 
-    fn scale_dyn(&self, _scale: &Vector<Real>, _num_subdivisions: u32) -> Option<Box<dyn Shape>> {
-        todo!()
+    fn scale_dyn(&self, scale: &Vector<Real>, _num_subdivisions: u32) -> Option<Box<dyn Shape>> {
+        Some(Box::new(self.clone().scaled(scale)))
     }
 
-    fn mass_properties(&self, _density: Real) -> MassProperties {
-        MassProperties::default()
+    fn mass_properties(&self, density: Real) -> MassProperties {
+        MassProperties::from_voxels(density, self)
     }
 
     fn shape_type(&self) -> ShapeType {

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -225,10 +225,7 @@ impl SharedShape {
     /// For initializing a voxels shape from a mesh to voxelize, see [`Self::voxelized_mesh`].
     /// For initializing multiple voxels shape from the convex decomposition of a mesh, see
     /// [`Self::voxelized_convex_decomposition`].
-    pub fn voxels(
-        voxel_size: Vector<Real>,
-        grid_coords: &[Point<i32>],
-    ) -> Self {
+    pub fn voxels(voxel_size: Vector<Real>, grid_coords: &[Point<i32>]) -> Self {
         let shape = Voxels::new(voxel_size, grid_coords);
         SharedShape::new(shape)
     }
@@ -237,10 +234,7 @@ impl SharedShape {
     ///
     /// Each voxel has the size `voxel_size` and contains at least one point from `centers`.
     /// The `primitive_geometry` controls the behavior of collision detection at voxels boundaries.
-    pub fn voxels_from_points(
-        voxel_size: Vector<Real>,
-        points: &[Point<Real>],
-    ) -> Self {
+    pub fn voxels_from_points(voxel_size: Vector<Real>, points: &[Point<Real>]) -> Self {
         let shape = Voxels::from_points(voxel_size, points);
         SharedShape::new(shape)
     }
@@ -264,8 +258,7 @@ impl SharedShape {
             .iter()
             .map(|v| vox_set.get_voxel_point(v))
             .collect();
-        let shape =
-            Voxels::from_points(Vector::repeat(vox_set.scale), &centers);
+        let shape = Voxels::from_points(Vector::repeat(vox_set.scale), &centers);
         SharedShape::new(shape)
     }
 

--- a/src/shape/voxels.rs
+++ b/src/shape/voxels.rs
@@ -378,9 +378,9 @@ impl Voxels {
     }
 
     /// Scale this shape.
-    pub fn scaled(mut self, scale: &Vector<Real>) -> Option<Self> {
+    pub fn scaled(mut self, scale: &Vector<Real>) -> Self {
         self.voxel_size.component_mul_assign(scale);
-        Some(self)
+        self
     }
 
     /// Sets the voxel at the given grid coordinates, returning `None` if it lies outside [`Self::domain`].

--- a/src/shape/voxels.rs
+++ b/src/shape/voxels.rs
@@ -199,10 +199,7 @@ impl Voxels {
     ///
     /// Each voxel will have its bottom-left-back corner located at
     /// `grid_coordinates * voxel_size`; and its center at `(grid_coordinates + 0.5) * voxel_size`.
-    pub fn new(
-        voxel_size: Vector<Real>,
-        grid_coordinates: &[Point<i32>],
-    ) -> Self {
+    pub fn new(voxel_size: Vector<Real>, grid_coordinates: &[Point<i32>]) -> Self {
         let mut domain_mins = grid_coordinates[0];
         let mut domain_maxs = grid_coordinates[0];
 
@@ -235,10 +232,7 @@ impl Voxels {
     /// The points are mapped to a regular grid centered at the provided point with smallest
     /// coordinates, and with grid cell size equal to `scale`. It is OK if multiple points
     /// fall into the same grid cell.
-    pub fn from_points(
-        voxel_size: Vector<Real>,
-        points: &[Point<Real>],
-    ) -> Self {
+    pub fn from_points(voxel_size: Vector<Real>, points: &[Point<Real>]) -> Self {
         let voxels: Vec<_> = points
             .iter()
             .map(|pt| {
@@ -672,19 +666,13 @@ impl Voxels {
         }
 
         let in_box = if !in_box.is_empty() {
-            Some(Voxels::from_points(
-                self.voxel_size,
-                &in_box,
-            ))
+            Some(Voxels::from_points(self.voxel_size, &in_box))
         } else {
             None
         };
 
         let rest = if !rest.is_empty() {
-            Some(Voxels::from_points(
-                self.voxel_size,
-                &rest,
-            ))
+            Some(Voxels::from_points(self.voxel_size, &rest))
         } else {
             None
         };

--- a/src/utils/hashmap.rs
+++ b/src/utils/hashmap.rs
@@ -27,10 +27,10 @@ pub fn deserialize_hashmap_capacity<
     d: D,
 ) -> Result<StdHashMap<K, V, H>, D::Error> {
     struct CapacityVisitor;
-    impl<'de> serde::de::Visitor<'de> for CapacityVisitor {
+    impl serde::de::Visitor<'_> for CapacityVisitor {
         type Value = u64;
 
-        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
             write!(formatter, "an integer between 0 and 2^64")
         }
 

--- a/src/utils/hashset.rs
+++ b/src/utils/hashset.rs
@@ -27,7 +27,7 @@ pub fn deserialize_hashset_capacity<
     d: D,
 ) -> Result<StdHashSet<K, H>, D::Error> {
     struct CapacityVisitor;
-    impl<'de> serde::de::Visitor<'de> for CapacityVisitor {
+    impl serde::de::Visitor<'_> for CapacityVisitor {
         type Value = u64;
 
         fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {


### PR DESCRIPTION
## 0.21.0

### Added

- Add `TriMesh::cast_ray_with_culling` and `TriMesh::cast_local_ray_with_culling` for casting rays on a triangle mesh
  but with the possibility to prevents hits on front-faces or back-faces.
- Add contact manifold calculation between two voxels shapes, or a voxels shape and compound shape.
- Add intersection check between voxels and other shapes.

### Modified

- Add new variants to `TypedWorkspaceData` for voxels-voxels and voxels-compound collision detection workspace
  data.
- The `Voxels` shape now only support cuboids as their leaf geometries (pseudo-balls were removed). 