### PR TITLE
Release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.22.0
 
 ### Fixed
 

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.22.0-beta.1"
+version = "0.22.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.22.0-beta.1"
+version = "0.22.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.22.0-beta.1"
+version = "0.22.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.22.0-beta.1"
+version = "0.22.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."


### PR DESCRIPTION
## 0.22.0

### Fixed

- Fix bug in BVH tree node removal.
- Fix bug in BVH tree building from exactly two leaves.

## 0.22.0-beta.1

### Fixed

- Fix invalid BVH state that could be reached after a removal resulting in a partial root.

## 0.22.0-beta.0

### Added

- Add a new `Bvh` acceleration data-structure. It replaces `Qbvh` entirely. It supports:
  - Traversals (best-first, depth-first, BVTT, leaf iterators, and leaf pairs iterator).
  - It can be constructed either incrementally by inserting nodes, or from a set of leaves using either the
    binned building strategy or the PLOC (without parallelism) strategy.
  - Dynamic leaf insertion, update, removal.
  - Incremental tree rebalancing.

### Fixed

- Fix `clip_aabb_line` crashing when given incorrect inputs (zero length direction or NAN).
- Fix `Segment::intersects_ray` returning false-positive when the segment is zero-length. ([#31](https://github.com/dimforge/parry/issues/31)).
- Expose `utils::sort3` and `utils::sort2`.

### Modified

- The `local_point_cloud_aabb`, `point_cloud_aabb`, and `Aabb::from_points` now takes an iterator over point values instead
  of an iterator to point references. Variants taking point references still exist and are named `local_point_cloud_aabb_ref`,
  `point_cloud_aabb_ref` and `Aabb::from_points_ref`.
- Renamed `SimdCompositeShape` and `TypedSimdCompositeShape` to `CompositeShape` and TypedCompositeShape`.
- The `TypedCompositeShape` trait now derives from `CompositeShape`.
- Removed every `*Visitor` structures. Instead, either call `Bvh::traverse` (or `Bvh::search_best`, or `Bvh::leaves`, or
  `bvh::leaf_pairs`), or wrap your composite shape into `CompositeShapeRef` to access some generic implementation of
  various geometric queries for any composite shape.
- All composite shapes now rely on the new `Bvh` acceleration structure instead of `Qbvh`.
- The `Qbvh` has been removed. Use `Bvh` instead.