### PR TITLE
fix(gjk): refine ltoi on last-chance fallback instead of early-returning

### DIFF
--- a/crates/parry3d/tests/geometry/mod.rs
+++ b/crates/parry3d/tests/geometry/mod.rs
@@ -4,6 +4,7 @@ mod ball_triangle_toi;
 mod convex_hull;
 mod cuboid_ray_cast;
 mod cylinder_cuboid_contact;
+mod shape_cast_huge_cuboid_toi;
 mod epa3;
 mod still_objects_toi;
 mod time_of_impact3;

--- a/crates/parry3d/tests/geometry/shape_cast_huge_cuboid_toi.rs
+++ b/crates/parry3d/tests/geometry/shape_cast_huge_cuboid_toi.rs
@@ -1,0 +1,113 @@
+//! Regression tests for shape-cast TOI against very large cuboids.
+//!
+//! Before the fix in `minkowski_ray_cast`, sweeping a cylinder straight
+//! down onto a 10 000 × 1 × 10 000 "backstop" cuboid returned ~10× too
+//! small a `time_of_impact`.
+
+use parry3d::math::{Pose, Real, Vector};
+use parry3d::query::{self, ShapeCastOptions};
+use parry3d::shape::{Ball, Cuboid, Cylinder};
+
+fn assert_close(actual: Real, expected: Real, tol: Real, label: &str) {
+    assert!(
+        (actual - expected).abs() <= tol,
+        "{}: got {}, expected {} (tol {})",
+        label,
+        actual,
+        expected,
+        tol,
+    );
+}
+
+fn down_cast_options() -> ShapeCastOptions {
+    ShapeCastOptions {
+        max_time_of_impact: 2.0,
+        target_distance: 0.0,
+        stop_at_penetration: true,
+        compute_impact_geometry_on_penetration: true,
+    }
+}
+
+#[test]
+fn ball_small_cuboid_down_sweep() {
+    let b = Ball::new(0.438_f32);
+    let cub = Cuboid::new(Vector::new(1.0, 0.5, 1.0));
+
+    let hit = query::cast_shapes(
+        &Pose::translation(0.0, 1.281, 0.0),
+        Vector::new(0.0, -1.0, 0.0),
+        &b,
+        &Pose::translation(0.0, -0.6, 0.0),
+        Vector::ZERO,
+        &cub,
+        down_cast_options(),
+    )
+    .unwrap()
+    .expect("should hit");
+
+    assert_close(hit.time_of_impact, 0.943, 1e-3, "ball_small_cuboid TOI");
+}
+
+#[test]
+fn cylinder_small_cuboid_down_sweep() {
+    let cyl = Cylinder::new(0.25_f32, 0.438);
+    let cub = Cuboid::new(Vector::new(1.0, 0.5, 1.0));
+
+    // Bottom cap y = 1.281 - 0.25 = 1.031; cuboid top y = -0.1 → TOI = 1.131.
+    let hit = query::cast_shapes(
+        &Pose::translation(0.0, 1.281, 0.0),
+        Vector::new(0.0, -1.0, 0.0),
+        &cyl,
+        &Pose::translation(0.0, -0.6, 0.0),
+        Vector::ZERO,
+        &cub,
+        down_cast_options(),
+    )
+    .unwrap()
+    .expect("should hit");
+
+    assert_close(hit.time_of_impact, 1.131, 1e-3, "cyl_small_cuboid TOI");
+}
+
+#[test]
+fn ball_huge_cuboid_down_sweep() {
+    let b = Ball::new(0.438_f32);
+    let cub = Cuboid::new(Vector::new(5000.0, 0.5, 5000.0));
+
+    let hit = query::cast_shapes(
+        &Pose::translation(43.0, 1.281, 5.7),
+        Vector::new(0.0, -1.0, 0.0),
+        &b,
+        &Pose::translation(0.0, -0.6, 0.0),
+        Vector::ZERO,
+        &cub,
+        down_cast_options(),
+    )
+    .unwrap()
+    .expect("should hit");
+
+    assert_close(hit.time_of_impact, 0.943, 1e-3, "ball_huge_cuboid TOI");
+}
+
+// Pre-fix: `time_of_impact` ≈ 0.12 instead of ~1.13.
+#[test]
+fn cylinder_huge_cuboid_down_sweep() {
+    let cyl = Cylinder::new(0.25_f32, 0.438);
+    let cub = Cuboid::new(Vector::new(5000.0, 0.5, 5000.0));
+
+    let hit = query::cast_shapes(
+        &Pose::translation(43.0, 1.281, 5.7),
+        Vector::new(0.0, -1.0, 0.0),
+        &cyl,
+        &Pose::translation(0.0, -0.6, 0.0),
+        Vector::ZERO,
+        &cub,
+        down_cast_options(),
+    )
+    .unwrap()
+    .expect("should hit");
+
+    // Loose tolerance: GJK precision is inherently limited on f32 supports
+    // with ±5000 magnitude. The pre-fix result was off by ~10×.
+    assert_close(hit.time_of_impact, 1.131, 5e-3, "cyl_huge_cuboid TOI");
+}

