### PR TITLE
Release v0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-## Unreleased
+## 0.26.1
 
 ### Added
 
-- Added `Bvh::traverse_indexed` to traverse only a part of the subtree, and to retrieve the node’s indices.
+- Added `Bvh::traverse_indexed` to traverse only a part of the subtree, and to retrieve the node’s indices ([#416](https://github.com/dimforge/parry/pull/416)).
+
+### Fixed
+
+- Fix `Bvh::optimize_incremental` being non-deterministic when restored from a serialized snapshot. The
+  incremental optimization state is now stored on the `Bvh` itself (instead of the non-serializable
+  `BvhWorkspace`) so it survives serialization/deserialization ([#403](https://github.com/dimforge/parry/pull/403)).
 
 ## 0.26.0
 

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d-f64"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry2d"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "2 dimensional collision detection library in Rust."

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d-f64"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parry3d"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 
 description = "3 dimensional collision detection library in Rust."


### PR DESCRIPTION
## 0.26.1

### Added

- Added `Bvh::traverse_indexed` to traverse only a part of the subtree, and to retrieve the node’s indices ([#416](https://github.com/dimforge/parry/pull/416)).

### Fixed

- Fix `Bvh::optimize_incremental` being non-deterministic when restored from a serialized snapshot. The
  incremental optimization state is now stored on the `Bvh` itself (instead of the non-serializable
  `BvhWorkspace`) so it survives serialization/deserialization ([#403](https://github.com/dimforge/parry/pull/403)).
