### PR TITLE
Bump glamx to 0.2 (glam 0.32)

### DIFF
--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -70,7 +70,7 @@ num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
 simba = { version = "0.9", default-features = false }
-glamx = { version = "0.1.2", default-features = false, features = ["nostd-libm", "approx"] }
+glamx = { version = "0.2", default-features = false, features = ["nostd-libm", "approx"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.2", optional = true }

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -71,7 +71,7 @@ num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
 simba = { version = "0.9", default-features = false }
-glamx = { version = "0.1.2", default-features = false, features = ["nostd-libm", "approx"] }
+glamx = { version = "0.2", default-features = false, features = ["nostd-libm", "approx"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.2", optional = true }

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -70,7 +70,7 @@ num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
 simba = { version = "0.9", default-features = false }
-glamx = { version = "0.1.2", default-features = false, features = ["nostd-libm", "approx"] }
+glamx = { version = "0.2", default-features = false, features = ["nostd-libm", "approx"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 serde_arrays = { version = "0.2", optional = true }

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -72,7 +72,7 @@ num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
 simba = { version = "0.9", default-features = false }
-glamx = { version = "0.1.2", default-features = false, features = ["nostd-libm", "approx"] }
+glamx = { version = "0.2", default-features = false, features = ["nostd-libm", "approx"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 serde_arrays = { version = "0.2", optional = true }


### PR DESCRIPTION
Bumps glamx to 0.2 (glam 0.32) so parry's math types line up with Bevy's, eliminating the boundary conversions Avian (and other Bevy-side consumers) currently need.