### PR TITLE
feat: add Bvh::cast_ray_best for SIMD-accelerated generic ray queries

### DIFF
--- a/src/partitioning/bvh/bvh_queries.rs
+++ b/src/partitioning/bvh/bvh_queries.rs
@@ -1,4 +1,4 @@
-use super::{Bvh, BvhNode};
+use super::{Bvh, BvhLeafCost, BvhNode};
 use crate::bounding_volume::{Aabb, BoundingVolume};
 use crate::math::Real;
 use crate::math::Vector;
@@ -247,6 +247,76 @@ impl Bvh {
                 let proj = primitive_check(primitive, max_distance)?;
                 Some((proj.0.point.distance(point), proj))
             },
+        )
+    }
+
+    /// Like [`cast_ray`](Self::cast_ray), but returns an arbitrary [`BvhLeafCost`]
+    /// type from the leaf test rather than just [`Real`].
+    ///
+    /// This lets callers collect richer per-hit data (e.g., a `RayIntersection`
+    /// which includes the surface normal) while still benefiting from
+    /// SIMD-accelerated AABB tests on supported platforms.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[cfg(all(feature = "dim3", feature = "f32"))] {
+    /// use parry3d::math::Vector;
+    /// use parry3d::query::{Ray, RayCast, RayIntersection};
+    /// use parry3d::shape::TriMesh;
+    ///
+    /// let vertices = vec![
+    ///     Vector::new(-1.0, -1.0, 0.0),
+    ///     Vector::new(1.0, -1.0, 0.0),
+    ///     Vector::new(1.0, 1.0, 0.0),
+    ///     Vector::new(-1.0, 1.0, 0.0),
+    /// ];
+    /// let mesh = TriMesh::new(vertices, vec![[0, 1, 2], [0, 2, 3]]).unwrap();
+    /// let ray = Ray::new(Vector::new(0.5, 0.3, -2.0), Vector::new(0.0, 0.0, 1.0));
+    ///
+    /// // cast_ray_best returns RayIntersection (with normal) instead of just Real:
+    /// let hit = mesh.bvh().cast_ray_best(&ray, f32::MAX, |leaf_id, _best| {
+    ///     let tri = mesh.triangle(leaf_id);
+    ///     tri.cast_local_ray_and_get_normal(&ray, f32::MAX, false)
+    /// });
+    ///
+    /// assert!(hit.is_some());
+    /// let (_triangle_index, intersection) = hit.unwrap();
+    /// assert!((intersection.time_of_impact - 2.0).abs() < 1e-5);
+    /// # }
+    /// ```
+    #[cfg(not(all(feature = "simd-is-enabled", feature = "dim3", feature = "f32")))]
+    pub fn cast_ray_best<L: BvhLeafCost>(
+        &self,
+        ray: &Ray,
+        max_time_of_impact: Real,
+        primitive_check: impl Fn(u32, Real) -> Option<L>,
+    ) -> Option<(u32, L)> {
+        self.find_best(
+            max_time_of_impact,
+            |node: &BvhNode, best_so_far| node.cast_ray(ray, best_so_far),
+            primitive_check,
+        )
+    }
+
+    /// Like [`cast_ray`](Self::cast_ray), but returns an arbitrary [`BvhLeafCost`]
+    /// type from the leaf test rather than just [`Real`].
+    ///
+    /// This lets callers collect richer per-hit data (e.g., a `RayIntersection`
+    /// which includes the surface normal) while still benefiting from
+    /// SIMD-accelerated AABB tests on supported platforms.
+    #[cfg(all(feature = "simd-is-enabled", feature = "dim3", feature = "f32"))]
+    pub fn cast_ray_best<L: BvhLeafCost>(
+        &self,
+        ray: &Ray,
+        max_time_of_impact: Real,
+        primitive_check: impl Fn(u32, Real) -> Option<L>,
+    ) -> Option<(u32, L)> {
+        let simd_inv_ray = SimdInvRay::from(*ray);
+        self.find_best(
+            max_time_of_impact,
+            |node: &BvhNode, _best_so_far| node.cast_inv_ray_simd(&simd_inv_ray),
+            primitive_check,
         )
     }
 