--- a/src/query/gjk/gjk.rs
+++ b/src/query/gjk/gjk.rs
@@ -710,17 +710,14 @@ where
         }
 
         let support_point = if max_bound >= old_max_bound {
-            // Upper bounds inconsistencies. Consider the projection as a valid support point.
+            // Upper-bound inconsistency. Fall back to a virtual support at the
+            // projected origin so the halfspace below can refine `ltoi` one
+            // last time before we give up.
             last_chance = true;
             CsoPoint::single_point(proj + curr_ray.origin)
         } else {
             CsoPoint::from_shapes(pos12, g1, g2, dir)
         };
-
-        if last_chance && ltoi > 0.0 {
-            // last_chance && ltoi > 0.0 && (support_point.point - curr_ray.origin).dot(ldir) >= 0.0 {
-            return Some((ltoi / ray_length, ldir));
-        }
 
         // Clip the ray on the support halfspace (None <=> t < 0)
         // The configurations are:
@@ -732,7 +729,14 @@ where
         //          > 0             |  > 0  | New higher bound.
         match query::details::ray_toi_with_halfspace(support_point.point, dir, &curr_ray) {
             Some(t) => {
-                if dir.dot(curr_ray.dir) < 0.0 && t > 0.0 {
+                // On the `last_chance` virtual support, skip the refine if
+                // `max_bound` is already at the convergence tolerance —
+                // otherwise we'd add precision noise to an `ltoi` that is
+                // already correct.
+                let advance = dir.dot(curr_ray.dir) < 0.0
+                    && t > 0.0
+                    && !(last_chance && max_bound <= _eps_rel * 10.0);
+                if advance {
                     // new lower bound
                     ldir = dir;
                     ltoi += t;
@@ -760,7 +764,11 @@ where
         }
 
         if last_chance {
-            return None;
+            return if ltoi > 0.0 {
+                Some((ltoi / ray_length, ldir))
+            } else {
+                None
+            };
         }
 
         let min_bound = -dir.dot(support_point.point - curr_ray.origin);


### PR DESCRIPTION
## What

`minkowski_ray_cast` (used by `cast_shapes_support_map_support_map`) returns a `time_of_impact` that is up to ~10× too small when sweeping a `Cylinder` against a very large `Cuboid` — e.g. a 10 000 × 1 × 10 000 ground backstop.

## Why

When `max_bound >= old_max_bound` (upper-bound inconsistency), the function used to early-return with the current `ltoi`. If an earlier halfspace update had under-reported `ltoi` due to dot-product cancellation — which is easy to trigger when support points have very large components orthogonal to the cast direction (±5000 here, vs a ~1-unit answer) — the returned value was wrong.

Trace of the pre-fix failure:

```
iter 2: dir ≈ (0.00015, 1.3e-5, 1.0)  support = (5043, 5006, -0.943)
        dir·support = 0.756 + 0.065 - 0.943 = -0.122   (would be -0.943 if dir were pure +Z)
        → halfspace t = 0.119     ← committed to ltoi
iter 4: max_bound plateaus → last_chance fires → early-return with ltoi = 0.119
```

The correct answer for that scenario is ~0.94, as `ball_huge_cuboid_down_sweep` shows — the same ray, ball instead of cylinder, returns the correct TOI.

## Fix

Let the halfspace refine run one last time on the `last_chance` path, using the virtual projected-origin support the branch already constructs. Skip the refine when `max_bound` is already at convergence tolerance so we don't add precision noise to an `ltoi` that is already correct.

## Tests

`crates/parry3d/tests/geometry/shape_cast_huge_cuboid_toi.rs` — ball/cylinder vs small and huge cuboids. The `cylinder_huge_cuboid_down_sweep` case is the pre-fix regression (returned ~0.12 instead of ~1.13).

Full `cargo test --package parry3d` passes (544 tests). Bound on the huge-cuboid cylinder case is loose (5e-3) because GJK precision is inherently limited on ±5000 f32 supports; what matters is the pre-fix ~10× error is gone.

## Found via

A Rapier `DynamicShapeCastVehicleController` sweeping wheels against a ground backstop cuboid — wheel visuals flickered to the hard point because the returned TOI put the wheel above its suspension anchor.