### PR TITLE
fix BVH leaf node index update after a removal that results in a partial root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.22.0-beta.1
+
+### Fixed
+
+- Fix invalid BVH state that could be reached after a removal resulting in a partial root.
+
 # 0.22.0-beta.0
 
 ### Added

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.22.0-beta.0"
+version = "0.22.0-beta.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.22.0-beta.0"
+version = "0.22.0-beta.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.22.0-beta.0"
+version = "0.22.0-beta.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.22.0-beta.0"
+version = "0.22.0-beta.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."

--- a/src/partitioning/bvh/bvh_tree.rs
+++ b/src/partitioning/bvh/bvh_tree.rs
@@ -703,7 +703,9 @@ impl Bvh {
                     // There is no parent pointer to update.
                     if !is_right {
                         // We remove the left leaf. Move the right leaf in its place.
+                        let moved_index = self.nodes[0].right.children;
                         self.nodes[0].left = self.nodes[0].right;
+                        self.leaf_node_indices[moved_index as usize] = BvhNodeIndex::left(0);
                     }
 
                     // Now we can just clear the right leaf.


### PR DESCRIPTION
This fixes a an incorrect BVH state that could be reached if a partial root is created after removing one of the remaining two leaves.