### PR TITLE
feat: implement cross-Voxels internal edges handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 0.21.1
+
+### Added
+
+- Add `Voxels::combine_voxel_states` to merge the voxel state of two `Voxels` shapes, updating their internal voxels
+  state as if both shapes were part of a single one. In particular, this will prevent any internal edge that would
+  arise at the boundaries of both shapes if they were adjacent.
+- Add `Voxels::propagate_voxel_change` to propagate a single-voxel modification from one `Voxels` shape to another,
+  in order to update their internal neighborhood information as if both were part of the same `Voxels` shape. 
+
 ## 0.21.0
 
 ### Added

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."

--- a/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
@@ -324,8 +324,12 @@ impl CanonicalVoxelShape {
     pub fn from_voxel(voxels: &Voxels, vox: &VoxelData) -> Self {
         let mut key_low = vox.grid_coords;
         let mut key_high = key_low;
-        let mins = voxels.domain()[0];
-        let maxs = voxels.domain()[1] - Vector::repeat(1);
+
+        // NOTE: the mins/maxs here are offset by 1 so we can expand past the last voxel if it
+        //       happens to also be infinite along the same axis (due to cross-voxels internal edges
+        //       detection).
+        let mins = voxels.domain()[0] - Vector::repeat(1);
+        let maxs = voxels.domain()[1];
         let mask1 = vox.state.free_faces();
 
         let adjust_canon = |axis: AxisMask, i: usize, key: &mut Point<i32>, val: i32| {

--- a/src/shape/shared_shape.rs
+++ b/src/shape/shared_shape.rs
@@ -78,7 +78,7 @@ impl SharedShape {
     }
 
     /// Initialize a cylindrical shape defined by its half-height
-    /// (along along the y axis) and its radius.
+    /// (along the y axis) and its radius.
     #[cfg(feature = "dim3")]
     pub fn cylinder(half_height: Real, radius: Real) -> Self {
         SharedShape(Arc::new(Cylinder::new(half_height, radius)))

--- a/src/shape/voxels.rs
+++ b/src/shape/voxels.rs
@@ -319,9 +319,18 @@ impl Voxels {
     ///
     /// This is the same as [`Voxels::combine_voxel_states`] but localized to a single voxel and its
     /// neighbors.
-    pub fn propagate_voxel_change(&mut self, other: &mut Self, voxel: Point<i32>, origin_shift: Vector<i32>) {
-        let center_is_empty = self.get_voxel_state(voxel).map(|vox| vox.is_empty()).unwrap_or(true);
-        let center_state_delta = other.update_neighbors_state(voxel - origin_shift, center_is_empty);
+    pub fn propagate_voxel_change(
+        &mut self,
+        other: &mut Self,
+        voxel: Point<i32>,
+        origin_shift: Vector<i32>,
+    ) {
+        let center_is_empty = self
+            .get_voxel_state(voxel)
+            .map(|vox| vox.is_empty())
+            .unwrap_or(true);
+        let center_state_delta =
+            other.update_neighbors_state(voxel - origin_shift, center_is_empty);
 
         if let Some(state_id) = self.get_linear_index(voxel) {
             self.states[state_id as usize].0 |= center_state_delta.0;
@@ -344,12 +353,12 @@ impl Voxels {
 
         // Intersect the domains + 1 cell.
         let d0 = [self.domain_mins - one, self.domain_maxs + one * 2];
-        let d1 = [other.domain_mins - one + origin_shift, other.domain_maxs + one * 2 + origin_shift];
-
-        let d01 = [
-            d0[0].sup(&d1[0]),
-            d0[1].inf(&d1[1]),
+        let d1 = [
+            other.domain_mins - one + origin_shift,
+            other.domain_maxs + one * 2 + origin_shift,
         ];
+
+        let d01 = [d0[0].sup(&d1[0]), d0[1].inf(&d1[1])];
         // Iterate on the domain intersection. If the voxel exists (and is non-empty) on both shapes, we
         // simply need to combine their bitmasks. If it doesn’t exist on both shapes, we need to
         // actually check the neighbors.
@@ -367,8 +376,12 @@ impl Voxels {
                     #[cfg(feature = "dim3")]
                     let key0 = Point::new(i, j, _k);
                     let key1 = key0 - origin_shift;
-                    let id0 = self.get_linear_index(key0).filter(|id| !self.states[*id as usize].is_empty());
-                    let id1 = other.get_linear_index(key1).filter(|id| !other.states[*id as usize].is_empty());
+                    let id0 = self
+                        .get_linear_index(key0)
+                        .filter(|id| !self.states[*id as usize].is_empty());
+                    let id1 = other
+                        .get_linear_index(key1)
+                        .filter(|id| !other.states[*id as usize].is_empty());
 
                     match (id0, id1) {
                         (Some(id0), Some(id1)) => {
@@ -376,14 +389,14 @@ impl Voxels {
                             other.states[id1 as usize].0 |= self.states[id0 as usize].0;
                         }
                         (Some(id0), None) => {
-                            self.states[id0 as usize].0 |= other.compute_voxel_neighborhood_bits(key1).0;
+                            self.states[id0 as usize].0 |=
+                                other.compute_voxel_neighborhood_bits(key1).0;
                         }
                         (None, Some(id1)) => {
-                            other.states[id1 as usize].0 |= self.compute_voxel_neighborhood_bits(key0).0;
+                            other.states[id1 as usize].0 |=
+                                self.compute_voxel_neighborhood_bits(key0).0;
                         }
-                        (None, None) => {
-                            /* Nothing to adjust. */
-                        }
+                        (None, None) => { /* Nothing to adjust. */ }
                     }
                 }
             }
@@ -891,14 +904,12 @@ impl Voxels {
             next[k] += 1;
 
             if let Some(next_id) = self.get_linear_index(next) {
-                if !self.states[next_id as usize].is_empty()
-                {
+                if !self.states[next_id as usize].is_empty() {
                     occupied_faces |= 1 << (k * 2);
                 }
             }
             if let Some(prev_id) = self.get_linear_index(prev) {
-                if !self.states[prev_id as usize].is_empty()
-                {
+                if !self.states[prev_id as usize].is_empty() {
                     occupied_faces |= 1 << (k * 2 + 1);
                 }
             }


### PR DESCRIPTION
It is not unusual for games to split their voxels world into multiple chunks, e.g., to differentiate between voxels of different types. however, than chunking can result in internal edges being created at the interface between two chunks.

This PR adds some helper functions for letting the user specify manually which pair of `Voxels` shapes are interfacing at their boundaries, to update their internal state accordingly.