### PR TITLE
bugfix: missing bvh.scale() in voxel collider

### DIFF
--- a/src/shape/voxels/voxels.rs
+++ b/src/shape/voxels/voxels.rs
@@ -746,6 +746,7 @@ impl Voxels {
     /// Scale this shape.
     pub fn scaled(mut self, scale: Vector) -> Self {
         self.voxel_size *= scale;
+        self.chunk_bvh.scale(scale);
         self
     }
 


### PR DESCRIPTION
I was getting some weird behavior in Avian3d when I had a voxel collider on an entity with a transform.scale other than 1. Adding this line fixed the problem. `voxel_edition.rs` has the similar function `set_voxel_size` which also calls `self.chunk_bvh.scale(...)`, so it seems like this change is in line with the original intent, and it was probably just an oversight that this line is missing.