### PR TITLE
Release v0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.25.2
+
+- Add the `encase` feature to enable implementation of `encase::ShaderType` for primitive shapes.
+- Fix regression in shape-vs-composite-shape contact calculation.
+
 ## 0.25.1
 
 - Fix point-projection of a ball on a voxels shape containing empty chunks (e.g. after voxels removal).

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."


### PR DESCRIPTION
## 0.25.2

- Add the `encase` feature to enable implementation of `encase::ShaderType` for primitive shapes.
- Fix regression in shape-vs-composite-shape contact calculation.