--- a/src/query/ray/ray_composite_shape.rs
+++ b/src/query/ray/ray_composite_shape.rs
@@ -1,5 +1,4 @@
 use crate::math::Real;
-use crate::partitioning::BvhNode;
 use crate::query::{Ray, RayCast, RayIntersection};
 use crate::shape::{CompositeShapeRef, Compound, Polyline, TypedCompositeShape};
 
@@ -46,10 +45,9 @@ impl<S: TypedCompositeShape> CompositeShapeRef<'_, S> {
         max_time_of_impact: Real,
         solid: bool,
     ) -> Option<(u32, RayIntersection)> {
-        self.0.bvh().find_best(
-            max_time_of_impact,
-            |node: &BvhNode, best_so_far| node.cast_ray(ray, best_so_far),
-            |primitive, best_so_far| {
+        self.0
+            .bvh()
+            .cast_ray_best(ray, max_time_of_impact, |primitive, best_so_far| {
                 self.0.map_typed_part_at(primitive, |pose, part, _| {
                     if let Some(pose) = pose {
                         part.cast_ray_and_get_normal(pose, ray, best_so_far, solid)
@@ -57,8 +55,7 @@ impl<S: TypedCompositeShape> CompositeShapeRef<'_, S> {
                         part.cast_local_ray_and_get_normal(ray, best_so_far, solid)
                     }
                 })?
-            },
-        )
+            })
     }
 }
 


### PR DESCRIPTION
## Problem

`CompositeShapeRef::cast_local_ray_and_get_normal` calls `bvh().find_best()` directly with `BvhNode::cast_ray` as the AABB cost function. This always uses the non-SIMD ray-AABB test, even on `f32/dim3/simd-is-enabled` builds where `cast_inv_ray_simd` is available.

Meanwhile, the sibling method `cast_local_ray` calls `bvh().cast_ray()` which *does* dispatch to the SIMD path. So `TriMesh::cast_local_ray` gets SIMD but `TriMesh::cast_local_ray_and_get_normal` does not — a surprising inconsistency.

The root cause: `Bvh::cast_ray` returns `Option<(u32, Real)>`, so it can't be used when the caller needs `RayIntersection` (which includes the surface normal). The caller was forced to use `find_best` directly and provide its own (non-SIMD) AABB cost closure.

## Solution

Add `Bvh::cast_ray_best<L: BvhLeafCost>` — identical to `cast_ray` but generic over the return type. Two `#[cfg]`-gated variants provide the same SIMD/non-SIMD dispatch as `cast_ray`:

```rust
// Non-SIMD
pub fn cast_ray_best<L: BvhLeafCost>(
    &self, ray: &Ray, max_time_of_impact: Real,
    primitive_check: impl Fn(u32, Real) -> Option<L>,
) -> Option<(u32, L)>

// SIMD (f32 + dim3 + simd-is-enabled)
pub fn cast_ray_best<L: BvhLeafCost>(
    &self, ray: &Ray, max_time_of_impact: Real,
    primitive_check: impl Fn(u32, Real) -> Option<L>,
) -> Option<(u32, L)>
```

`RayIntersection` already implements `BvhLeafCost` (returns `time_of_impact` as cost), so `cast_local_ray_and_get_normal` can now simply call `bvh().cast_ray_best(...)`.

## Test plan

- [x] `cargo test` — all 520 tests pass across parry2d, parry2d-f64, parry3d, parry3d-f64
- [x] `cargo fmt -- --check`
- [x] `RUSTFLAGS="-D warnings" cargo clippy`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] Doc-test example on `cast_ray_best` with proper feature gate
- [ ] Benchmark comparison (SIMD vs non-SIMD) — would appreciate guidance on parry's benchmarking setup if one exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)