### PR TITLE
Release 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.25.0
+
+- The `Voxels` shape now uses a sparse storage internally.
+- Remove `Voxels::try_set_voxel`. Use `::set_voxel` instead.
+- The `Voxels::domain` function returns values instead of references now.
+- Removed `Voxels::extents` and `Voxels::domain_center`. They can be obtained
+  from `Voxels::local_aabb`.
+
 ## 0.24.0
 
 - Fixed same-machine determinism of the re-exported hashmap when building without the `enhanced-determinism` feature.

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."

--- a/src/shape/voxels/voxels.rs
+++ b/src/shape/voxels/voxels.rs
@@ -278,27 +278,6 @@ impl Voxels {
         &self.chunk_bvh
     }
 
-    // /// The extents of the total axis-aligned volume covered by this [`Voxels`] shape.
-    // ///
-    // /// This accounts for all the voxels reserved in the internal buffer of `self`, including empty
-    // /// ones.
-    // pub fn extents(&self) -> Vector<Real> {
-    //     self.dimensions()
-    //         .cast::<Real>()
-    //         .component_mul(&self.voxel_size)
-    // }
-
-    // /// The center of this shape’s domain (accounting for both empty and filled voxels).
-    // pub fn domain_center(&self) -> Point<Real> {
-    //     (self
-    //         .domain_mins
-    //         .coords
-    //         .cast::<Real>()
-    //         .component_mul(&self.voxel_size)
-    //         + self.extents() / 2.0)
-    //         .into()
-    // }
-
     /// The semi-open range of voxels in shape.
     ///
     /// This provides conservative bounds on the range of voxel indices that might be set to filled.


### PR DESCRIPTION
## 0.25.0

- The `Voxels` shape now uses a sparse storage internally.
- Remove `Voxels::try_set_voxel`. Use `::set_voxel` instead.
- The `Voxels::domain` function returns values instead of references now.
- Removed `Voxels::extents` and `Voxels::domain_center`. They can be obtained
  from `Voxels::local_aabb`.