### PR TITLE
Fix Bvh::optimize_incremental non-determinism

### DIFF
--- a/src/partitioning/bvh/bvh_optimize.rs
+++ b/src/partitioning/bvh/bvh_optimize.rs
@@ -240,7 +240,8 @@ impl Bvh {
         }
 
         workspace.rebuild_leaves.clear();
-        self.optimization.rebuild_frame_index = self.optimization.rebuild_frame_index.overflowing_add(1).0;
+        self.optimization.rebuild_frame_index =
+            self.optimization.rebuild_frame_index.overflowing_add(1).0;
         let config = self.optimization_config(self.optimization.rebuild_frame_index);
 
         /*

--- a/src/partitioning/bvh/bvh_optimize.rs
+++ b/src/partitioning/bvh/bvh_optimize.rs
@@ -240,15 +240,15 @@ impl Bvh {
         }
 
         workspace.rebuild_leaves.clear();
-        workspace.rebuild_frame_index = workspace.rebuild_frame_index.overflowing_add(1).0;
-        let config = self.optimization_config(workspace.rebuild_frame_index);
+        self.optimization.rebuild_frame_index = self.optimization.rebuild_frame_index.overflowing_add(1).0;
+        let config = self.optimization_config(self.optimization.rebuild_frame_index);
 
         /*
          * Subtree optimizations.
          */
         // let t0 = core::time::Instant::now();
         let num_leaves = self.nodes[0].leaf_count();
-        let mut start_index = workspace.rebuild_start_index;
+        let mut start_index = self.optimization.rebuild_start_index;
 
         // println!("Max candidate leaf count = {}", max_candidate_leaf_count);
         self.find_optimization_roots(
@@ -266,7 +266,7 @@ impl Bvh {
             //       to reach the target subtree count.
         }
 
-        workspace.rebuild_start_index = start_index;
+        self.optimization.rebuild_start_index = start_index;
 
         // println!(
         //     "Num refinement candidates: {}, list: {:?}",
@@ -520,6 +520,19 @@ impl Bvh {
             }
         }
     }
+}
+
+/// The optimization state for used by `Bvh::optimize_incremental`.
+/// This allows each call to `optimize_incremental` to continue from where the last one left off.
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+pub(super) struct BvhIncrementalOptimizationState {
+    pub(super) rebuild_frame_index: u32,
+    pub(super) rebuild_start_index: u32,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/src/partitioning/bvh/bvh_optimize.rs
+++ b/src/partitioning/bvh/bvh_optimize.rs
@@ -522,7 +522,7 @@ impl Bvh {
     }
 }
 
-/// The optimization state for used by `Bvh::optimize_incremental`.
+/// The optimization state used by `Bvh::optimize_incremental`.
 /// This allows each call to `optimize_incremental` to continue from where the last one left off.
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]

--- a/src/partitioning/bvh/bvh_tree.rs
+++ b/src/partitioning/bvh/bvh_tree.rs
@@ -1,4 +1,5 @@
 use super::BvhOptimizationHeapEntry;
+use super::bvh_optimize::BvhIncrementalOptimizationState;
 use crate::bounding_volume::{Aabb, BoundingVolume};
 use crate::math::{Real, Vector};
 use crate::query::{Ray, RayCast};
@@ -136,8 +137,6 @@ pub enum BvhBuildStrategy {
 pub struct BvhWorkspace {
     pub(super) refit_tmp: BvhNodeVec,
     pub(super) rebuild_leaves: Vec<BvhNode>,
-    pub(super) rebuild_frame_index: u32,
-    pub(super) rebuild_start_index: u32,
     pub(super) optimization_roots: Vec<u32>,
     pub(super) queue: BinaryHeap<BvhOptimizationHeapEntry>,
     pub(super) dequeue: VecDeque<u32>,
@@ -1752,6 +1751,7 @@ pub struct Bvh {
     // We don’t store this in `Self::nodes` since it’s only useful for node removal.
     pub(super) parents: Vec<BvhNodeIndex>,
     pub(super) leaf_node_indices: VecMap<BvhNodeIndex>,
+    pub(super) optimization: BvhIncrementalOptimizationState,
 }
 
 impl Bvh {
@@ -2186,6 +2186,7 @@ impl Bvh {
             nodes,
             parents,
             leaf_node_indices,
+            optimization: _,
         } = self;
         nodes.capacity() * size_of::<BvhNodeWide>()
             + parents.capacity() * size_of::<BvhNodeIndex>()

--- a/src/partitioning/bvh/bvh_tree.rs
+++ b/src/partitioning/bvh/bvh_tree.rs
@@ -1751,6 +1751,8 @@ pub struct Bvh {
     // We don’t store this in `Self::nodes` since it’s only useful for node removal.
     pub(super) parents: Vec<BvhNodeIndex>,
     pub(super) leaf_node_indices: VecMap<BvhNodeIndex>,
+    // NOTE: this cannot be in the workspace as we need this to survive serialization/deserialization
+    //       to maintain determinism.
     pub(super) optimization: BvhIncrementalOptimizationState,
 }
 

--- a/src/partitioning/bvh/bvh_tree.rs
+++ b/src/partitioning/bvh/bvh_tree.rs
@@ -1,5 +1,5 @@
-use super::BvhOptimizationHeapEntry;
 use super::bvh_optimize::BvhIncrementalOptimizationState;
+use super::BvhOptimizationHeapEntry;
 use crate::bounding_volume::{Aabb, BoundingVolume};
 use crate::math::{Real, Vector};
 use crate::query::{Ray, RayCast};


### PR DESCRIPTION
Closes #402 

There is a non-determinism issue in `Bvh::optimize_incremental` when you are restoring your `Bvh` from a serialized snapshot. It occurs because `Bvh::optimize_incremental` relies on significant state in `BvhWorkspace` which is ephemeral and cannot be serialized. This change moves the significant fields into `Bvh` so that they do get serialized, enabling deterministic execution once again.

I've written a lot more background on these two tickets:
- #402 
- https://github.com/dimforge/rapier/issues/910

I have verified that all tests pass, and I have verified that this fixes the non-determinism issue in my application.

I am happy to rework this in other ways if you would prefer. 