### PR TITLE
Fix CI nightly's mismatched_lifetime_syntaxes

### DIFF
--- a/src/partitioning/bvh/bvh_traverse.rs
+++ b/src/partitioning/bvh/bvh_traverse.rs
@@ -76,7 +76,7 @@ impl Bvh {
     ///
     /// See also the [`Bvh::traverse`] function which is slightly less convenient since it doesn’t
     /// rely on the iterator system, but takes a closure that implements [`FnMut`] instead of [`Fn`].
-    pub fn leaves<F: Fn(&BvhNode) -> bool>(&self, check_node: F) -> Leaves<F> {
+    pub fn leaves<F: Fn(&BvhNode) -> bool>(&self, check_node: F) -> Leaves<'_, F> {
         if let Some(root) = self.nodes.first() {
             let mut stack = SmallVec::default();
             if root.right.leaf_count() > 0 {

--- a/src/query/contact_manifolds/contact_manifolds_composite_shape_composite_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_composite_shape_composite_shape.rs
@@ -190,7 +190,7 @@ pub fn contact_manifolds_composite_shape_composite_shape<'a, ManifoldData, Conta
 }
 
 impl WorkspaceData for CompositeShapeCompositeShapeContactManifoldsWorkspace {
-    fn as_typed_workspace_data(&self) -> TypedWorkspaceData {
+    fn as_typed_workspace_data(&self) -> TypedWorkspaceData<'_> {
         TypedWorkspaceData::CompositeShapeCompositeShapeContactManifoldsWorkspace(self)
     }
 

--- a/src/query/contact_manifolds/contact_manifolds_composite_shape_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_composite_shape_shape.rs
@@ -154,7 +154,7 @@ pub fn contact_manifolds_composite_shape_shape<ManifoldData, ContactData>(
 }
 
 impl WorkspaceData for CompositeShapeShapeContactManifoldsWorkspace {
-    fn as_typed_workspace_data(&self) -> TypedWorkspaceData {
+    fn as_typed_workspace_data(&self) -> TypedWorkspaceData<'_> {
         TypedWorkspaceData::CompositeShapeShapeContactManifoldsWorkspace(self)
     }
 

--- a/src/query/contact_manifolds/contact_manifolds_heightfield_composite_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_heightfield_composite_shape.rs
@@ -169,7 +169,7 @@ pub fn contact_manifolds_heightfield_composite_shape<ManifoldData, ContactData>(
 }
 
 impl WorkspaceData for HeightFieldCompositeShapeContactManifoldsWorkspace {
-    fn as_typed_workspace_data(&self) -> TypedWorkspaceData {
+    fn as_typed_workspace_data(&self) -> TypedWorkspaceData<'_> {
         TypedWorkspaceData::HeightfieldCompositeShapeContactManifoldsWorkspace(self)
     }
 

--- a/src/query/contact_manifolds/contact_manifolds_heightfield_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_heightfield_shape.rs
@@ -189,7 +189,7 @@ pub fn contact_manifolds_heightfield_shape<ManifoldData, ContactData>(
 }
 
 impl WorkspaceData for HeightFieldShapeContactManifoldsWorkspace {
-    fn as_typed_workspace_data(&self) -> TypedWorkspaceData {
+    fn as_typed_workspace_data(&self) -> TypedWorkspaceData<'_> {
         TypedWorkspaceData::HeightfieldShapeContactManifoldsWorkspace(self)
     }
 

--- a/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_trimesh_shape.rs
@@ -218,7 +218,7 @@ pub fn contact_manifolds_trimesh_shape<ManifoldData, ContactData>(
 }
 
 impl WorkspaceData for TriMeshShapeContactManifoldsWorkspace {
-    fn as_typed_workspace_data(&self) -> TypedWorkspaceData {
+    fn as_typed_workspace_data(&self) -> TypedWorkspaceData<'_> {
         TypedWorkspaceData::TriMeshShapeContactManifoldsWorkspace(self)
     }
 

--- a/src/query/contact_manifolds/contact_manifolds_voxels_composite_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_composite_shape.rs
@@ -14,7 +14,7 @@ use alloc::{boxed::Box, vec::Vec};
 use na::Vector3;
 
 impl WorkspaceData for VoxelsShapeContactManifoldsWorkspace<3> {
-    fn as_typed_workspace_data(&self) -> TypedWorkspaceData {
+    fn as_typed_workspace_data(&self) -> TypedWorkspaceData<'_> {
         TypedWorkspaceData::VoxelsCompositeShapeContactManifoldsWorkspace(self)
     }
 

--- a/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
@@ -60,7 +60,7 @@ impl<const N: usize> VoxelsShapeContactManifoldsWorkspace<N> {
 }
 
 impl WorkspaceData for VoxelsShapeContactManifoldsWorkspace<2> {
-    fn as_typed_workspace_data(&self) -> TypedWorkspaceData {
+    fn as_typed_workspace_data(&self) -> TypedWorkspaceData<'_> {
         TypedWorkspaceData::VoxelsShapeContactManifoldsWorkspace(self)
     }
 

--- a/src/query/contact_manifolds/contact_manifolds_voxels_voxels.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_voxels.rs
@@ -13,7 +13,7 @@ use alloc::{boxed::Box, vec::Vec};
 use na::Vector4;
 
 impl WorkspaceData for VoxelsShapeContactManifoldsWorkspace<4> {
-    fn as_typed_workspace_data(&self) -> TypedWorkspaceData {
+    fn as_typed_workspace_data(&self) -> TypedWorkspaceData<'_> {
         TypedWorkspaceData::VoxelsVoxelsContactManifoldsWorkspace(self)
     }
 

--- a/src/query/contact_manifolds/contact_manifolds_workspace.rs
+++ b/src/query/contact_manifolds/contact_manifolds_workspace.rs
@@ -94,7 +94,7 @@ impl DeserializableWorkspaceData {
 /// Data from a [`ContactManifoldsWorkspace`].
 pub trait WorkspaceData: DowncastSync {
     /// Gets the underlying workspace as an enum.
-    fn as_typed_workspace_data(&self) -> TypedWorkspaceData;
+    fn as_typed_workspace_data(&self) -> TypedWorkspaceData<'_>;
 
     /// Clones `self`.
     fn clone_dyn(&self) -> Box<dyn WorkspaceData>;

--- a/src/shape/heightfield3.rs
+++ b/src/shape/heightfield3.rs
@@ -251,7 +251,7 @@ impl HeightField {
     }
 
     /// An iterator through all the triangles around the given point, after vertical projection on the heightfield.
-    pub fn triangles_around_point(&self, point: &Point3<Real>) -> HeightFieldRadialTriangles {
+    pub fn triangles_around_point(&self, point: &Point3<Real>) -> HeightFieldRadialTriangles<'_> {
         let center = self.closest_cell_at_point(point);
         HeightFieldRadialTriangles {
             heightfield: self,

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -381,7 +381,7 @@ pub trait Shape: RayCast + PointQuery + DowncastSync {
     fn shape_type(&self) -> ShapeType;
 
     /// Gets the underlying shape as an enum.
-    fn as_typed_shape(&self) -> TypedShape;
+    fn as_typed_shape(&self) -> TypedShape<'_>;
 
     fn ccd_thickness(&self) -> Real;
 
@@ -717,7 +717,7 @@ impl Shape for Ball {
         ShapeType::Ball
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::Ball(self)
     }
 
@@ -771,7 +771,7 @@ impl Shape for Cuboid {
         ShapeType::Cuboid
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::Cuboid(self)
     }
 
@@ -836,7 +836,7 @@ impl Shape for Capsule {
         ShapeType::Capsule
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::Capsule(self)
     }
 
@@ -895,7 +895,7 @@ impl Shape for Triangle {
         ShapeType::Triangle
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::Triangle(self)
     }
 
@@ -971,7 +971,7 @@ impl Shape for Segment {
         ShapeType::Segment
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::Segment(self)
     }
 
@@ -1038,7 +1038,7 @@ impl Shape for Compound {
         ShapeType::Compound
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::Compound(self)
     }
 
@@ -1090,7 +1090,7 @@ impl Shape for Polyline {
         ShapeType::Polyline
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::Polyline(self)
     }
 
@@ -1140,7 +1140,7 @@ impl Shape for TriMesh {
         ShapeType::TriMesh
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::TriMesh(self)
     }
 
@@ -1203,7 +1203,7 @@ impl Shape for HeightField {
         ShapeType::HeightField
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::HeightField(self)
     }
 
@@ -1321,7 +1321,7 @@ impl Shape for ConvexPolyhedron {
         ShapeType::ConvexPolyhedron
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::ConvexPolyhedron(self)
     }
 
@@ -1390,7 +1390,7 @@ impl Shape for Cylinder {
         ShapeType::Cylinder
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::Cylinder(self)
     }
 
@@ -1448,7 +1448,7 @@ impl Shape for Cone {
         ShapeType::Cone
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::Cone(self)
     }
 
@@ -1517,7 +1517,7 @@ impl Shape for HalfSpace {
         ShapeType::HalfSpace
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::HalfSpace(self)
     }
 }
@@ -1548,7 +1548,7 @@ impl Shape for Voxels {
         ShapeType::Voxels
     }
 
-    fn as_typed_shape(&self) -> TypedShape {
+    fn as_typed_shape(&self) -> TypedShape<'_> {
         TypedShape::Voxels(self)
     }
 
@@ -1598,7 +1598,7 @@ macro_rules! impl_shape_for_round_shape(
                 ShapeType::$Tag
             }
 
-            fn as_typed_shape(&self) -> TypedShape {
+            fn as_typed_shape(&self) -> TypedShape<'_> {
                 TypedShape::$Tag(self)
             }
 


### PR DESCRIPTION
Current `master` has [warnings on nightly](https://github.com/dimforge/parry/actions/runs/16371307515/job/46260101976) due to a bunch of `mismatched_lifetime_syntaxes`:

```rs
warning: lifetime flowing from input to output with different syntax can be confusing
  --> crates/parry3d/../../src/partitioning/bvh/bvh_traverse.rs:79:44
   |
79 |     pub fn leaves<F: Fn(&BvhNode) -> bool>(&self, check_node: F) -> Leaves<F> {
   |                                            ^^^^^                    --------- the lifetime gets resolved as `'_`
   |                                            |
   |                                            this lifetime flows to the output
   |
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
79 |     pub fn leaves<F: Fn(&BvhNode) -> bool>(&self, check_node: F) -> Leaves<'_, F> {
   |
```