### PR TITLE
Feature normal at point

### DIFF
--- a/src/shape/cone.rs
+++ b/src/shape/cone.rs
@@ -78,13 +78,15 @@ impl Cone {
     /// Computes the normal for given [FeatureId] at a given point.
     ///
     /// Supports only `FeatureId::Face(0)` (base) and `FeatureId::Face(1)` (side).
-    pub fn feature_normal_at_point(
+    ///
+    /// Exposed through [Shape::feature_normal_at_point][crate::shape::Shape::feature_normal_at_point]
+    pub fn feature_normal_at(
         &self,
         feature_id: FeatureId,
         point: &Point<Real>,
     ) -> Option<Unit<Vector<Real>>> {
         match feature_id {
-            FeatureId::Vertex(vertex) => {
+            FeatureId::Vertex(_) => {
                 // TODO: if top of the cone, return (0,0,1) ?
                 None
             }
@@ -152,39 +154,48 @@ impl SupportMap for Cone {
 }
 
 #[cfg(test)]
+#[cfg(feature = "dim3")]
 mod test {
+    use approx::RelativeEq;
+
+    use crate::shape::Shape;
+
     use super::*;
 
     #[test]
     fn cone_normal() {
+        let espilon = 0.00001
         let cone = Cone::new(0.5, 1.0);
 
         let point = Point::new(1.0, 1.0, 1.0);
         let normal = cone
             .feature_normal_at_point(FeatureId::Face(1), &point)
             .unwrap();
-        assert_relative_eq!(
-            Vector::new(normal.x, normal.y, normal.z),
-            Vector::new(0.5, 0.70710677, 0.5)
-        );
+        assert!(Vector::new(normal.x, normal.y, normal.z).relative_eq(
+            &Vector::new(0.5, 0.70710677, 0.5),
+            espilon,
+            espilon
+        ),);
         // Higher point, not aligned with normal
         let point = Point::new(1.0, 2.0, 1.0);
         let normal = cone
             .feature_normal_at_point(FeatureId::Face(1), &point)
             .unwrap();
-        assert_relative_eq!(
-            Vector::new(normal.x, normal.y, normal.z),
-            Vector::new(0.5, 0.70710677, 0.5)
-        );
+        assert!(Vector::new(normal.x, normal.y, normal.z).relative_eq(
+            &Vector::new(0.5, 0.70710677, 0.5),
+            espilon,
+            espilon
+        ),);
         // longer cone
         let cone = Cone::new(1.0, 1.0);
         let point = Point::new(0.5, 2.0, 1.0);
         let normal = cone
             .feature_normal_at_point(FeatureId::Face(1), &point)
             .unwrap();
-        assert_relative_eq!(
-            Vector::new(normal.x, normal.y, normal.z),
-            Vector::new(0.39999998, 0.44721365, 0.79999995)
-        );
+        assert!(Vector::new(normal.x, normal.y, normal.z).relative_eq(
+            &Vector::new(0.39999998, 0.44721365, 0.79999995),
+            espilon,
+            espilon
+        ),);
     }
 }

--- a/src/shape/cylinder.rs
+++ b/src/shape/cylinder.rs
@@ -1,8 +1,8 @@
 //! Support mapping based Cylinder shape.
 
 use crate::math::{Point, Real, Vector};
-use crate::shape::SupportMap;
-use na;
+use crate::shape::{FeatureId, SupportMap};
+use na::{self, Unit};
 use num::Zero;
 
 #[cfg(feature = "alloc")]
@@ -69,6 +69,31 @@ impl Cylinder {
                 self.half_height * scale.y,
                 self.radius * scale.x,
             )))
+        }
+    }
+
+    /// Computes the normal for given [FeatureId] at a given point.
+    ///
+    /// Supports only `FeatureId::Face(0)` (bottom), `FeatureId::Face(1)` (top) and `FeatureId::Face(2)` (side).
+    pub fn feature_normal_at_point(
+        &self,
+        feature_id: FeatureId,
+        point: &Point<Real>,
+    ) -> Option<Unit<Vector<Real>>> {
+        match feature_id {
+            FeatureId::Vertex(_) => None,
+            // Bottom
+            FeatureId::Face(0) => Some(-Vector::y_axis()),
+            // Top
+            FeatureId::Face(1) => Some(Vector::y_axis()),
+            // Side
+            FeatureId::Face(2) => Some(Unit::try_new(
+                Vector::new(point.x, 0.0, point.z),
+                Real::EPSILON,
+            )?),
+            FeatureId::Face(_) => None,
+            FeatureId::Unknown => None,
+            FeatureId::Edge(_) => None,
         }
     }
 }

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -1472,7 +1472,7 @@ impl Shape for Cone {
         feature: FeatureId,
         point: &Point<Real>,
     ) -> Option<Unit<Vector<Real>>> {
-        self.feature_normal_at_point(feature, point)
+        self.feature_normal_at(feature, point)
     }
 }
 

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -918,13 +918,10 @@ impl Shape for Triangle {
 
     fn feature_normal_at_point(
         &self,
-        _feature: FeatureId,
+        feature: FeatureId,
         _point: &Point<Real>,
     ) -> Option<Unit<Vector<Real>>> {
-        #[cfg(feature = "dim2")]
-        return None;
-        #[cfg(feature = "dim3")]
-        return self.feature_normal(_feature);
+        self.feature_normal(feature)
     }
 }
 
