### PR TITLE
Fix bvh crashing when removing and adding a lot of collider in the same frame.

### DIFF
--- a/src/partitioning/bvh/bvh_tree.rs
+++ b/src/partitioning/bvh/bvh_tree.rs
@@ -716,14 +716,16 @@ impl Bvh {
                     // Both parent pointers need to be updated since both nodes moved to the root.
                     let new_root = &mut self.nodes[0];
                     if new_root.left.is_leaf() {
-                        self.leaf_node_indices[new_root.left.children as usize] =
-                            BvhNodeIndex::left(0);
+                        let _ = self
+                            .leaf_node_indices
+                            .insert(new_root.left.children as usize, BvhNodeIndex::left(0));
                     } else {
                         self.parents[new_root.left.children as usize] = BvhNodeIndex::left(0);
                     }
                     if new_root.right.is_leaf() {
-                        self.leaf_node_indices[new_root.right.children as usize] =
-                            BvhNodeIndex::right(0);
+                        let _ = self
+                            .leaf_node_indices
+                            .insert(new_root.right.children as usize, BvhNodeIndex::right(0));
                     } else {
                         self.parents[new_root.right.children as usize] = BvhNodeIndex::right(0);
                     }


### PR DESCRIPTION
I encountered a crash while updating [bevy_rapier](https://github.com/dimforge/bevy_rapier/pull/671), and tracked it to this fix.

It would be worth verifying the rest of the logic, and add more tests.

Reproduce on https://github.com/dimforge/bevy_rapier/pull/671/commits/af92a929263f036e47d9e8ddaa8c68bd9d0008ff: run `cargo run --example testbed2` -> change example to `ropejoint2` (but any other demo change will trigger the crash)

<details><summary>Backtrace</summary>
<p>

```
thread 'Compute Task Pool (14)' panicked at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parry2d-0.22.0-beta.1/src/partitioning/bvh/bvh_tree.rs:725:47:
key not present
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panicking.rs:75:14
   2: core::panicking::panic_display
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panicking.rs:269:5
   3: core::option::expect_failed
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/option.rs:2049:5
   4: expect<&mut parry2d::partitioning::bvh::bvh_tree::BvhNodeIndex>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:958:21
   5: index_mut<parry2d::partitioning::bvh::bvh_tree::BvhNodeIndex>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parry2d-0.22.0-beta.1/src/utils/vec_map.rs:890:9
   6: remove
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parry2d-0.22.0-beta.1/src/partitioning/bvh/bvh_tree.rs:725:47
   7: update_with_strategy
             at /home/tb/.cargo/git/checkouts/rapier-a5b391197ab0b400/2e516f5/crates/rapier2d/../../src/geometry/broad_phase_bvh.rs:70:13
   8: update
             at /home/tb/.cargo/git/checkouts/rapier-a5b391197ab0b400/2e516f5/crates/rapier2d/../../src/geometry/broad_phase_bvh.rs:260:9
   9: detect_collisions
             at /home/tb/.cargo/git/checkouts/rapier-a5b391197ab0b400/2e516f5/crates/rapier2d/../../src/pipeline/physics_pipeline.rs:119:9
  10: step
             at /home/tb/.cargo/git/checkouts/rapier-a5b391197ab0b400/2e516f5/crates/rapier2d/../../src/pipeline/physics_pipeline.rs:487:9
  11: step_simulation
             at ./bevy_rapier2d/../src/plugin/context/mod.rs:698:21
  12: step_simulation<()>
             at ./bevy_rapier2d/../src/plugin/systems/mod.rs:67:13
  13: call_mut<fn(bevy_ecs::system::query::Query<(&mut bevy_rapier2d::plugin::context::RapierContextSimulation, &mut bevy_rapier2d::plugin::context::RapierContextColliders, &mut bevy_rapier2d::plugin::context::RapierContextJoints, &mut bevy_rapier2d::plugin::context::RapierRigidBodySet, &bevy_rapier2d::plugin::configuration::RapierConfiguration, &mut bevy_rapier2d::plugin::context::SimulationToRenderTime), ()>, bevy_ecs::change_detection::Res<bevy_rapier2d::plugin::configuration::TimestepMode>, bevy_ecs::system::system_param::StaticSystemParam<()>, bevy_ecs::change_detection::Res<bevy_time::time::Time<()>>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::CollisionEvent>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::ContactForceEvent>, bevy_ecs::system::query::Query<(&bevy_rapier2d::dynamics::rigid_body::RapierRigidBodyHandle, &mut bevy_rapier2d::dynamics::rigid_body::TransformInterpolation), ()>), (bevy_ecs::system::query::Query<(&mut bevy_rapier2d::plugin::context::RapierContextSimulation, &mut bevy_rapier2d::plugin::context::RapierContextColliders, &mut bevy_rapier2d::plugin::context::RapierContextJoints, &mut bevy_rapier2d::plugin::context::RapierRigidBodySet, &bevy_rapier2d::plugin::configuration::RapierConfiguration, &mut bevy_rapier2d::plugin::context::SimulationToRenderTime), ()>, bevy_ecs::change_detection::Res<bevy_rapier2d::plugin::configuration::TimestepMode>, bevy_ecs::system::system_param::StaticSystemParam<()>, bevy_ecs::change_detection::Res<bevy_time::time::Time<()>>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::CollisionEvent>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::ContactForceEvent>, bevy_ecs::system::query::Query<(&bevy_rapier2d::dynamics::rigid_body::RapierRigidBodyHandle, &mut bevy_rapier2d::dynamics::rigid_body::TransformInterpolation), ()>)>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:166:5
  14: call_mut<(bevy_ecs::system::query::Query<(&mut bevy_rapier2d::plugin::context::RapierContextSimulation, &mut bevy_rapier2d::plugin::context::RapierContextColliders, &mut bevy_rapier2d::plugin::context::RapierContextJoints, &mut bevy_rapier2d::plugin::context::RapierRigidBodySet, &bevy_rapier2d::plugin::configuration::RapierConfiguration, &mut bevy_rapier2d::plugin::context::SimulationToRenderTime), ()>, bevy_ecs::change_detection::Res<bevy_rapier2d::plugin::configuration::TimestepMode>, bevy_ecs::system::system_param::StaticSystemParam<()>, bevy_ecs::change_detection::Res<bevy_time::time::Time<()>>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::CollisionEvent>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::ContactForceEvent>, bevy_ecs::system::query::Query<(&bevy_rapier2d::dynamics::rigid_body::RapierRigidBodyHandle, &mut bevy_rapier2d::dynamics::rigid_body::TransformInterpolation), ()>), fn(bevy_ecs::system::query::Query<(&mut bevy_rapier2d::plugin::context::RapierContextSimulation, &mut bevy_rapier2d::plugin::context::RapierContextColliders, &mut bevy_rapier2d::plugin::context::RapierContextJoints, &mut bevy_rapier2d::plugin::context::RapierRigidBodySet, &bevy_rapier2d::plugin::configuration::RapierConfiguration, &mut bevy_rapier2d::plugin::context::SimulationToRenderTime), ()>, bevy_ecs::change_detection::Res<bevy_rapier2d::plugin::configuration::TimestepMode>, bevy_ecs::system::system_param::StaticSystemParam<()>, bevy_ecs::change_detection::Res<bevy_time::time::Time<()>>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::CollisionEvent>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::ContactForceEvent>, bevy_ecs::system::query::Query<(&bevy_rapier2d::dynamics::rigid_body::RapierRigidBodyHandle, &mut bevy_rapier2d::dynamics::rigid_body::TransformInterpolation), ()>)>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:294:13
  15: call_inner<(), bevy_ecs::system::query::Query<(&mut bevy_rapier2d::plugin::context::RapierContextSimulation, &mut bevy_rapier2d::plugin::context::RapierContextColliders, &mut bevy_rapier2d::plugin::context::RapierContextJoints, &mut bevy_rapier2d::plugin::context::RapierRigidBodySet, &bevy_rapier2d::plugin::configuration::RapierConfiguration, &mut bevy_rapier2d::plugin::context::SimulationToRenderTime), ()>, bevy_ecs::change_detection::Res<bevy_rapier2d::plugin::configuration::TimestepMode>, bevy_ecs::system::system_param::StaticSystemParam<()>, bevy_ecs::change_detection::Res<bevy_time::time::Time<()>>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::CollisionEvent>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::ContactForceEvent>, bevy_ecs::system::query::Query<(&bevy_rapier2d::dynamics::rigid_body::RapierRigidBodyHandle, &mut bevy_rapier2d::dynamics::rigid_body::TransformInterpolation), ()>, &mut fn(bevy_ecs::system::query::Query<(&mut bevy_rapier2d::plugin::context::RapierContextSimulation, &mut bevy_rapier2d::plugin::context::RapierContextColliders, &mut bevy_rapier2d::plugin::context::RapierContextJoints, &mut bevy_rapier2d::plugin::context::RapierRigidBodySet, &bevy_rapier2d::plugin::configuration::RapierConfiguration, &mut bevy_rapier2d::plugin::context::SimulationToRenderTime), ()>, bevy_ecs::change_detection::Res<bevy_rapier2d::plugin::configuration::TimestepMode>, bevy_ecs::system::system_param::StaticSystemParam<()>, bevy_ecs::change_detection::Res<bevy_time::time::Time<()>>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::CollisionEvent>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::ContactForceEvent>, bevy_ecs::system::query::Query<(&bevy_rapier2d::dynamics::rigid_body::RapierRigidBodyHandle, &mut bevy_rapier2d::dynamics::rigid_body::TransformInterpolation), ()>)>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.16.1/src/system/function_system.rs:945:21
  16: run<(), fn(bevy_ecs::system::query::Query<(&mut bevy_rapier2d::plugin::context::RapierContextSimulation, &mut bevy_rapier2d::plugin::context::RapierContextColliders, &mut bevy_rapier2d::plugin::context::RapierContextJoints, &mut bevy_rapier2d::plugin::context::RapierRigidBodySet, &bevy_rapier2d::plugin::configuration::RapierConfiguration, &mut bevy_rapier2d::plugin::context::SimulationToRenderTime), ()>, bevy_ecs::change_detection::Res<bevy_rapier2d::plugin::configuration::TimestepMode>, bevy_ecs::system::system_param::StaticSystemParam<()>, bevy_ecs::change_detection::Res<bevy_time::time::Time<()>>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::CollisionEvent>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::ContactForceEvent>, bevy_ecs::system::query::Query<(&bevy_rapier2d::dynamics::rigid_body::RapierRigidBodyHandle, &mut bevy_rapier2d::dynamics::rigid_body::TransformInterpolation), ()>), bevy_ecs::system::query::Query<(&mut bevy_rapier2d::plugin::context::RapierContextSimulation, &mut bevy_rapier2d::plugin::context::RapierContextColliders, &mut bevy_rapier2d::plugin::context::RapierContextJoints, &mut bevy_rapier2d::plugin::context::RapierRigidBodySet, &bevy_rapier2d::plugin::configuration::RapierConfiguration, &mut bevy_rapier2d::plugin::context::SimulationToRenderTime), ()>, bevy_ecs::change_detection::Res<bevy_rapier2d::plugin::configuration::TimestepMode>, bevy_ecs::system::system_param::StaticSystemParam<()>, bevy_ecs::change_detection::Res<bevy_time::time::Time<()>>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::CollisionEvent>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::ContactForceEvent>, bevy_ecs::system::query::Query<(&bevy_rapier2d::dynamics::rigid_body::RapierRigidBodyHandle, &mut bevy_rapier2d::dynamics::rigid_body::TransformInterpolation), ()>>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.16.1/src/system/function_system.rs:948:17
  17: run_unsafe<fn(bevy_ecs::system::query::Query<(&mut bevy_rapier2d::plugin::context::RapierContextSimulation, &mut bevy_rapier2d::plugin::context::RapierContextColliders, &mut bevy_rapier2d::plugin::context::RapierContextJoints, &mut bevy_rapier2d::plugin::context::RapierRigidBodySet, &bevy_rapier2d::plugin::configuration::RapierConfiguration, &mut bevy_rapier2d::plugin::context::SimulationToRenderTime), ()>, bevy_ecs::change_detection::Res<bevy_rapier2d::plugin::configuration::TimestepMode>, bevy_ecs::system::system_param::StaticSystemParam<()>, bevy_ecs::change_detection::Res<bevy_time::time::Time<()>>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::CollisionEvent>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::ContactForceEvent>, bevy_ecs::system::query::Query<(&bevy_rapier2d::dynamics::rigid_body::RapierRigidBodyHandle, &mut bevy_rapier2d::dynamics::rigid_body::TransformInterpolation), ()>), fn(bevy_ecs::system::query::Query<(&mut bevy_rapier2d::plugin::context::RapierContextSimulation, &mut bevy_rapier2d::plugin::context::RapierContextColliders, &mut bevy_rapier2d::plugin::context::RapierContextJoints, &mut bevy_rapier2d::plugin::context::RapierRigidBodySet, &bevy_rapier2d::plugin::configuration::RapierConfiguration, &mut bevy_rapier2d::plugin::context::SimulationToRenderTime), ()>, bevy_ecs::change_detection::Res<bevy_rapier2d::plugin::configuration::TimestepMode>, bevy_ecs::system::system_param::StaticSystemParam<()>, bevy_ecs::change_detection::Res<bevy_time::time::Time<()>>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::CollisionEvent>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::ContactForceEvent>, bevy_ecs::system::query::Query<(&bevy_rapier2d::dynamics::rigid_body::RapierRigidBodyHandle, &mut bevy_rapier2d::dynamics::rigid_body::TransformInterpolation), ()>)>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.16.1/src/system/function_system.rs:735:19
  18: run_unsafe<bevy_ecs::system::function_system::FunctionSystem<fn(bevy_ecs::system::query::Query<(&mut bevy_rapier2d::plugin::context::RapierContextSimulation, &mut bevy_rapier2d::plugin::context::RapierContextColliders, &mut bevy_rapier2d::plugin::context::RapierContextJoints, &mut bevy_rapier2d::plugin::context::RapierRigidBodySet, &bevy_rapier2d::plugin::configuration::RapierConfiguration, &mut bevy_rapier2d::plugin::context::SimulationToRenderTime), ()>, bevy_ecs::change_detection::Res<bevy_rapier2d::plugin::configuration::TimestepMode>, bevy_ecs::system::system_param::StaticSystemParam<()>, bevy_ecs::change_detection::Res<bevy_time::time::Time<()>>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::CollisionEvent>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::ContactForceEvent>, bevy_ecs::system::query::Query<(&bevy_rapier2d::dynamics::rigid_body::RapierRigidBodyHandle, &mut bevy_rapier2d::dynamics::rigid_body::TransformInterpolation), ()>), fn(bevy_ecs::system::query::Query<(&mut bevy_rapier2d::plugin::context::RapierContextSimulation, &mut bevy_rapier2d::plugin::context::RapierContextColliders, &mut bevy_rapier2d::plugin::context::RapierContextJoints, &mut bevy_rapier2d::plugin::context::RapierRigidBodySet, &bevy_rapier2d::plugin::configuration::RapierConfiguration, &mut bevy_rapier2d::plugin::context::SimulationToRenderTime), ()>, bevy_ecs::change_detection::Res<bevy_rapier2d::plugin::configuration::TimestepMode>, bevy_ecs::system::system_param::StaticSystemParam<()>, bevy_ecs::change_detection::Res<bevy_time::time::Time<()>>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::CollisionEvent>, bevy_ecs::event::writer::EventWriter<bevy_rapier2d::pipeline::events::ContactForceEvent>, bevy_ecs::system::query::Query<(&bevy_rapier2d::dynamics::rigid_body::RapierRigidBodyHandle, &mut bevy_rapier2d::dynamics::rigid_body::TransformInterpolation), ()>)>>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.16.1/src/system/schedule_system.rs:68:9
  19: run_unsafe
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.16.1/src/schedule/executor/mod.rs:280:22
  20: {closure#0}
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.16.1/src/schedule/executor/multi_threaded.rs:634:39
  21: call_once<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block#0}::{closure_env#0}, ()>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  22: call_once<(), bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block#0}::{closure_env#0}>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:272:9
  23: do_call<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block#0}::{closure_env#0}>, ()>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:589:40
  24: try<(), core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block#0}::{closure_env#0}>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:552:19
  25: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block#0}::{closure_env#0}>, ()>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  26: {async_block#0}
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.16.1/src/schedule/executor/multi_threaded.rs:627:23
  27: poll<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:297:9
  28: {closure#0}<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.0/src/future.rs:656:42
  29: call_once<core::task::poll::Poll<()>, futures_lite::future::{impl#11}::poll::{closure_env#0}<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:272:9
  30: do_call<core::panic::unwind_safe::AssertUnwindSafe<futures_lite::future::{impl#11}::poll::{closure_env#0}<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>>, core::task::poll::Poll<()>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:589:40
  31: try<core::task::poll::Poll<()>, core::panic::unwind_safe::AssertUnwindSafe<futures_lite::future::{impl#11}::poll::{closure_env#0}<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:552:19
  32: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<futures_lite::future::{impl#11}::poll::{closure_env#0}<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>>, core::task::poll::Poll<()>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  33: poll<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.0/src/future.rs:656:9
  34: poll<futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>, async_executor::{impl#5}::spawn_inner::{closure_env#0}<core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>>>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-executor-1.13.2/src/lib.rs:1179:9
  35: {closure#1}<async_executor::AsyncCallOnDrop<futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>, async_executor::{impl#5}::spawn_inner::{closure_env#0}<core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>>>, core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, async_executor::{impl#5}::schedule::{closure_env#0}, ()>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-task-4.7.1/src/raw.rs:550:21
  36: call_once<async_task::raw::{impl#3}::run::{closure_env#1}<async_executor::AsyncCallOnDrop<futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>, async_executor::{impl#5}::spawn_inner::{closure_env#0}<core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>>>, core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, async_executor::{impl#5}::schedule::{closure_env#0}, ()>, ()>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  37: call_once<core::task::poll::Poll<core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>>, async_task::raw::{impl#3}::run::{closure_env#1}<async_executor::AsyncCallOnDrop<futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>, async_executor::{impl#5}::spawn_inner::{closure_env#0}<core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>>>, core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, async_executor::{impl#5}::schedule::{closure_env#0}, ()>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:272:9
  38: do_call<core::panic::unwind_safe::AssertUnwindSafe<async_task::raw::{impl#3}::run::{closure_env#1}<async_executor::AsyncCallOnDrop<futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>, async_executor::{impl#5}::spawn_inner::{closure_env#0}<core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>>>, core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, async_executor::{impl#5}::schedule::{closure_env#0}, ()>>, core::task::poll::Poll<core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:589:40
  39: try<core::task::poll::Poll<core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>>, core::panic::unwind_safe::AssertUnwindSafe<async_task::raw::{impl#3}::run::{closure_env#1}<async_executor::AsyncCallOnDrop<futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>, async_executor::{impl#5}::spawn_inner::{closure_env#0}<core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>>>, core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, async_executor::{impl#5}::schedule::{closure_env#0}, ()>>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:552:19
  40: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<async_task::raw::{impl#3}::run::{closure_env#1}<async_executor::AsyncCallOnDrop<futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>, async_executor::{impl#5}::spawn_inner::{closure_env#0}<core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>>>, core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, async_executor::{impl#5}::schedule::{closure_env#0}, ()>>, core::task::poll::Poll<core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  41: run<async_executor::AsyncCallOnDrop<futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>, async_executor::{impl#5}::spawn_inner::{closure_env#0}<core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, futures_lite::future::CatchUnwind<core::panic::unwind_safe::AssertUnwindSafe<bevy_ecs::schedule::executor::multi_threaded::{impl#5}::spawn_system_task::{async_block_env#0}>>>>, core::result::Result<(), alloc::boxed::Box<(dyn core::any::Any + core::marker::Send), alloc::alloc::Global>>, async_executor::{impl#5}::schedule::{closure_env#0}, ()>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-task-4.7.1/src/raw.rs:549:23
  42: {async_block#0}<core::result::Result<(), async_channel::RecvError>, futures_lite::future::Or<bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure#0}::{closure#0}::{async_block_env#0}, async_channel::Recv<()>>>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-executor-1.13.2/src/lib.rs:745:21
  43: poll<core::result::Result<(), async_channel::RecvError>, futures_lite::future::Or<bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure#0}::{closure#0}::{async_block_env#0}, async_channel::Recv<()>>, async_executor::{impl#13}::run::{async_fn#0}::{async_block_env#0}<core::result::Result<(), async_channel::RecvError>, futures_lite::future::Or<bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure#0}::{closure#0}::{async_block_env#0}, async_channel::Recv<()>>>>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.0/src/future.rs:457:33
  44: {async_fn#0}<core::result::Result<(), async_channel::RecvError>, futures_lite::future::Or<bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure#0}::{closure#0}::{async_block_env#0}, async_channel::Recv<()>>>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-executor-1.13.2/src/lib.rs:752:32
  45: {async_fn#0}<core::result::Result<(), async_channel::RecvError>, futures_lite::future::Or<bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure#0}::{closure#0}::{async_block_env#0}, async_channel::Recv<()>>>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-executor-1.13.2/src/lib.rs:343:34
  46: {closure#0}<core::result::Result<(), async_channel::RecvError>, async_executor::{impl#5}::run::{async_fn_env#0}<core::result::Result<(), async_channel::RecvError>, futures_lite::future::Or<bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure#0}::{closure#0}::{async_block_env#0}, async_channel::Recv<()>>>>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.0/src/future.rs:99:19
  47: try_with<core::cell::RefCell<(parking::Parker, core::task::wake::Waker)>, futures_lite::future::block_on::{closure_env#0}<core::result::Result<(), async_channel::RecvError>, async_executor::{impl#5}::run::{async_fn_env#0}<core::result::Result<(), async_channel::RecvError>, futures_lite::future::Or<bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure#0}::{closure#0}::{async_block_env#0}, async_channel::Recv<()>>>>, core::result::Result<(), async_channel::RecvError>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:315:12
  48: with<core::cell::RefCell<(parking::Parker, core::task::wake::Waker)>, futures_lite::future::block_on::{closure_env#0}<core::result::Result<(), async_channel::RecvError>, async_executor::{impl#5}::run::{async_fn_env#0}<core::result::Result<(), async_channel::RecvError>, futures_lite::future::Or<bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure#0}::{closure#0}::{async_block_env#0}, async_channel::Recv<()>>>>, core::result::Result<(), async_channel::RecvError>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:279:15
  49: block_on<core::result::Result<(), async_channel::RecvError>, async_executor::{impl#5}::run::{async_fn_env#0}<core::result::Result<(), async_channel::RecvError>, futures_lite::future::Or<bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure#0}::{closure#0}::{async_block_env#0}, async_channel::Recv<()>>>>
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.0/src/future.rs:78:5
  50: {closure#0}
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_tasks-0.16.1/src/task_pool.rs:203:37
  51: do_call<bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure#0}::{closure_env#0}, core::result::Result<(), async_channel::RecvError>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:589:40
  52: try<core::result::Result<(), async_channel::RecvError>, bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure#0}::{closure_env#0}>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:552:19
  53: catch_unwind<bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure#0}::{closure_env#0}, core::result::Result<(), async_channel::RecvError>>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  54: {closure#0}
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_tasks-0.16.1/src/task_pool.rs:197:43
  55: try_with<bevy_tasks::executor::LocalExecutor, bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure_env#0}, ()>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:315:12
  56: with<bevy_tasks::executor::LocalExecutor, bevy_tasks::task_pool::{impl#2}::new_internal::{closure#0}::{closure#0}::{closure_env#0}, ()>
             at /home/tb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:279:15
  57: {closure#0}
             at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_tasks-0.16.1/src/task_pool.rs:190:25
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Encountered a panic in system `bevy_rapier2d::plugin::systems::step_simulation<()>`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!
```

</p>
</details> 
