### PR TITLE
fix: BvhNode::scale now handles negative scale components correctly

### DIFF
--- a/src/partitioning/bvh/bvh_tree.rs
+++ b/src/partitioning/bvh/bvh_tree.rs
@@ -811,8 +811,12 @@ impl BvhNode {
     /// - [`Bvh::scale`] - Scale an entire BVH tree
     #[inline]
     pub fn scale(&mut self, scale: Vector) {
-        self.mins *= scale;
-        self.maxs *= scale;
+        let new_mins = self.mins * scale;
+        let new_maxs = self.maxs * scale;
+        // When scale has negative components, mins/maxs swap on those axes.
+        // Use component-wise min/max to maintain the AABB invariant (mins <= maxs).
+        self.mins = new_mins.min(new_maxs);
+        self.maxs = new_mins.max(new_maxs);
     }
 
     /// Calculates the volume of this node's AABB.
@@ -1995,18 +1999,18 @@ impl Bvh {
 
     /// Scales all AABBs in the tree by the given factors.
     ///
-    /// This multiplies all AABB coordinates (mins and maxs) by the corresponding components
-    /// of the scale vector. This is useful when scaling an entire scene or changing coordinate
-    /// systems.
+    /// Each AABB's coordinates are multiplied by the corresponding scale components, with
+    /// mins and maxs swapped on any axis where the scale is negative to preserve the
+    /// AABB invariant. This is useful when scaling an entire scene or changing coordinate
+    /// systems, including reflections.
     ///
     /// # Arguments
     ///
-    /// * `scale` - Per-axis scale factors (must all be positive)
+    /// * `scale` - Per-axis scale factors. Each component must be non-zero.
     ///
     /// # Panics
     ///
-    /// This function has undefined behavior if any scale component is negative or zero.
-    /// Always use positive scale values.
+    /// Undefined behavior if any scale component is zero (degenerate AABB).
     ///
     /// # Example
     ///


### PR DESCRIPTION
check/update bvh for negative scales and remove arg condition. this condition was not mentioned in (at least) `TriMesh::scaled_by`, doesn't seem expensive to check correctly, and is on an infrequent codepath.

--

Previously, scaling an AABB by a negative factor would produce an inverted AABB (mins > maxs on the negated axis), breaking the BVH invariant and causing all intersection/shapecast queries to silently miss geometry.

Fix by taking component-wise min/max of the two scaled corners, so the AABB invariant is preserved regardless of sign. The parent-child containment property of the BVH is maintained since scale(merge(A,B)) == merge(scale(A),scale(B)) holds for any non-zero scale.

This unblocks use of TriMesh::scaled with negative scale (e.g. reflections).