@@ -1469,6 +1466,13 @@ impl Shape for Cone {
 
     fn as_polygonal_feature_map(&self) -> Option<(&dyn PolygonalFeatureMap, Real)> {
         Some((self as &dyn PolygonalFeatureMap, 0.0))
+    }
+    fn feature_normal_at_point(
+        &self,
+        feature: FeatureId,
+        point: &Point<Real>,
+    ) -> Option<Unit<Vector<Real>>> {
+        self.feature_normal_at_point(feature, point)
     }
 }
 

--- a/src/shape/triangle.rs
+++ b/src/shape/triangle.rs
@@ -13,7 +13,7 @@ use num::Zero;
 use {crate::shape::FeatureId, core::f64};
 
 #[cfg(feature = "dim2")]
-use crate::shape::PackedFeatureId;
+use crate::shape::{feature_id, PackedFeatureId};
 
 #[cfg(feature = "rkyv")]
 use rkyv::{bytecheck, CheckBytes};
@@ -542,6 +542,19 @@ impl Triangle {
     #[cfg(feature = "dim3")]
     pub fn feature_normal(&self, _: FeatureId) -> Option<Unit<Vector<Real>>> {
         self.normal()
+    }
+
+    /// The normal of the given feature of this shape.
+    #[cfg(feature = "dim2")]
+    pub fn feature_normal(&self, feature_id: super::FeatureId) -> Option<Unit<Vector<Real>>> {
+        match feature_id {
+            super::FeatureId::Vertex(vertex) => {
+                let local_point = self.vertices().get(vertex as usize)? - self.center();
+                Unit::try_new(local_point, Real::EPSILON)
+            }
+            super::FeatureId::Face(_) => None,
+            super::FeatureId::Unknown => None,
+        }
     }
 
     /// The orientation of the triangle, based on its signed area.


### PR DESCRIPTION
Some shapes are missing ``

- halfspace -> todo?
- triangle (2d) -> attempt 🤔 triangle has no edge?
- trimesh (2d) -> not attempted 🤔 -> get all neighbour vertices and compute normal ? sounds convoluted
- Cone -> attempt ; math can probably be simplified: see https://github.com/user-attachments/assets/f068cd71-35dd-4f00-b400-0e2c175c850e
- Cylinder -> done ; check if faces are ok (to challenge with cone too)
- heightfield -> todo -> ⚠️ more difficult
- polyline -> todo -> ⚠️ more difficult
- Voxels -> ⚠️ more difficult
- compound -> impossible? we'd need to know which shape we're targetting the feature on (more complex featureId, out of scope for this PR)
- roundshape -> what whould that mean? delegate to inner shape? todo? 
- identifying features is complex due to 2 ways of doing that (ncollide/parry)
- TODO: lowprio: return err\<notimplemented\> or no such feature
	- This leads to controversial api changes so I'd like to keep this PR simple
	

Cone implementation can probably be simplified from:
<img width="564" alt="Image" src="https://github.com/user-attachments/assets/f068cd71-35dd-4f00-b400-0e2c175c850e" />