### PR TITLE
feat: improve spirv-compatibility + bump dependencies + a few bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## Unreleased
+
+### Breaking changes
+
+- `CompositeShapeRef::project_local_point` and `project_local_point_and_get_feature` now return
+  `Option<...>` instead of unwrapping internally, and take an additional `max_dist` parameter that
+  bounds the search distance.
+
+### Modified
+
+- Bump `glamx` to 0.3 (built on `glam` 0.33), `simba` to 0.10, `rstar` to 0.13, `hashbrown` to 0.17,
+  `rand` to 0.10, and `kiss3d` (visual examples) to 0.42.
+- Many shape, AABB, and voxel internals were reworked to avoid bracket-indexing of `glam` vectors,
+  which is not supported on SPIR-V targets. A new `VectorExt::vget`/`vset` API and a `for_each_dim!`
+  macro are now used in place of `v[i]`. `parry3d`'s `alloc` feature also now gates `smallvec`,
+  `downcast-rs`, `rstar`, and `glamx/approx`, so the no-alloc build can target SPIR-V.
+
+### Fixed
+
+- Fix multiple EPA failures on large coordinate magnitudes by scaling the face-rejection tolerance
+  relative to the simplex vertex magnitudes ([#415](https://github.com/dimforge/parry/issues/415)).
+- Fix CCD edge cases (in both ball-vs-ball and support-map-vs-support-map casts) where casts
+  starting at (or very close to) the contact boundary with a near-tangent direction would return
+  an unreliable normal. The fallback now uses the contact query to recover a robust closest-point
+  normal, and the small-TOI threshold was relaxed from `1e-5` to `1e-4`.
+- Fix `Aabb::cast_local_ray_and_get_normal` panicking with a subtraction overflow when casting a
+  zero-direction ray starting inside the AABB ([#383](https://github.com/dimforge/parry/issues/383)).
+- Fix infinite loop in `TriMesh::intersection_with_local_plane` on degenerate adjacency graphs
+  that don't loop cleanly back to the starting index
+  ([#398](https://github.com/dimforge/parry/issues/398)).
+- Fix panic in `mesh_intersection` when constraint edges overlap (e.g. for co-planar triangles).
+  Overlapping constraints are now skipped instead of crashing the CDT
+  ([#389](https://github.com/dimforge/parry/issues/389)).
+- Fix panic in 3D voxelization's internal convex-hull step by falling back to `try_convex_hull`
+  and returning an empty hull on failure ([#347](https://github.com/dimforge/parry/issues/347)).
+- Fix `WSign::copy_sign_to` on non-CUDA targets by using the native `copysign` (the bit-twiddling
+  workaround is now scoped to `nvptx64`, where `cuda_std`'s `copysign` does not compile).
+
 ## 0.26.1
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,18 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+version = "0.26.1"
+authors = ["Sébastien Crozet <developer@crozet.re>"]
+documentation = "https://parry.rs/docs"
+homepage = "https://parry.rs"
+repository = "https://github.com/dimforge/parry"
+readme = "README.md"
+keywords = ["collision", "geometry", "distance", "ray", "convex"]
+categories = ["science", "game-development", "mathematics", "wasm"]
+license = "Apache-2.0"
+edition = "2021"
+
 [workspace.lints]
 rust.unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(feature, values("dim2", "dim3", "f32", "f64"))',
@@ -21,6 +33,46 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 alloc_instead_of_core = "warn"
 std_instead_of_alloc = "warn"
 std_instead_of_core = "warn"
+
+[workspace.dependencies]
+either = { version = "1", default-features = false }
+bitflags = "2.3"
+downcast-rs = { version = "2", default-features = false, features = ["sync"] }
+num-traits = { version = "0.2", default-features = false }
+slab = "0.4"
+arrayvec = { version = "0.7", default-features = false }
+simba = { version = "0.10", default-features = false }
+glamx = { version = "0.3", default-features = false, features = ["nostd-libm"] }
+approx = { version = "0.5", default-features = false }
+serde = { version = "1.0", features = ["derive"] }
+serde_arrays = "0.2"
+rkyv = { version = "0.8", default-features = false, features = ["bytecheck", "alloc"] }
+num-derive = "0.4"
+indexmap = { version = "2", features = ["serde"] }
+hashbrown = { version = "0.17", default-features = false, features = [
+    "default-hasher",
+] }
+spade = { version = "2.9", default-features = false }
+rayon = "1"
+bytemuck = { version = "1", features = ["derive"] }
+log = "0.4"
+ordered-float = { version = "5", default-features = false }
+thiserror = { version = "2", default-features = false }
+rstar = "0.13.0"
+obj = "0.10.2"
+ena = { version = "0.14.3", default-features = false }
+smallvec = "1"
+static_assertions = "1"
+foldhash = { version = "0.2", default-features = false }
+encase = "0.12"
+
+# dev-dependencies
+oorandom = "11"
+ptree = "0.4.0"
+rand = "0.10"
+kiss3d = "0.42"
+rand_isaac = "0.5"
+web-time = "1"
 
 [patch.crates-io]
 parry2d = { path = "crates/parry2d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
     # "wavefront" is only used for 3D crates.
     'cfg(feature, values("wavefront"))',
     # "encase" is only used in f32 crates.
-    'cfg(feature, values("encase"))'
+    'cfg(feature, values("encase"))',
+    'cfg(target_arch, values("spirv"))',
 ] }
 
 [workspace.lints.clippy]

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -70,7 +70,7 @@ num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
 simba = { version = "0.9", default-features = false }
-glamx = { version = "0.1.2", default-features = false, features = ["nostd-libm", "approx"] }
+glamx = { version = "0.2", default-features = false, features = ["nostd-libm", "approx"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.2", optional = true }

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -69,8 +69,8 @@ downcast-rs = { version = "2", default-features = false, features = ["sync"] }
 num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
-simba = { version = "0.9", default-features = false }
-glamx = { version = "0.2", default-features = false, features = ["nostd-libm", "approx"] }
+simba = { version = "0.10", default-features = false }
+glamx = { version = "0.3", default-features = false, features = ["nostd-libm", "approx", "f64", "i64"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.2", optional = true }
@@ -91,7 +91,7 @@ smallvec = "1"
 foldhash = { version = "0.2", default-features = false }
 
 [dev-dependencies]
-simba = { version = "0.9", default-features = false }
+simba = { version = "0.10", default-features = false }
 oorandom = "11"
 ptree = "0.4.0"
-rand = { version = "0.9" }
+rand = { version = "0.10" }

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -77,7 +77,7 @@ serde_arrays = { version = "0.2", optional = true }
 rkyv = { version = "0.8", optional = true, default-features = false, features = ["bytecheck", "alloc"] }
 num-derive = "0.4"
 indexmap = { version = "2", features = ["serde"], optional = true }
-hashbrown = { version = "0.16", optional = true, default-features = false, features = [
+hashbrown = { version = "0.17", optional = true, default-features = false, features = [
     "default-hasher",
 ] }
 spade = { version = "2", optional = true, default-features = false }

--- a/crates/parry2d-f64/Cargo.toml
+++ b/crates/parry2d-f64/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
 name = "parry2d-f64"
-version = "0.26.1"
-authors = ["Sébastien Crozet <developer@crozet.re>"]
-
+version.workspace = true
+authors.workspace = true
 description = "2 dimensional collision detection library in Rust. 64-bit precision version."
-documentation = "https://parry.rs/docs"
-homepage = "https://parry.rs"
-repository = "https://github.com/dimforge/parry"
-readme = "README.md"
-keywords = ["collision", "geometry", "distance", "ray", "convex"]
-categories = ["science", "game-development", "mathematics", "wasm"]
-license = "Apache-2.0"
-edition = "2021"
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -63,35 +62,33 @@ path = "../../src/lib.rs"
 required-features = ["required-features"]
 
 [dependencies]
-either = { version = "1", default-features = false }
-bitflags = "2.3"
-downcast-rs = { version = "2", default-features = false, features = ["sync"] }
-num-traits = { version = "0.2", default-features = false }
-slab = { version = "0.4", optional = true }
-arrayvec = { version = "0.7", default-features = false }
-simba = { version = "0.10", default-features = false }
-glamx = { version = "0.3", default-features = false, features = ["nostd-libm", "approx", "f64", "i64"] }
-approx = { version = "0.5", default-features = false }
-serde = { version = "1.0", optional = true, features = ["derive"] }
-serde_arrays = { version = "0.2", optional = true }
-rkyv = { version = "0.8", optional = true, default-features = false, features = ["bytecheck", "alloc"] }
-num-derive = "0.4"
-indexmap = { version = "2", features = ["serde"], optional = true }
-hashbrown = { version = "0.17", optional = true, default-features = false, features = [
-    "default-hasher",
-] }
-spade = { version = "2", optional = true, default-features = false }
-rayon = { version = "1", optional = true }
-bytemuck = { version = "1", features = ["derive"], optional = true }
-log = "0.4"
-ordered-float = { version = "5", default-features = false }
-thiserror = { version = "2", default-features = false }
-ena = { version = "0.14.3", optional = true, default-features = false }
-smallvec = "1"
-foldhash = { version = "0.2", default-features = false }
+either = { workspace = true }
+bitflags = { workspace = true }
+downcast-rs = { workspace = true }
+num-traits = { workspace = true }
+slab = { workspace = true, optional = true }
+arrayvec = { workspace = true }
+simba = { workspace = true }
+glamx = { workspace = true, features = ["approx", "f64", "i64"] }
+approx = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_arrays = { workspace = true, optional = true }
+rkyv = { workspace = true, optional = true }
+num-derive = { workspace = true }
+indexmap = { workspace = true, optional = true }
+hashbrown = { workspace = true, optional = true }
+spade = { workspace = true, optional = true }
+rayon = { workspace = true, optional = true }
+bytemuck = { workspace = true, optional = true }
+log = { workspace = true }
+ordered-float = { workspace = true }
+thiserror = { workspace = true }
+ena = { workspace = true, optional = true }
+smallvec = { workspace = true }
+foldhash = { workspace = true }
 
 [dev-dependencies]
-simba = { version = "0.10", default-features = false }
-oorandom = "11"
-ptree = "0.4.0"
-rand = { version = "0.10" }
+simba = { workspace = true }
+oorandom = { workspace = true }
+ptree = { workspace = true }
+rand = { workspace = true }

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -97,7 +97,7 @@ simba = { version = "0.9", default-features = false }
 oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.9" }
-kiss3d = "0.39"
+kiss3d = "0.41"
 web-time = "1"
 
 [package.metadata.docs.rs]

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -49,7 +49,7 @@ simd-stable = ["simba/wide", "simd-is-enabled"]
 simd-nightly = ["simba/portable_simd", "simd-is-enabled"]
 enhanced-determinism = ["simba/libm_force", "indexmap", "glamx/libm"]
 parallel = ["rayon"]
-alloc = ["hashbrown"]
+alloc = ["hashbrown", "smallvec", "downcast-rs", "glamx/approx"]
 spade = ["dep:spade", "alloc"]
 improved_fixed_point_support = []
 encase = [ "dep:encase", "glamx/encase" ]
@@ -66,12 +66,12 @@ required-features = ["required-features"]
 [dependencies]
 either = { version = "1", default-features = false }
 bitflags = "2.3"
-downcast-rs = { version = "2", default-features = false, features = ["sync"] }
+downcast-rs = { version = "2", default-features = false, features = ["sync"], optional = true }
 num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
 simba = { version = "0.9", default-features = false }
-glamx = { version = "0.1.2", default-features = false, features = ["nostd-libm", "approx"] }
+glamx = { version = "0.1.2", default-features = false, features = ["nostd-libm"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.2", optional = true }
@@ -88,7 +88,7 @@ ordered-float = { version = "5", default-features = false }
 log = "0.4"
 thiserror = { version = "2", default-features = false }
 ena = { version = "0.14.3", optional = true, default-features = false }
-smallvec = "1"
+smallvec = { version = "1", optional = true }
 foldhash = { version = "0.2", default-features = false }
 encase = { version = "0.12", optional = true }
 

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -78,7 +78,7 @@ serde_arrays = { version = "0.2", optional = true }
 rkyv = { version = "0.8", optional = true, default-features = false, features = ["bytecheck", "alloc"] }
 num-derive = "0.4"
 indexmap = { version = "2", features = ["serde"], optional = true }
-hashbrown = { version = "0.16", optional = true, default-features = false, features = [
+hashbrown = { version = "0.17", optional = true, default-features = false, features = [
     "default-hasher",
 ] }
 spade = { version = "2", optional = true, default-features = false }

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -71,7 +71,7 @@ num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
 simba = { version = "0.9", default-features = false }
-glamx = { version = "0.1.2", default-features = false, features = ["nostd-libm"] }
+glamx = { version = "0.2", default-features = false, features = ["nostd-libm"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.2", optional = true }

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -70,8 +70,8 @@ downcast-rs = { version = "2", default-features = false, features = ["sync"], op
 num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
-simba = { version = "0.9", default-features = false }
-glamx = { version = "0.2", default-features = false, features = ["nostd-libm"] }
+simba = { version = "0.10", default-features = false }
+glamx = { version = "0.3", default-features = false, features = ["nostd-libm", "i32"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.2", optional = true }
@@ -93,11 +93,11 @@ foldhash = { version = "0.2", default-features = false }
 encase = { version = "0.12", optional = true }
 
 [dev-dependencies]
-simba = { version = "0.9", default-features = false }
+simba = { version = "0.10", default-features = false }
 oorandom = "11"
 ptree = "0.4.0"
-rand = { version = "0.9" }
-kiss3d = "0.41"
+rand = { version = "0.10" }
+kiss3d = "0.42"
 web-time = "1"
 
 [package.metadata.docs.rs]

--- a/crates/parry2d/Cargo.toml
+++ b/crates/parry2d/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
 name = "parry2d"
-version = "0.26.1"
-authors = ["Sébastien Crozet <developer@crozet.re>"]
-
+version.workspace = true
+authors.workspace = true
 description = "2 dimensional collision detection library in Rust."
-documentation = "https://parry.rs/docs"
-homepage = "https://parry.rs"
-repository = "https://github.com/dimforge/parry"
-readme = "README.md"
-keywords = ["collision", "geometry", "distance", "ray", "convex"]
-categories = ["science", "game-development", "mathematics", "wasm"]
-license = "Apache-2.0"
-edition = "2021"
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -64,41 +63,39 @@ path = "../../src/lib.rs"
 required-features = ["required-features"]
 
 [dependencies]
-either = { version = "1", default-features = false }
-bitflags = "2.3"
-downcast-rs = { version = "2", default-features = false, features = ["sync"], optional = true }
-num-traits = { version = "0.2", default-features = false }
-slab = { version = "0.4", optional = true }
-arrayvec = { version = "0.7", default-features = false }
-simba = { version = "0.10", default-features = false }
-glamx = { version = "0.3", default-features = false, features = ["nostd-libm", "i32"] }
-approx = { version = "0.5", default-features = false }
-serde = { version = "1.0", optional = true, features = ["derive"] }
-serde_arrays = { version = "0.2", optional = true }
-rkyv = { version = "0.8", optional = true, default-features = false, features = ["bytecheck", "alloc"] }
-num-derive = "0.4"
-indexmap = { version = "2", features = ["serde"], optional = true }
-hashbrown = { version = "0.17", optional = true, default-features = false, features = [
-    "default-hasher",
-] }
-spade = { version = "2", optional = true, default-features = false }
-rayon = { version = "1", optional = true }
-bytemuck = { version = "1", features = ["derive"], optional = true }
-ordered-float = { version = "5", default-features = false }
-log = "0.4"
-thiserror = { version = "2", default-features = false }
-ena = { version = "0.14.3", optional = true, default-features = false }
-smallvec = { version = "1", optional = true }
-foldhash = { version = "0.2", default-features = false }
-encase = { version = "0.12", optional = true }
+either = { workspace = true }
+bitflags = { workspace = true }
+downcast-rs = { workspace = true, optional = true }
+num-traits = { workspace = true }
+slab = { workspace = true, optional = true }
+arrayvec = { workspace = true }
+simba = { workspace = true }
+glamx = { workspace = true, features = ["i32"] }
+approx = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_arrays = { workspace = true, optional = true }
+rkyv = { workspace = true, optional = true }
+num-derive = { workspace = true }
+indexmap = { workspace = true, optional = true }
+hashbrown = { workspace = true, optional = true }
+spade = { workspace = true, optional = true }
+rayon = { workspace = true, optional = true }
+bytemuck = { workspace = true, optional = true }
+ordered-float = { workspace = true }
+log = { workspace = true }
+thiserror = { workspace = true }
+ena = { workspace = true, optional = true }
+smallvec = { workspace = true, optional = true }
+foldhash = { workspace = true }
+encase = { workspace = true, optional = true }
 
 [dev-dependencies]
-simba = { version = "0.10", default-features = false }
-oorandom = "11"
-ptree = "0.4.0"
-rand = { version = "0.10" }
-kiss3d = "0.42"
-web-time = "1"
+simba = { workspace = true }
+oorandom = { workspace = true }
+ptree = { workspace = true }
+rand = { workspace = true }
+kiss3d = { workspace = true }
+web-time = { workspace = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -77,14 +77,14 @@ serde_arrays = { version = "0.2", optional = true }
 rkyv = { version = "0.8", optional = true, default-features = false, features = ["bytecheck", "alloc"] }
 num-derive = "0.4"
 indexmap = { version = "2", features = ["serde"], optional = true }
-hashbrown = { version = "0.16", optional = true, default-features = false, features = [
+hashbrown = { version = "0.17", optional = true, default-features = false, features = [
     "default-hasher",
 ] }
 foldhash = { version = "0.2", default-features = false }
 spade = { version = "2.9", optional = true, default-features = false }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
-rstar = "0.12.0"
+rstar = "0.13.0"
 obj = { version = "0.10.2", optional = true }
 ena = { version = "0.14.3", optional = true, default-features = false }
 smallvec = "1"

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -70,7 +70,7 @@ num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
 simba = { version = "0.9", default-features = false }
-glamx = { version = "0.1.2", default-features = false, features = ["nostd-libm", "approx"] }
+glamx = { version = "0.2", default-features = false, features = ["nostd-libm", "approx"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 serde_arrays = { version = "0.2", optional = true }

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -69,8 +69,8 @@ downcast-rs = { version = "2", default-features = false, features = ["sync"] }
 num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
-simba = { version = "0.9", default-features = false }
-glamx = { version = "0.2", default-features = false, features = ["nostd-libm", "approx"] }
+simba = { version = "0.10", default-features = false }
+glamx = { version = "0.3", default-features = false, features = ["nostd-libm", "approx", "f64"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 serde_arrays = { version = "0.2", optional = true }
@@ -96,7 +96,7 @@ thiserror = { version = "2", default-features = false }
 [dev-dependencies]
 oorandom = "11"
 ptree = "0.4.0"
-rand = { version = "0.9" }
+rand = { version = "0.10" }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
 name = "parry3d-f64"
-version = "0.26.1"
-authors = ["Sébastien Crozet <developer@crozet.re>"]
-
+version.workspace = true
+authors.workspace = true
 description = "3 dimensional collision detection library in Rust. 64-bits precision version."
-documentation = "https://parry.rs/docs"
-homepage = "https://parry.rs"
-repository = "https://github.com/dimforge/parry"
-readme = "README.md"
-keywords = ["collision", "geometry", "distance", "ray", "convex"]
-categories = ["science", "game-development", "mathematics", "wasm"]
-license = "Apache-2.0"
-edition = "2021"
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -63,40 +62,38 @@ path = "../../src/lib.rs"
 required-features = ["required-features"]
 
 [dependencies]
-either = { version = "1", default-features = false }
-bitflags = "2.3"
-downcast-rs = { version = "2", default-features = false, features = ["sync"] }
-num-traits = { version = "0.2", default-features = false }
-slab = { version = "0.4", optional = true }
-arrayvec = { version = "0.7", default-features = false }
-simba = { version = "0.10", default-features = false }
-glamx = { version = "0.3", default-features = false, features = ["nostd-libm", "approx", "f64"] }
-approx = { version = "0.5", default-features = false }
-serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
-serde_arrays = { version = "0.2", optional = true }
-rkyv = { version = "0.8", optional = true, default-features = false, features = ["bytecheck", "alloc"] }
-num-derive = "0.4"
-indexmap = { version = "2", features = ["serde"], optional = true }
-hashbrown = { version = "0.17", optional = true, default-features = false, features = [
-    "default-hasher",
-] }
-foldhash = { version = "0.2", default-features = false }
-spade = { version = "2.9", optional = true, default-features = false }
-rayon = { version = "1", optional = true }
-bytemuck = { version = "1", features = ["derive"], optional = true }
-rstar = "0.13.0"
-obj = { version = "0.10.2", optional = true }
-ena = { version = "0.14.3", optional = true, default-features = false }
-smallvec = "1"
+either = { workspace = true }
+bitflags = { workspace = true }
+downcast-rs = { workspace = true }
+num-traits = { workspace = true }
+slab = { workspace = true, optional = true }
+arrayvec = { workspace = true }
+simba = { workspace = true }
+glamx = { workspace = true, features = ["approx", "f64"] }
+approx = { workspace = true }
+serde = { workspace = true, optional = true, features = ["rc"] }
+serde_arrays = { workspace = true, optional = true }
+rkyv = { workspace = true, optional = true }
+num-derive = { workspace = true }
+indexmap = { workspace = true, optional = true }
+hashbrown = { workspace = true, optional = true }
+foldhash = { workspace = true }
+spade = { workspace = true, optional = true }
+rayon = { workspace = true, optional = true }
+bytemuck = { workspace = true, optional = true }
+rstar = { workspace = true }
+obj = { workspace = true, optional = true }
+ena = { workspace = true, optional = true }
+smallvec = { workspace = true }
 
-log = "0.4"
-ordered-float = { version = "5", default-features = false }
-thiserror = { version = "2", default-features = false }
+log = { workspace = true }
+ordered-float = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-oorandom = "11"
-ptree = "0.4.0"
-rand = { version = "0.10" }
+oorandom = { workspace = true }
+ptree = { workspace = true }
+rand = { workspace = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -79,7 +79,7 @@ serde_arrays = { version = "0.2", optional = true }
 rkyv = { version = "0.8", optional = true, default-features = false, features = ["bytecheck", "alloc"] }
 num-derive = "0.4"
 indexmap = { version = "2", features = ["serde"], optional = true }
-hashbrown = { version = "0.16", optional = true, default-features = false, features = [
+hashbrown = { version = "0.17", optional = true, default-features = false, features = [
     "default-hasher",
 ] }
 spade = { version = "2.9", optional = true, default-features = false }
@@ -88,7 +88,7 @@ bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
 ordered-float = { version = "5", default-features = false }
 thiserror = { version = "2", default-features = false }
-rstar = { version = "0.12.0", optional = true }
+rstar = { version = "0.13.0", optional = true }
 obj = { version = "0.10.2", optional = true }
 ena = { version = "0.14.3", optional = true, default-features = false }
 smallvec = { version = "1", optional = true }

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -50,7 +50,7 @@ enhanced-determinism = ["simba/libm_force", "indexmap", "glamx/libm"]
 parallel = ["rayon"]
 # Adds `TriMesh:to_obj_file` function.
 wavefront = ["obj"]
-alloc = ["hashbrown"]
+alloc = ["hashbrown", "smallvec", "downcast-rs", "rstar", "glamx/approx"]
 spade = ["dep:spade", "alloc"]
 improved_fixed_point_support = []
 encase = [ "dep:encase", "glamx/encase" ]
@@ -67,12 +67,12 @@ required-features = ["required-features"]
 [dependencies]
 either = { version = "1", default-features = false }
 bitflags = "2.3"
-downcast-rs = { version = "2", default-features = false, features = ["sync"] }
+downcast-rs = { version = "2", default-features = false, features = ["sync"], optional = true }
 num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
 simba = { version = "0.9", default-features = false }
-glamx = { version = "0.1.2", default-features = false, features = ["nostd-libm", "approx"] }
+glamx = { version = "0.1.2", default-features = false, features = ["nostd-libm"] } # , "approx"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 serde_arrays = { version = "0.2", optional = true }
@@ -88,10 +88,10 @@ bytemuck = { version = "1", features = ["derive"], optional = true }
 log = "0.4"
 ordered-float = { version = "5", default-features = false }
 thiserror = { version = "2", default-features = false }
-rstar = "0.12.0"
+rstar = { version = "0.12.0", optional = true }
 obj = { version = "0.10.2", optional = true }
 ena = { version = "0.14.3", optional = true, default-features = false }
-smallvec = "1"
+smallvec = { version = "1", optional = true }
 static_assertions = "1"
 foldhash = { version = "0.2", default-features = false }
 encase = { version = "0.12", optional = true }

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -71,8 +71,8 @@ downcast-rs = { version = "2", default-features = false, features = ["sync"], op
 num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
-simba = { version = "0.9", default-features = false }
-glamx = { version = "0.2", default-features = false, features = ["nostd-libm"] } # , "approx"] }
+simba = { version = "0.10", default-features = false }
+glamx = { version = "0.3", default-features = false, features = ["nostd-libm", "i32"] } # , "approx"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 serde_arrays = { version = "0.2", optional = true }
@@ -99,9 +99,9 @@ encase = { version = "0.12", optional = true }
 [dev-dependencies]
 oorandom = "11"
 ptree = "0.4.0"
-rand = { version = "0.9" }
-kiss3d = "0.41"
-rand_isaac = "0.4"
+rand = { version = "0.10" }
+kiss3d = "0.42"
+rand_isaac = "0.5"
 web-time = "1"
 
 [package.metadata.docs.rs]

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -96,7 +96,6 @@ static_assertions = "1"
 foldhash = { version = "0.2", default-features = false }
 encase = { version = "0.12", optional = true }
 
-
 [dev-dependencies]
 oorandom = "11"
 ptree = "0.4.0"

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -100,7 +100,7 @@ encase = { version = "0.12", optional = true }
 oorandom = "11"
 ptree = "0.4.0"
 rand = { version = "0.9" }
-kiss3d = "0.39"
+kiss3d = "0.41"
 rand_isaac = "0.4"
 web-time = "1"
 

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
 name = "parry3d"
-version = "0.26.1"
-authors = ["Sébastien Crozet <developer@crozet.re>"]
-
+version.workspace = true
+authors.workspace = true
 description = "3 dimensional collision detection library in Rust."
-documentation = "https://parry.rs/docs"
-homepage = "https://parry.rs"
-repository = "https://github.com/dimforge/parry"
-readme = "README.md"
-keywords = ["collision", "geometry", "distance", "ray", "convex"]
-categories = ["science", "game-development", "mathematics", "wasm"]
-license = "Apache-2.0"
-edition = "2021"
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -65,44 +64,42 @@ path = "../../src/lib.rs"
 required-features = ["required-features"]
 
 [dependencies]
-either = { version = "1", default-features = false }
-bitflags = "2.3"
-downcast-rs = { version = "2", default-features = false, features = ["sync"], optional = true }
-num-traits = { version = "0.2", default-features = false }
-slab = { version = "0.4", optional = true }
-arrayvec = { version = "0.7", default-features = false }
-simba = { version = "0.10", default-features = false }
-glamx = { version = "0.3", default-features = false, features = ["nostd-libm", "i32"] } # , "approx"] }
-approx = { version = "0.5", default-features = false }
-serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
-serde_arrays = { version = "0.2", optional = true }
-rkyv = { version = "0.8", optional = true, default-features = false, features = ["bytecheck", "alloc"] }
-num-derive = "0.4"
-indexmap = { version = "2", features = ["serde"], optional = true }
-hashbrown = { version = "0.17", optional = true, default-features = false, features = [
-    "default-hasher",
-] }
-spade = { version = "2.9", optional = true, default-features = false }
-rayon = { version = "1", optional = true }
-bytemuck = { version = "1", features = ["derive"], optional = true }
-log = "0.4"
-ordered-float = { version = "5", default-features = false }
-thiserror = { version = "2", default-features = false }
-rstar = { version = "0.13.0", optional = true }
-obj = { version = "0.10.2", optional = true }
-ena = { version = "0.14.3", optional = true, default-features = false }
-smallvec = { version = "1", optional = true }
-static_assertions = "1"
-foldhash = { version = "0.2", default-features = false }
-encase = { version = "0.12", optional = true }
+either = { workspace = true }
+bitflags = { workspace = true }
+downcast-rs = { workspace = true, optional = true }
+num-traits = { workspace = true }
+slab = { workspace = true, optional = true }
+arrayvec = { workspace = true }
+simba = { workspace = true }
+glamx = { workspace = true, features = ["i32"] } # , "approx"] }
+approx = { workspace = true }
+serde = { workspace = true, optional = true, features = ["rc"] }
+serde_arrays = { workspace = true, optional = true }
+rkyv = { workspace = true, optional = true }
+num-derive = { workspace = true }
+indexmap = { workspace = true, optional = true }
+hashbrown = { workspace = true, optional = true }
+spade = { workspace = true, optional = true }
+rayon = { workspace = true, optional = true }
+bytemuck = { workspace = true, optional = true }
+log = { workspace = true }
+ordered-float = { workspace = true }
+thiserror = { workspace = true }
+rstar = { workspace = true, optional = true }
+obj = { workspace = true, optional = true }
+ena = { workspace = true, optional = true }
+smallvec = { workspace = true, optional = true }
+static_assertions = { workspace = true }
+foldhash = { workspace = true }
+encase = { workspace = true, optional = true }
 
 [dev-dependencies]
-oorandom = "11"
-ptree = "0.4.0"
-rand = { version = "0.10" }
-kiss3d = "0.42"
-rand_isaac = "0.5"
-web-time = "1"
+oorandom = { workspace = true }
+ptree = { workspace = true }
+rand = { workspace = true }
+kiss3d = { workspace = true }
+rand_isaac = { workspace = true }
+web-time = { workspace = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -72,7 +72,7 @@ num-traits = { version = "0.2", default-features = false }
 slab = { version = "0.4", optional = true }
 arrayvec = { version = "0.7", default-features = false }
 simba = { version = "0.9", default-features = false }
-glamx = { version = "0.1.2", default-features = false, features = ["nostd-libm"] } # , "approx"] }
+glamx = { version = "0.2", default-features = false, features = ["nostd-libm"] } # , "approx"] }
 approx = { version = "0.5", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 serde_arrays = { version = "0.2", optional = true }

--- a/crates/parry3d/benches/common/default_gen.rs
+++ b/crates/parry3d/benches/common/default_gen.rs
@@ -3,7 +3,7 @@ use parry3d::math::{Pose3, Real, Rot3, Vec3, Vector};
 use parry3d::query::Ray;
 use parry3d::shape::ConvexPolyhedron;
 use parry3d::shape::{Ball, Capsule, Cone, Cuboid, Cylinder, Segment, Triangle};
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 pub trait DefaultGen {
     fn generate<R: Rng>(rng: &mut R) -> Self;

--- a/crates/parry3d/benches/common/generators.rs
+++ b/crates/parry3d/benches/common/generators.rs
@@ -1,6 +1,6 @@
 use parry3d::math::Vec3;
 use parry3d::shape::TriMesh;
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 pub fn generate_trimesh_around_origin<R: Rng>(rng: &mut R) -> TriMesh {
     let pts = (0..3000)

--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -1,7 +1,7 @@
 //! Axis Aligned Bounding Box.
 
 use crate::bounding_volume::{BoundingSphere, BoundingVolume};
-use crate::math::{Pose, Real, Vector, DIM, TWO_DIM};
+use crate::math::{Pose, Real, Vector, VectorExt, DIM, TWO_DIM};
 use crate::shape::{Cuboid, SupportMap};
 use crate::utils::PoseOps;
 use arrayvec::ArrayVec;
@@ -536,7 +536,7 @@ impl Aabb {
     #[inline]
     pub fn contains_local_point(&self, point: Vector) -> bool {
         for i in 0..DIM {
-            if point[i] < self.mins[i] || point[i] > self.maxs[i] {
+            if point.vget(i) < self.mins.vget(i) || point.vget(i) > self.maxs.vget(i) {
                 return false;
             }
         }
@@ -570,7 +570,7 @@ impl Aabb {
         };
 
         for i in 0..DIM {
-            if result.mins[i] > result.maxs[i] {
+            if result.mins.vget(i) > result.maxs.vget(i) {
                 return None;
             }
         }
@@ -636,7 +636,7 @@ impl Aabb {
         //       This isn’t exactly the same as `!self.intersects(rhs)`
         //       because of the equality.
         for i in 0..DIM {
-            if self.mins[i] >= rhs.maxs[i] || self.maxs[i] <= rhs.mins[i] {
+            if self.mins.vget(i) >= rhs.maxs.vget(i) || self.maxs.vget(i) <= rhs.mins.vget(i) {
                 result.push(*self);
                 return (result, cut_sequence);
             }
@@ -645,20 +645,20 @@ impl Aabb {
         let mut rest = *self;
 
         for i in 0..DIM {
-            if rhs.mins[i] > rest.mins[i] {
+            if rhs.mins.vget(i) > rest.mins.vget(i) {
                 let mut fragment = rest;
-                fragment.maxs[i] = rhs.mins[i];
-                rest.mins[i] = rhs.mins[i];
+                fragment.maxs.vset(i, rhs.mins.vget(i));
+                rest.mins.vset(i, rhs.mins.vget(i));
                 result.push(fragment);
-                cut_sequence.push((i as i8 + 1, rhs.mins[i]));
+                cut_sequence.push((i as i8 + 1, rhs.mins.vget(i)));
             }
 
-            if rhs.maxs[i] < rest.maxs[i] {
+            if rhs.maxs.vget(i) < rest.maxs.vget(i) {
                 let mut fragment = rest;
-                fragment.mins[i] = rhs.maxs[i];
-                rest.maxs[i] = rhs.maxs[i];
+                fragment.mins.vset(i, rhs.maxs.vget(i));
+                rest.maxs.vset(i, rhs.maxs.vget(i));
                 result.push(fragment);
-                cut_sequence.push((-(i as i8 + 1), -rhs.maxs[i]));
+                cut_sequence.push((-(i as i8 + 1), -rhs.maxs.vget(i)));
             }
         }
 
@@ -919,12 +919,12 @@ impl Aabb {
         let mut candidates = vec![];
 
         let planes = [
-            (-self.mins[0], -Vector::X, 0),
-            (self.maxs[0], Vector::X, 0),
-            (-self.mins[1], -Vector::Y, 1),
-            (self.maxs[1], Vector::Y, 1),
-            (-self.mins[2], -Vector::Z, 2),
-            (self.maxs[2], Vector::Z, 2),
+            (-self.mins.x, -Vector::X, 0),
+            (self.maxs.x, Vector::X, 0),
+            (-self.mins.y, -Vector::Y, 1),
+            (self.maxs.y, Vector::Y, 1),
+            (-self.mins.z, -Vector::Z, 2),
+            (self.maxs.z, Vector::Z, 2),
         ];
 
         let range = self.project_on_axis(axis);
@@ -948,10 +948,10 @@ impl Aabb {
             for root in roots.drain(..) {
                 let point = distance_fn.spiral_pt_at(root.midpoint());
                 let (j, k) = ((i + 1) % 3, (i + 2) % 3);
-                if point[j] >= self.mins[j]
-                    && point[j] <= self.maxs[j]
-                    && point[k] >= self.mins[k]
-                    && point[k] <= self.maxs[k]
+                if point.vget(j) >= self.mins.vget(j)
+                    && point.vget(j) <= self.maxs.vget(j)
+                    && point.vget(k) >= self.mins.vget(k)
+                    && point.vget(k) <= self.maxs.vget(k)
                 {
                     return true;
                 }

--- a/src/bounding_volume/aabb_triangle.rs
+++ b/src/bounding_volume/aabb_triangle.rs
@@ -1,6 +1,6 @@
 use crate::{
     bounding_volume::Aabb,
-    math::{Pose, Vector, DIM},
+    math::{Pose, Vector},
     shape::Triangle,
 };
 
@@ -21,9 +21,9 @@ impl Triangle {
         let mut min = Vector::ZERO;
         let mut max = Vector::ZERO;
 
-        for d in 0..DIM {
-            min[d] = a[d].min(b[d]).min(c[d]);
-            max[d] = a[d].max(b[d]).max(c[d]);
+        for_each_dim! {
+            min[ii] = a[ii].min(b[ii]).min(c[ii]);
+            max[ii] = a[ii].max(b[ii]).max(c[ii]);
         }
 
         Aabb::new(min, max)

--- a/src/bounding_volume/aabb_utils.rs
+++ b/src/bounding_volume/aabb_utils.rs
@@ -1,8 +1,8 @@
 use core::iter::IntoIterator;
 
 use crate::bounding_volume::Aabb;
-use crate::math::{Pose, Vector, DIM};
 use crate::math::VectorExt;
+use crate::math::{Pose, Vector, DIM};
 use crate::shape::SupportMap;
 
 /// Computes the [`Aabb`] of an [support mapped shape](SupportMap).

--- a/src/bounding_volume/aabb_utils.rs
+++ b/src/bounding_volume/aabb_utils.rs
@@ -2,6 +2,7 @@ use core::iter::IntoIterator;
 
 use crate::bounding_volume::Aabb;
 use crate::math::{Pose, Vector, DIM};
+use crate::math::VectorExt;
 use crate::shape::SupportMap;
 
 /// Computes the [`Aabb`] of an [support mapped shape](SupportMap).
@@ -17,13 +18,13 @@ where
     for d in 0..DIM {
         // TODO: this could be further improved iterating on `m`'s columns, and passing
         // Id as the transformation matrix.
-        basis[d] = 1.0;
-        max[d] = i.support_point(m, basis)[d];
+        basis.vset(d, 1.0);
+        max.vset(d, i.support_point(m, basis).vget(d));
 
-        basis[d] = -1.0;
-        min[d] = i.support_point(m, basis)[d];
+        basis.vset(d, -1.0);
+        min.vset(d, i.support_point(m, basis).vget(d));
 
-        basis[d] = 0.0;
+        basis.vset(d, 0.0);
     }
 
     Aabb::new(min, max)
@@ -41,13 +42,13 @@ where
     for d in 0..DIM {
         // TODO: this could be further improved iterating on `m`'s columns, and passing
         // Id as the transformation matrix.
-        basis[d] = 1.0;
-        max[d] = i.local_support_point(basis)[d];
+        basis.vset(d, 1.0);
+        max.vset(d, i.local_support_point(basis).vget(d));
 
-        basis[d] = -1.0;
-        min[d] = i.local_support_point(basis)[d];
+        basis.vset(d, -1.0);
+        min.vset(d, i.local_support_point(basis).vget(d));
 
-        basis[d] = 0.0;
+        basis.vset(d, 0.0);
     }
 
     Aabb::new(min, max)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,9 @@ pub extern crate either;
 pub extern crate glamx;
 pub extern crate simba;
 
+#[macro_use]
+mod macros;
+
 pub mod bounding_volume;
 pub mod mass_properties;
 pub mod math;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,94 @@
+/// Inner implementation of [`for_each_dim!`]. A tt-muncher that replaces every
+/// occurrence of the sentinel `[ii]` in the token stream with `.$f` (i.e. `.x`,
+/// `.y`, or `.z`) for the current dimension.
+#[doc(hidden)]
+macro_rules! for_each_dim_inner {
+    // Base case: no more input tokens, emit accumulated output.
+    ($f:ident [$($out:tt)*]) => { $($out)* };
+
+    // Match the [ii] sentinel and replace with .field_name.
+    ($f:ident [$($out:tt)*] [ii] $($rest:tt)*) => {
+        for_each_dim_inner!($f [$($out)* . $f] $($rest)*)
+    };
+
+    // Recurse into `{ }` delimited groups.
+    ($f:ident [$($out:tt)*] { $($inner:tt)* } $($rest:tt)*) => {
+        for_each_dim_inner!($f [$($out)* { for_each_dim_inner!($f [] $($inner)*) }] $($rest)*)
+    };
+
+    // Recurse into `( )` delimited groups.
+    ($f:ident [$($out:tt)*] ( $($inner:tt)* ) $($rest:tt)*) => {
+        for_each_dim_inner!($f [$($out)* ( for_each_dim_inner!($f [] $($inner)*) )] $($rest)*)
+    };
+
+    // Recurse into `[ ]` delimited groups (general case, NOT [ii]).
+    ($f:ident [$($out:tt)*] [ $($inner:tt)* ] $($rest:tt)*) => {
+        for_each_dim_inner!($f [$($out)* [ for_each_dim_inner!($f [] $($inner)*) ]] $($rest)*)
+    };
+
+    // Pass through any other token unchanged.
+    ($f:ident [$($out:tt)*] $other:tt $($rest:tt)*) => {
+        for_each_dim_inner!($f [$($out)* $other] $($rest)*)
+    };
+}
+
+/// Unrolls a loop over spatial dimensions (2 or 3 depending on features),
+/// replacing occurrences of the sentinel `[ii]` with direct field access
+/// (`.x`, `.y`, `.z`) on glam vectors. This avoids bracket indexing which
+/// is not supported on SPIR-V targets.
+///
+/// # Usage
+///
+/// Basic form — every `[ii]` in the body is replaced with `.x`, `.y`, `.z`
+/// in successive unrolled iterations:
+/// ```ignore
+/// for_each_dim! {
+///     min[ii] = a[ii].min(b[ii]);
+/// }
+/// // Expands to:
+/// //   min.x = a.x.min(b.x);
+/// //   min.y = a.y.min(b.y);
+/// //   min.z = a.z.min(b.z);  // only in 3D
+/// ```
+///
+/// With a dimension index (provided as a `const usize`):
+/// ```ignore
+/// for_each_dim! { i =>
+///     if mask & (1 << i) != 0 {
+///         result[ii] = -result[ii];
+///     }
+/// }
+/// ```
+///
+/// # Limitations
+///
+/// - The sentinel `[ii]` is replaced **everywhere** it appears in the body,
+///   so avoid using `[ii]` for other purposes inside the macro.
+macro_rules! for_each_dim {
+    ($i:ident => $($body:tt)*) => {{
+        #[cfg(feature = "dim2")]
+        {
+            { const $i: usize = 0; for_each_dim_inner!(x [] $($body)*); }
+            { const $i: usize = 1; for_each_dim_inner!(y [] $($body)*); }
+        }
+        #[cfg(feature = "dim3")]
+        {
+            { const $i: usize = 0; for_each_dim_inner!(x [] $($body)*); }
+            { const $i: usize = 1; for_each_dim_inner!(y [] $($body)*); }
+            { const $i: usize = 2; for_each_dim_inner!(z [] $($body)*); }
+        }
+    }};
+    ($($body:tt)*) => {{
+        #[cfg(feature = "dim2")]
+        {
+            for_each_dim_inner!(x [] $($body)*);
+            for_each_dim_inner!(y [] $($body)*);
+        }
+        #[cfg(feature = "dim3")]
+        {
+            for_each_dim_inner!(x [] $($body)*);
+            for_each_dim_inner!(y [] $($body)*);
+            for_each_dim_inner!(z [] $($body)*);
+        }
+    }};
+}

--- a/src/mass_properties/mass_properties.rs
+++ b/src/mass_properties/mass_properties.rs
@@ -586,6 +586,7 @@ impl approx::AbsDiffEq for MassProperties {
     }
 }
 
+#[cfg(feature = "alloc")] // TODO: this is a workaround because the `approx` feature of `glam` cannot be enabled on spirv targets.
 impl approx::RelativeEq for MassProperties {
     fn default_max_relative() -> Self::Epsilon {
         Real::default_max_relative()

--- a/src/mass_properties/mass_properties_trimesh3d.rs
+++ b/src/mass_properties/mass_properties_trimesh3d.rs
@@ -48,18 +48,18 @@ pub fn tetrahedron_unit_inertia_tensor_wrt_point(
     let p4 = p4 - point;
 
     // Just for readability.
-    let x1 = p1[0];
-    let y1 = p1[1];
-    let z1 = p1[2];
-    let x2 = p2[0];
-    let y2 = p2[1];
-    let z2 = p2[2];
-    let x3 = p3[0];
-    let y3 = p3[1];
-    let z3 = p3[2];
-    let x4 = p4[0];
-    let y4 = p4[1];
-    let z4 = p4[2];
+    let x1 = p1.x;
+    let y1 = p1.y;
+    let z1 = p1.z;
+    let x2 = p2.x;
+    let y2 = p2.y;
+    let z2 = p2.z;
+    let x3 = p3.x;
+    let y3 = p3.y;
+    let z3 = p3.z;
+    let x4 = p4.x;
+    let y4 = p4.y;
+    let z4 = p4.z;
 
     let diag_x = x1 * x1
         + x1 * x2

--- a/src/math/vector_ext.rs
+++ b/src/math/vector_ext.rs
@@ -86,7 +86,9 @@ impl VectorExt for Vector {
             _ => panic!("Index out of bounds for 2D vector: {i}"),
         };
         #[cfg(not(target_arch = "spirv"))]
-        { self[i] }
+        {
+            self[i]
+        }
     }
 
     #[inline]
@@ -100,7 +102,9 @@ impl VectorExt for Vector {
             _ => panic!("Index out of bounds for 2D vector: {i}"),
         };
         #[cfg(not(target_arch = "spirv"))]
-        { self[i] = val; }
+        {
+            self[i] = val;
+        }
     }
 }
 
@@ -127,7 +131,9 @@ impl IVectorExt for IVector {
             _ => panic!("Index out of bounds for 2D integer vector: {i}"),
         };
         #[cfg(not(target_arch = "spirv"))]
-        { self[i] }
+        {
+            self[i]
+        }
     }
 
     #[inline]
@@ -141,6 +147,8 @@ impl IVectorExt for IVector {
             _ => panic!("Index out of bounds for 2D integer vector: {i}"),
         }
         #[cfg(not(target_arch = "spirv"))]
-        { self[i] = val; }
+        {
+            self[i] = val;
+        }
     }
 }

--- a/src/math/vector_ext.rs
+++ b/src/math/vector_ext.rs
@@ -39,6 +39,7 @@ impl VectorExt for Vector {
             _ => Self::ZERO,
         }
     }
+
     #[inline]
     #[cfg(feature = "dim3")]
     fn ith(i: usize, val: Real) -> Self {
@@ -75,45 +76,31 @@ impl VectorExt for Vector {
     }
 
     #[inline]
-    #[cfg(feature = "dim2")]
     fn vget(&self, i: usize) -> Real {
-        match i {
+        #[cfg(target_arch = "spirv")]
+        return match i {
             0 => self.x,
             1 => self.y,
-            _ => panic!("Index out of bounds for 2D vector: {i}"),
-        }
-    }
-
-    #[inline]
-    #[cfg(feature = "dim3")]
-    fn vget(&self, i: usize) -> Real {
-        match i {
-            0 => self.x,
-            1 => self.y,
+            #[cfg(feature = "dim3")]
             2 => self.z,
-            _ => panic!("Index out of bounds for 3D vector: {i}"),
-        }
-    }
-
-    #[inline]
-    #[cfg(feature = "dim2")]
-    fn vset(&mut self, i: usize, val: Real) {
-        match i {
-            0 => self.x = val,
-            1 => self.y = val,
             _ => panic!("Index out of bounds for 2D vector: {i}"),
-        }
+        };
+        #[cfg(not(target_arch = "spirv"))]
+        { self[i] }
     }
 
     #[inline]
-    #[cfg(feature = "dim3")]
     fn vset(&mut self, i: usize, val: Real) {
+        #[cfg(target_arch = "spirv")]
         match i {
             0 => self.x = val,
             1 => self.y = val,
+            #[cfg(feature = "dim3")]
             2 => self.z = val,
-            _ => panic!("Index out of bounds for 3D vector: {i}"),
-        }
+            _ => panic!("Index out of bounds for 2D vector: {i}"),
+        };
+        #[cfg(not(target_arch = "spirv"))]
+        { self[i] = val; }
     }
 }
 
@@ -130,44 +117,30 @@ pub trait IVectorExt: Sized + Copy {
 
 impl IVectorExt for IVector {
     #[inline]
-    #[cfg(feature = "dim2")]
     fn ivget(&self, i: usize) -> Int {
-        match i {
+        #[cfg(target_arch = "spirv")]
+        return match i {
             0 => self.x,
             1 => self.y,
-            _ => panic!("Index out of bounds for 2D integer vector: {i}"),
-        }
-    }
-
-    #[inline]
-    #[cfg(feature = "dim3")]
-    fn ivget(&self, i: usize) -> Int {
-        match i {
-            0 => self.x,
-            1 => self.y,
+            #[cfg(feature = "dim3")]
             2 => self.z,
-            _ => panic!("Index out of bounds for 3D integer vector: {i}"),
-        }
+            _ => panic!("Index out of bounds for 2D integer vector: {i}"),
+        };
+        #[cfg(not(target_arch = "spirv"))]
+        { self[i] }
     }
 
     #[inline]
-    #[cfg(feature = "dim2")]
     fn ivset(&mut self, i: usize, val: Int) {
+        #[cfg(target_arch = "spirv")]
         match i {
             0 => self.x = val,
             1 => self.y = val,
+            #[cfg(feature = "dim3")]
+            2 => self.z = val,
             _ => panic!("Index out of bounds for 2D integer vector: {i}"),
         }
-    }
-
-    #[inline]
-    #[cfg(feature = "dim3")]
-    fn ivset(&mut self, i: usize, val: Int) {
-        match i {
-            0 => self.x = val,
-            1 => self.y = val,
-            2 => self.z = val,
-            _ => panic!("Index out of bounds for 3D integer vector: {i}"),
-        }
+        #[cfg(not(target_arch = "spirv"))]
+        { self[i] = val; }
     }
 }

--- a/src/math/vector_ext.rs
+++ b/src/math/vector_ext.rs
@@ -1,6 +1,6 @@
 //! Vector extension trait for glam types.
 
-use crate::math::{Matrix, Real, Vector};
+use crate::math::{IVector, Int, Matrix, Real, Vector};
 
 #[cfg(not(feature = "std"))]
 use simba::scalar::ComplexField;
@@ -15,6 +15,18 @@ pub trait VectorExt: Sized + Copy {
 
     /// Computes the kronecker product between two vectors.
     fn kronecker(self, other: Self) -> Matrix;
+
+    /// Gets the i-th component of the vector by index.
+    ///
+    /// This is a SPIR-V compatible replacement for bracket indexing (`v[i]`),
+    /// which is not supported on glam types when targeting SPIR-V.
+    fn vget(&self, i: usize) -> Real;
+
+    /// Sets the i-th component of the vector by index.
+    ///
+    /// This is a SPIR-V compatible replacement for bracket indexing (`v[i] = val`),
+    /// which is not supported on glam types when targeting SPIR-V.
+    fn vset(&mut self, i: usize, val: Real);
 }
 
 impl VectorExt for Vector {
@@ -60,5 +72,102 @@ impl VectorExt for Vector {
     #[cfg(feature = "dim3")]
     fn kronecker(self, other: Self) -> Matrix {
         Matrix::from_cols(self * other.x, self * other.y, self * other.z)
+    }
+
+    #[inline]
+    #[cfg(feature = "dim2")]
+    fn vget(&self, i: usize) -> Real {
+        match i {
+            0 => self.x,
+            1 => self.y,
+            _ => panic!("Index out of bounds for 2D vector: {i}"),
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "dim3")]
+    fn vget(&self, i: usize) -> Real {
+        match i {
+            0 => self.x,
+            1 => self.y,
+            2 => self.z,
+            _ => panic!("Index out of bounds for 3D vector: {i}"),
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "dim2")]
+    fn vset(&mut self, i: usize, val: Real) {
+        match i {
+            0 => self.x = val,
+            1 => self.y = val,
+            _ => panic!("Index out of bounds for 2D vector: {i}"),
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "dim3")]
+    fn vset(&mut self, i: usize, val: Real) {
+        match i {
+            0 => self.x = val,
+            1 => self.y = val,
+            2 => self.z = val,
+            _ => panic!("Index out of bounds for 3D vector: {i}"),
+        }
+    }
+}
+
+/// Extension trait for integer vector types with index-based component access.
+///
+/// Provides SPIR-V compatible replacement for bracket indexing on glam integer vectors.
+pub trait IVectorExt: Sized + Copy {
+    /// Gets the i-th component of the integer vector by index.
+    fn ivget(&self, i: usize) -> Int;
+
+    /// Sets the i-th component of the integer vector by index.
+    fn ivset(&mut self, i: usize, val: Int);
+}
+
+impl IVectorExt for IVector {
+    #[inline]
+    #[cfg(feature = "dim2")]
+    fn ivget(&self, i: usize) -> Int {
+        match i {
+            0 => self.x,
+            1 => self.y,
+            _ => panic!("Index out of bounds for 2D integer vector: {i}"),
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "dim3")]
+    fn ivget(&self, i: usize) -> Int {
+        match i {
+            0 => self.x,
+            1 => self.y,
+            2 => self.z,
+            _ => panic!("Index out of bounds for 3D integer vector: {i}"),
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "dim2")]
+    fn ivset(&mut self, i: usize, val: Int) {
+        match i {
+            0 => self.x = val,
+            1 => self.y = val,
+            _ => panic!("Index out of bounds for 2D integer vector: {i}"),
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "dim3")]
+    fn ivset(&mut self, i: usize, val: Int) {
+        match i {
+            0 => self.x = val,
+            1 => self.y = val,
+            2 => self.z = val,
+            _ => panic!("Index out of bounds for 3D integer vector: {i}"),
+        }
     }
 }

--- a/src/partitioning/bvh/bvh_binned_build.rs
+++ b/src/partitioning/bvh/bvh_binned_build.rs
@@ -48,7 +48,10 @@ impl Bvh {
 
         let centroid_aabb = Aabb::from_points(leaves.iter().map(|node| node.center()));
         let bins_axis = centroid_aabb.extents().max_position();
-        let bins_range = [centroid_aabb.mins.vget(bins_axis), centroid_aabb.maxs.vget(bins_axis)];
+        let bins_range = [
+            centroid_aabb.mins.vget(bins_axis),
+            centroid_aabb.maxs.vget(bins_axis),
+        ];
 
         // Compute bins characteristics.
         let k1 = NUM_BINS as Real * (1.0 - BIN_EPSILON) / (bins_range[1] - bins_range[0]);

--- a/src/partitioning/bvh/bvh_binned_build.rs
+++ b/src/partitioning/bvh/bvh_binned_build.rs
@@ -1,7 +1,7 @@
 use super::bvh_tree::{BvhBuildStrategy, BvhNodeIndex, BvhNodeWide};
 use super::{Bvh, BvhNode, BvhWorkspace};
 use crate::bounding_volume::{Aabb, BoundingVolume};
-use crate::math::Real;
+use crate::math::{Real, VectorExt};
 
 impl Bvh {
     /// Fully rebuilds this BVH using the given strategy.
@@ -48,13 +48,13 @@ impl Bvh {
 
         let centroid_aabb = Aabb::from_points(leaves.iter().map(|node| node.center()));
         let bins_axis = centroid_aabb.extents().max_position();
-        let bins_range = [centroid_aabb.mins[bins_axis], centroid_aabb.maxs[bins_axis]];
+        let bins_range = [centroid_aabb.mins.vget(bins_axis), centroid_aabb.maxs.vget(bins_axis)];
 
         // Compute bins characteristics.
         let k1 = NUM_BINS as Real * (1.0 - BIN_EPSILON) / (bins_range[1] - bins_range[0]);
         let k0 = bins_range[0];
         for leaf in &*leaves {
-            let bin_id = (k1 * (leaf.center()[bins_axis] - k0)) as usize;
+            let bin_id = (k1 * (leaf.center().vget(bins_axis) - k0)) as usize;
             let bin = &mut bins[bin_id];
             bin.aabb.merge(&leaf.aabb());
             bin.leaf_count += 1;
@@ -102,7 +102,7 @@ impl Bvh {
             // TODO PERF: try with using teh leaves_tmp instead of in-place sorting.
             let bin = |leaves: &mut [BvhNode], id: usize| {
                 let node = &leaves[id];
-                (k1 * (node.center()[bins_axis] - k0)) as usize
+                (k1 * (node.center().vget(bins_axis) - k0)) as usize
             };
 
             let mut left_id = 0;

--- a/src/query/clip/clip_aabb_line.rs
+++ b/src/query/clip/clip_aabb_line.rs
@@ -1,5 +1,5 @@
 use crate::bounding_volume::Aabb;
-use crate::math::{Real, Vector, DIM};
+use crate::math::{Real, Vector, VectorExt, DIM};
 use crate::query::Ray;
 use crate::shape::Segment;
 use num::{Bounded, Zero};
@@ -89,15 +89,15 @@ pub fn clip_aabb_line(
     let mut far_diag = false;
 
     for i in 0usize..DIM {
-        if dir[i].is_zero() {
-            if origin[i] < aabb.mins[i] || origin[i] > aabb.maxs[i] {
+        if dir.vget(i).is_zero() {
+            if origin.vget(i) < aabb.mins.vget(i) || origin.vget(i) > aabb.maxs.vget(i) {
                 return None;
             }
         } else {
-            let denom = 1.0 / dir[i];
+            let denom = 1.0 / dir.vget(i);
             let flip_sides;
-            let mut inter_with_near_halfspace = (aabb.mins[i] - origin[i]) * denom;
-            let mut inter_with_far_halfspace = (aabb.maxs[i] - origin[i]) * denom;
+            let mut inter_with_near_halfspace = (aabb.mins.vget(i) - origin.vget(i)) * denom;
+            let mut inter_with_far_halfspace = (aabb.maxs.vget(i) - origin.vget(i)) * denom;
 
             if inter_with_near_halfspace > inter_with_far_halfspace {
                 flip_sides = true;
@@ -153,9 +153,9 @@ pub fn clip_aabb_line(
         let mut normal = Vector::ZERO;
 
         if near_side < 0 {
-            normal[(-near_side - 1) as usize] = 1.0;
+            normal.vset((-near_side - 1) as usize, 1.0);
         } else {
-            normal[(near_side - 1) as usize] = -1.0;
+            normal.vset((near_side - 1) as usize, -1.0);
         }
 
         (tmin, normal, near_side)
@@ -175,9 +175,9 @@ pub fn clip_aabb_line(
         let mut normal = Vector::ZERO;
 
         if far_side < 0 {
-            normal[(-far_side - 1) as usize] = -1.0;
+            normal.vset((-far_side - 1) as usize, -1.0);
         } else {
-            normal[(far_side - 1) as usize] = 1.0;
+            normal.vset((far_side - 1) as usize, 1.0);
         }
 
         (tmax, normal, far_side)

--- a/src/query/contact/contact_support_map_support_map.rs
+++ b/src/query/contact/contact_support_map_support_map.rs
@@ -71,3 +71,40 @@ where
     // Everything failed
     GJKResult::NoIntersection(Vector::X)
 }
+
+#[cfg(all(test, feature = "dim2"))]
+mod test {
+    use crate::bounding_volume::Aabb;
+    use crate::math::{Pose, Vector};
+    use crate::query::contact;
+    use crate::shape::{Cuboid, Segment};
+
+    /// Regression test for <https://github.com/dimforge/parry/issues/415>: a segment overlapping
+    /// a cuboid must report a penetrating contact. An absolute tolerance used in EPA's `FaceId`
+    /// construction used to spuriously reject valid faces (and make `contact` return `None`) when
+    /// using `f64` precision with large coordinates.
+    ///
+    /// NOTE: this is not in the `tests` directory since we want it for both f32 and f64 versions.
+    #[test]
+    fn contact_segment_cuboid_issue_415() {
+        let segment = Segment {
+            a: Vector::new(60.0, 10.0),
+            b: Vector::new(10.0, 0.0),
+        };
+        let aabb = Aabb {
+            mins: Vector::new(40.0, -50.0),
+            maxs: Vector::new(60.0, 150.0),
+        };
+        let cuboid = Cuboid::new(aabb.half_extents());
+        let pos_cuboid = Pose::from_translation(aabb.center());
+
+        let contact = contact(&Pose::IDENTITY, &segment, &pos_cuboid, &cuboid, 1.0)
+            .unwrap()
+            .expect("the overlapping segment and cuboid must report a contact");
+        assert!(
+            contact.dist < 0.0,
+            "expected a penetrating contact, got dist = {}",
+            contact.dist
+        );
+    }
+}

--- a/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_ball.rs
@@ -182,10 +182,10 @@ pub fn project_point_on_pseudo_cube(
             let i1 = pattern as usize - OctantPattern::FACE_X as usize;
             let i2 = (i1 + 1) % 2;
 
-            if unit_dpos[i2] > 1.0 || unit_dpos[i2] < 0.0 {
+            if unit_dpos.vget(i2) > 1.0 || unit_dpos.vget(i2) < 0.0 {
                 None
             } else {
-                let dist = unit_dpos[i1] - 1.0; // Subtract 1 to get the distance wrt. the boundary of the unit voxel.
+                let dist = unit_dpos.vget(i1) - 1.0; // Subtract 1 to get the distance wrt. the boundary of the unit voxel.
                 Some((Vector::ith(i1, 1.0), dist))
             }
         }
@@ -195,14 +195,14 @@ pub fn project_point_on_pseudo_cube(
             let i2 = (i1 + 1) % 3;
             let i3 = (i1 + 2) % 3;
 
-            if unit_dpos[i2] > 1.0
-                || unit_dpos[i2] < 0.0
-                || unit_dpos[i3] > 1.0
-                || unit_dpos[i3] < 0.0
+            if unit_dpos.vget(i2) > 1.0
+                || unit_dpos.vget(i2) < 0.0
+                || unit_dpos.vget(i3) > 1.0
+                || unit_dpos.vget(i3) < 0.0
             {
                 None
             } else {
-                let dist = unit_dpos[i1] - 1.0; // Subtract 1 to get the distance wrt. the boundary of the unit voxel.
+                let dist = unit_dpos.vget(i1) - 1.0; // Subtract 1 to get the distance wrt. the boundary of the unit voxel.
                 Some((Vector::ith(i1, 1.0), dist))
             }
         }

--- a/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
+++ b/src/query/contact_manifolds/contact_manifolds_voxels_shape.rs
@@ -1,5 +1,5 @@
 use crate::bounding_volume::Aabb;
-use crate::math::{IVector, Int, Pose, Real, Vector, DIM};
+use crate::math::{IVector, IVectorExt, Int, Pose, Real, Vector, VectorExt, DIM};
 use crate::query::{
     ContactManifold, ContactManifoldsWorkspace, PersistentQueryDispatcher, PointQuery,
     TypedWorkspaceData, WorkspaceData,
@@ -346,19 +346,19 @@ impl CanonicalVoxelShape {
 
         let adjust_canon = |axis: AxisMask, i: usize, key: &mut IVector, val: Int| {
             if !mask1.contains(axis) {
-                key[i] = val.as_();
+                key.ivset(i, val.as_());
             }
         };
 
-        adjust_canon(AxisMask::X_POS, 0, &mut key_high, maxs[0]);
-        adjust_canon(AxisMask::X_NEG, 0, &mut key_low, mins[0]);
-        adjust_canon(AxisMask::Y_POS, 1, &mut key_high, maxs[1]);
-        adjust_canon(AxisMask::Y_NEG, 1, &mut key_low, mins[1]);
+        adjust_canon(AxisMask::X_POS, 0, &mut key_high, maxs.x);
+        adjust_canon(AxisMask::X_NEG, 0, &mut key_low, mins.x);
+        adjust_canon(AxisMask::Y_POS, 1, &mut key_high, maxs.y);
+        adjust_canon(AxisMask::Y_NEG, 1, &mut key_low, mins.y);
 
         #[cfg(feature = "dim3")]
         {
-            adjust_canon(AxisMask::Z_POS, 2, &mut key_high, maxs[2]);
-            adjust_canon(AxisMask::Z_NEG, 2, &mut key_low, mins[2]);
+            adjust_canon(AxisMask::Z_POS, 2, &mut key_high, maxs.z);
+            adjust_canon(AxisMask::Z_NEG, 2, &mut key_low, mins.z);
         }
 
         #[cfg(feature = "dim2")]
@@ -385,12 +385,12 @@ impl CanonicalVoxelShape {
         let mut canonical_maxs = voxels.voxel_center(self.range[1]);
 
         for k in 0..DIM {
-            if self.range[0][k] != vox.grid_coords[k] {
-                canonical_mins[k] = canonical_mins[k].max(domain2_1.mins[k]);
+            if self.range[0].ivget(k) != vox.grid_coords.ivget(k) {
+                canonical_mins.vset(k, canonical_mins.vget(k).max(domain2_1.mins.vget(k)));
             }
 
-            if self.range[1][k] != vox.grid_coords[k] {
-                canonical_maxs[k] = canonical_maxs[k].min(domain2_1.maxs[k]);
+            if self.range[1].ivget(k) != vox.grid_coords.ivget(k) {
+                canonical_maxs.vset(k, canonical_maxs.vget(k).min(domain2_1.maxs.vget(k)));
             }
         }
 

--- a/src/query/epa/epa2.rs
+++ b/src/query/epa/epa2.rs
@@ -19,8 +19,9 @@ struct FaceId {
 }
 
 impl FaceId {
-    fn new(id: usize, neg_dist: Real) -> Option<Self> {
-        if neg_dist > gjk::eps_tol() {
+    /// Creates a new face id, rejecting faces whose `neg_dist` is positive beyond `tol`.
+    fn new(id: usize, neg_dist: Real, tol: Real) -> Option<Self> {
+        if neg_dist > tol {
             None
         } else {
             Some(FaceId { id, neg_dist })
@@ -361,6 +362,20 @@ impl EPA {
             self.vertices.push(*simplex.point(i));
         }
 
+        // Tolerance used to reject degenerate faces. It is scaled relative to the magnitude of
+        // the simplex coordinates: dot products used to compute face distances accumulate
+        // rounding errors proportional to the coordinate magnitudes, so an absolute tolerance
+        // would spuriously abort EPA for large coordinates.
+        // See <https://github.com/dimforge/parry/issues/415>.
+        let dist_tol = {
+            let scale = self
+                .vertices
+                .iter()
+                .map(|v| v.point.length())
+                .fold(0.0, Real::max);
+            gjk::eps_tol() * scale.max(1.0)
+        };
+
         if simplex.dimension() == 0 {
             const MAX_ITERS: usize = 100; // If there is no convergence, just use whatever direction was extracted so fare
 
@@ -422,17 +437,17 @@ impl EPA {
 
             if proj_inside1 {
                 let dist1 = self.faces[0].normal.dot(self.vertices[0].point);
-                self.heap.push(FaceId::new(0, -dist1)?);
+                self.heap.push(FaceId::new(0, -dist1, dist_tol)?);
             }
 
             if proj_inside2 {
                 let dist2 = self.faces[1].normal.dot(self.vertices[1].point);
-                self.heap.push(FaceId::new(1, -dist2)?);
+                self.heap.push(FaceId::new(1, -dist2, dist_tol)?);
             }
 
             if proj_inside3 {
                 let dist3 = self.faces[2].normal.dot(self.vertices[2].point);
-                self.heap.push(FaceId::new(2, -dist3)?);
+                self.heap.push(FaceId::new(2, -dist3, dist_tol)?);
             }
 
             if !(proj_inside1 || proj_inside2 || proj_inside3) {
@@ -462,8 +477,8 @@ impl EPA {
             let dist1 = self.faces[0].normal.dot(self.vertices[0].point);
             let dist2 = self.faces[1].normal.dot(self.vertices[1].point);
 
-            self.heap.push(FaceId::new(0, dist1)?);
-            self.heap.push(FaceId::new(1, dist2)?);
+            self.heap.push(FaceId::new(0, dist1, dist_tol)?);
+            self.heap.push(FaceId::new(1, dist2, dist_tol)?);
         }
 
         let mut niter = 0;
@@ -526,7 +541,8 @@ impl EPA {
                     }
 
                     if !f.0.deleted {
-                        self.heap.push(FaceId::new(self.faces.len(), -dist)?);
+                        self.heap
+                            .push(FaceId::new(self.faces.len(), -dist, dist_tol)?);
                     }
                 }
 

--- a/src/query/epa/epa3.rs
+++ b/src/query/epa/epa3.rs
@@ -20,8 +20,9 @@ struct FaceId {
 }
 
 impl FaceId {
-    fn new(id: usize, neg_dist: Real) -> Option<Self> {
-        if neg_dist > gjk::eps_tol() {
+    /// Creates a new face id, rejecting faces whose `neg_dist` is positive beyond `tol`.
+    fn new(id: usize, neg_dist: Real, tol: Real) -> Option<Self> {
+        if neg_dist > tol {
             None
         } else {
             Some(FaceId { id, neg_dist })
@@ -447,6 +448,20 @@ impl EPA {
             self.vertices.push(*simplex.point(i));
         }
 
+        // Tolerance used to reject degenerate faces. It is scaled relative to the magnitude of
+        // the simplex coordinates: dot products used to compute face distances accumulate
+        // rounding errors proportional to the coordinate magnitudes, so an absolute tolerance
+        // would spuriously abort EPA for large coordinates.
+        // See <https://github.com/dimforge/parry/issues/415>.
+        let dist_tol = {
+            let scale = self
+                .vertices
+                .iter()
+                .map(|v| v.point.length())
+                .fold(0.0, Real::max);
+            gjk::eps_tol() * scale.max(1.0)
+        };
+
         if simplex.dimension() == 0 {
             let mut n: Vector = Vector::ZERO;
             n.y = 1.0;
@@ -482,22 +497,22 @@ impl EPA {
 
             if proj_inside1 {
                 let dist1 = self.faces[0].normal.dot(self.vertices[0].point);
-                self.heap.push(FaceId::new(0, -dist1)?);
+                self.heap.push(FaceId::new(0, -dist1, dist_tol)?);
             }
 
             if proj_inside2 {
                 let dist2 = self.faces[1].normal.dot(self.vertices[1].point);
-                self.heap.push(FaceId::new(1, -dist2)?);
+                self.heap.push(FaceId::new(1, -dist2, dist_tol)?);
             }
 
             if proj_inside3 {
                 let dist3 = self.faces[2].normal.dot(self.vertices[2].point);
-                self.heap.push(FaceId::new(2, -dist3)?);
+                self.heap.push(FaceId::new(2, -dist3, dist_tol)?);
             }
 
             if proj_inside4 {
                 let dist4 = self.faces[3].normal.dot(self.vertices[3].point);
-                self.heap.push(FaceId::new(3, -dist4)?);
+                self.heap.push(FaceId::new(3, -dist4, dist_tol)?);
             }
 
             if !(proj_inside1 || proj_inside2 || proj_inside3 || proj_inside4) {
@@ -530,8 +545,8 @@ impl EPA {
             self.faces.push(face1);
             self.faces.push(face2);
 
-            self.heap.push(FaceId::new(0, 0.0)?);
-            self.heap.push(FaceId::new(1, 0.0)?);
+            self.heap.push(FaceId::new(0, 0.0, dist_tol)?);
+            self.heap.push(FaceId::new(1, 0.0, dist_tol)?);
         }
 
         let mut niter = 0;
@@ -618,7 +633,7 @@ impl EPA {
                             return Some((points.0, points.1, face.normal));
                         }
 
-                        self.heap.push(FaceId::new(new_face_id, -dist)?);
+                        self.heap.push(FaceId::new(new_face_id, -dist, dist_tol)?);
                     }
                 }
             }

--- a/src/query/epa/epa3.rs
+++ b/src/query/epa/epa3.rs
@@ -449,7 +449,7 @@ impl EPA {
 
         if simplex.dimension() == 0 {
             let mut n: Vector = Vector::ZERO;
-            n[1] = 1.0;
+            n.y = 1.0;
             return Some((Vector::ZERO, Vector::ZERO, n));
         } else if simplex.dimension() == 3 {
             let dp1 = self.vertices[1] - self.vertices[0];

--- a/src/query/nonlinear_shape_cast/nonlinear_shape_cast_voxels_shape.rs
+++ b/src/query/nonlinear_shape_cast/nonlinear_shape_cast_voxels_shape.rs
@@ -1,5 +1,5 @@
 use crate::bounding_volume::BoundingVolume;
-use crate::math::{IVector, Real, Vector};
+use crate::math::{IVector, IVectorExt, Real, Vector, VectorExt};
 use crate::query::{NonlinearRigidMotion, QueryDispatcher, ShapeCastHit};
 use crate::shape::{Cuboid, Shape, Voxels};
 
@@ -101,15 +101,17 @@ where
         let ii = [0, 1, 2];
 
         let toi = ii.map(|i| {
-            if motion2.linvel[i] > 0.0 {
-                let t = (search_domain_aabb.maxs[i] - start_aabb2_1.maxs[i]) / motion2.linvel[i];
+            if motion2.linvel.vget(i) > 0.0 {
+                let t = (search_domain_aabb.maxs.vget(i) - start_aabb2_1.maxs.vget(i))
+                    / motion2.linvel.vget(i);
                 if t < 0.0 {
                     (Real::max_value(), true)
                 } else {
                     (t, true)
                 }
-            } else if motion2.linvel[i] < 0.0 {
-                let t = (search_domain_aabb.mins[i] - start_aabb2_1.mins[i]) / motion2.linvel[i];
+            } else if motion2.linvel.vget(i) < 0.0 {
+                let t = (search_domain_aabb.mins.vget(i) - start_aabb2_1.mins.vget(i))
+                    / motion2.linvel.vget(i);
                 if t < 0.0 {
                     (Real::max_value(), false)
                 } else {
@@ -133,33 +135,33 @@ where
         let imin = Vector::from(toi.map(|t| t.0)).min_position();
 
         if toi[imin].1 {
-            search_domain[0][imin] += 1;
-            search_domain[1][imin] += 1;
+            search_domain[0].ivset(imin, search_domain[0].ivget(imin) + 1);
+            search_domain[1].ivset(imin, search_domain[1].ivget(imin) + 1);
 
-            if search_domain[1][imin] <= domain_maxs[imin] {
+            if search_domain[1].ivget(imin) <= domain_maxs.ivget(imin) {
                 // Check the voxels on the added row.
                 let mut prev_row = search_domain[0];
-                prev_row[imin] = search_domain[1][imin] - 1;
+                prev_row.ivset(imin, search_domain[1].ivget(imin) - 1);
 
                 let range_to_check = [prev_row, search_domain[1]];
                 check_voxels_in_range(range_to_check);
-            } else if search_domain[0][imin] >= domain_maxs[imin] {
-                // Leaving the shape’s bounds.
+            } else if search_domain[0].ivget(imin) >= domain_maxs.ivget(imin) {
+                // Leaving the shape's bounds.
                 break;
             }
         } else {
-            search_domain[0][imin] -= 1;
-            search_domain[1][imin] -= 1;
+            search_domain[0].ivset(imin, search_domain[0].ivget(imin) - 1);
+            search_domain[1].ivset(imin, search_domain[1].ivget(imin) - 1);
 
-            if search_domain[0][imin] >= domain_mins[imin] {
+            if search_domain[0].ivget(imin) >= domain_mins.ivget(imin) {
                 // Check the voxels on the added row.
                 let mut next_row = search_domain[1];
-                next_row[imin] = search_domain[0][imin] + 1;
+                next_row.ivset(imin, search_domain[0].ivget(imin) + 1);
 
                 let range_to_check = [search_domain[0], next_row];
                 check_voxels_in_range(range_to_check);
-            } else if search_domain[1][imin] <= domain_mins[imin] {
-                // Leaving the shape’s bounds.
+            } else if search_domain[1].ivget(imin) <= domain_mins.ivget(imin) {
+                // Leaving the shape's bounds.
                 break;
             }
         }

--- a/src/query/point/point_aabb.rs
+++ b/src/query/point/point_aabb.rs
@@ -1,5 +1,5 @@
 use crate::bounding_volume::Aabb;
-use crate::math::{Real, Vector, DIM};
+use crate::math::{Real, Vector, VectorExt, DIM};
 use crate::num::{Bounded, Zero};
 use crate::query::{PointProjection, PointQuery};
 use crate::shape::FeatureId;
@@ -71,7 +71,7 @@ impl PointQuery for Aabb {
         let mut last_not_zero_shift = 0;
 
         for i in 0..DIM {
-            if shift[i].is_zero() {
+            if shift.vget(i).is_zero() {
                 nzero_shifts += 1;
                 last_zero_shift = i;
             } else {
@@ -81,10 +81,10 @@ impl PointQuery for Aabb {
 
         if nzero_shifts == DIM {
             for i in 0..DIM {
-                if ls_pt[i] > self.maxs[i] - crate::math::DEFAULT_EPSILON {
+                if ls_pt.vget(i) > self.maxs.vget(i) - crate::math::DEFAULT_EPSILON {
                     return (proj, FeatureId::Face(i as u32));
                 }
-                if ls_pt[i] <= self.mins[i] + crate::math::DEFAULT_EPSILON {
+                if ls_pt.vget(i) <= self.mins.vget(i) + crate::math::DEFAULT_EPSILON {
                     return (proj, FeatureId::Face((i + DIM) as u32));
                 }
             }
@@ -92,7 +92,7 @@ impl PointQuery for Aabb {
             (proj, FeatureId::Unknown)
         } else if nzero_shifts == DIM - 1 {
             // On a 3D face.
-            if ls_pt[last_not_zero_shift] < self.center()[last_not_zero_shift] {
+            if ls_pt.vget(last_not_zero_shift) < self.center().vget(last_not_zero_shift) {
                 (proj, FeatureId::Face((last_not_zero_shift + DIM) as u32))
             } else {
                 (proj, FeatureId::Face(last_not_zero_shift as u32))
@@ -103,7 +103,7 @@ impl PointQuery for Aabb {
             let center = self.center();
 
             for i in 0..DIM {
-                if ls_pt[i] < center[i] {
+                if ls_pt.vget(i) < center.vget(i) {
                     id |= 1 << i;
                 }
             }

--- a/src/query/point/point_aabb.rs
+++ b/src/query/point/point_aabb.rs
@@ -1,8 +1,9 @@
 use crate::bounding_volume::Aabb;
 use crate::math::{Real, Vector, VectorExt, DIM};
-use crate::num::{Bounded, Zero};
+use crate::num::Zero;
 use crate::query::{PointProjection, PointQuery};
 use crate::shape::FeatureId;
+use crate::utils::WSign;
 
 impl Aabb {
     fn do_project_local_point(&self, pt: Vector, solid: bool) -> (bool, Vector, Vector) {
@@ -17,7 +18,7 @@ impl Aabb {
         } else {
             // Projection for the case where the point is inside the box.
             let centered_pt = pt - self.center();
-            let pt_sgn_with_zero = Vector::splat(1.0).copysign(centered_pt);
+            let pt_sgn_with_zero = centered_pt.copy_sign_to(Vector::splat(1.0));
             // This is the sign of pt, or -1 for components that were zero.
             // This bias is arbitrary (we could have picked +1), but we picked it so
             // it matches the previous implementation.

--- a/src/query/point/point_aabb.rs
+++ b/src/query/point/point_aabb.rs
@@ -10,44 +10,45 @@ impl Aabb {
         let pt_maxs = pt - self.maxs;
         let shift = mins_pt.max(Vector::ZERO) - pt_maxs.max(Vector::ZERO);
 
-        let inside = shift == Vector::ZERO;
-
-        if !inside {
+        if shift != Vector::ZERO {
             (false, pt + shift, shift)
         } else if solid {
-            (true, pt, shift)
+            (true, pt, Vector::ZERO)
         } else {
-            let _max: Real = Bounded::max_value();
-            let mut best = -_max;
-            let mut is_mins = false;
-            let mut best_id = 0;
+            // Projection for the case where the point is inside the box.
+            let centered_pt = pt - self.center();
+            let pt_sgn_with_zero = Vector::splat(1.0).copysign(centered_pt);
+            // This is the sign of pt, or -1 for components that were zero.
+            // This bias is arbitrary (we could have picked +1), but we picked it so
+            // it matches the previous implementation.
+            let pt_sgn = pt_sgn_with_zero + (pt_sgn_with_zero.abs() - Vector::ONE);
+            let diff = self.half_extents() - pt_sgn * centered_pt;
 
-            for i in 0..DIM {
-                let mins_pt_i = mins_pt[i];
-                let pt_maxs_i = pt_maxs[i];
+            #[cfg(feature = "dim2")]
+            let shift = {
+                let pick_x = diff.x <= diff.y;
+                let shift_x = Vector::new(diff.x * pt_sgn.x, 0.0);
+                let shift_y = Vector::new(0.0, diff.y * pt_sgn.y);
+                if pick_x { shift_x } else { shift_y }
+            };
 
-                if mins_pt_i < pt_maxs_i {
-                    if pt_maxs[i] > best {
-                        best_id = i;
-                        is_mins = false;
-                        best = pt_maxs_i
-                    }
-                } else if mins_pt_i > best {
-                    best_id = i;
-                    is_mins = true;
-                    best = mins_pt_i
+            #[cfg(feature = "dim3")]
+            let shift = {
+                let pick_x = diff.x <= diff.y && diff.x <= diff.z;
+                let pick_y = diff.y <= diff.x && diff.y <= diff.z;
+                let shift_x = Vector::new(diff.x * pt_sgn.x, 0.0, 0.0);
+                let shift_y = Vector::new(0.0, diff.y * pt_sgn.y, 0.0);
+                let shift_z = Vector::new(0.0, 0.0, diff.z * pt_sgn.z);
+                if pick_x {
+                    shift_x
+                } else if pick_y {
+                    shift_y
+                } else {
+                    shift_z
                 }
-            }
+            };
 
-            let mut shift: Vector = Vector::ZERO;
-
-            if is_mins {
-                shift[best_id] = best;
-            } else {
-                shift[best_id] = -best;
-            }
-
-            (inside, pt + shift, shift)
+            (true, pt + shift, shift)
         }
     }
 }

--- a/src/query/point/point_aabb.rs
+++ b/src/query/point/point_aabb.rs
@@ -30,7 +30,11 @@ impl Aabb {
                 let pick_x = diff.x <= diff.y;
                 let shift_x = Vector::new(diff.x * pt_sgn.x, 0.0);
                 let shift_y = Vector::new(0.0, diff.y * pt_sgn.y);
-                if pick_x { shift_x } else { shift_y }
+                if pick_x {
+                    shift_x
+                } else {
+                    shift_y
+                }
             };
 
             #[cfg(feature = "dim3")]

--- a/src/query/point/point_composite_shape.rs
+++ b/src/query/point/point_composite_shape.rs
@@ -59,10 +59,11 @@ impl<S: TypedCompositeShape> CompositeShapeRef<'_, S> {
     pub fn project_local_point(
         &self,
         point: Vector,
+        max_dist: Real,
         solid: bool,
     ) -> Option<(u32, PointProjection)> {
         let (best_id, (_, proj)) = self.0.bvh().find_best(
-            Real::MAX,
+            max_dist,
             |node: &BvhNode, _best_so_far| node.aabb().distance_to_local_point(point, true),
             |primitive, _best_so_far| {
                 let proj = self.0.map_typed_part_at(primitive, |pose, shape, _| {
@@ -88,9 +89,10 @@ impl<S: TypedCompositeShape> CompositeShapeRef<'_, S> {
     pub fn project_local_point_and_get_feature(
         &self,
         point: Vector,
+        max_dist: Real,
     ) -> Option<(u32, (PointProjection, FeatureId))> {
         let (best_id, (_, (proj, feature_id))) = self.0.bvh().find_best(
-            Real::MAX,
+            max_dist,
             |node: &BvhNode, _best_so_far| node.aabb().distance_to_local_point(point, true),
             |primitive, _best_so_far| {
                 let proj = self.0.map_typed_part_at(primitive, |pose, shape, _| {
@@ -133,7 +135,7 @@ impl PointQuery for Polyline {
     #[inline]
     fn project_local_point(&self, point: Vector, solid: bool) -> PointProjection {
         CompositeShapeRef(self)
-            .project_local_point(point, solid)
+            .project_local_point(point, Real::MAX, solid)
             .unwrap_or_else(|| unreachable!())
             .1
     }
@@ -141,7 +143,7 @@ impl PointQuery for Polyline {
     #[inline]
     fn project_local_point_and_get_feature(&self, point: Vector) -> (PointProjection, FeatureId) {
         let (seg_id, (proj, feature)) = CompositeShapeRef(self)
-            .project_local_point_and_get_feature(point)
+            .project_local_point_and_get_feature(point, Real::MAX)
             .unwrap_or_else(|| unreachable!());
         let polyline_feature = self.segment_feature_to_polyline_feature(seg_id, feature);
         (proj, polyline_feature)
@@ -161,7 +163,7 @@ impl PointQuery for TriMesh {
     #[inline]
     fn project_local_point(&self, point: Vector, solid: bool) -> PointProjection {
         CompositeShapeRef(self)
-            .project_local_point(point, solid)
+            .project_local_point(point, Real::MAX, solid)
             .unwrap_or_else(|| unreachable!())
             .1
     }
@@ -178,7 +180,7 @@ impl PointQuery for TriMesh {
 
         let solid = cfg!(feature = "dim2");
         let (tri_id, proj) = CompositeShapeRef(self)
-            .project_local_point(point, solid)
+            .project_local_point(point, Real::MAX, solid)
             .unwrap_or_else(|| unreachable!());
         (proj, FeatureId::Face(tri_id))
     }
@@ -217,7 +219,7 @@ impl PointQuery for Compound {
     #[inline]
     fn project_local_point(&self, point: Vector, solid: bool) -> PointProjection {
         CompositeShapeRef(self)
-            .project_local_point(point, solid)
+            .project_local_point(point, Real::MAX, solid)
             .unwrap_or_else(|| unreachable!())
             .1
     }
@@ -226,7 +228,7 @@ impl PointQuery for Compound {
     fn project_local_point_and_get_feature(&self, point: Vector) -> (PointProjection, FeatureId) {
         (
             CompositeShapeRef(self)
-                .project_local_point_and_get_feature(point)
+                .project_local_point_and_get_feature(point, Real::MAX)
                 .unwrap_or_else(|| unreachable!())
                 .1
                  .0,

--- a/src/query/point/point_composite_shape.rs
+++ b/src/query/point/point_composite_shape.rs
@@ -56,27 +56,27 @@ impl<S: TypedCompositeShape> CompositeShapeRef<'_, S> {
     /// Returns the projected point as well as the index of the sub-shape of `self` that was hit.
     /// If `solid` is `false` then the point will be projected to the closest boundary of `self` even
     /// if it is contained by one of its sub-shapes.
-    pub fn project_local_point(&self, point: Vector, solid: bool) -> (u32, PointProjection) {
-        let (best_id, (_, proj)) = self
-            .0
-            .bvh()
-            .find_best(
-                Real::MAX,
-                |node: &BvhNode, _best_so_far| node.aabb().distance_to_local_point(point, true),
-                |primitive, _best_so_far| {
-                    let proj = self.0.map_typed_part_at(primitive, |pose, shape, _| {
-                        if let Some(pose) = pose {
-                            shape.project_point(pose, point, solid)
-                        } else {
-                            shape.project_local_point(point, solid)
-                        }
-                    })?;
-                    let dist = (proj.point - point).length();
-                    Some((dist, proj))
-                },
-            )
-            .unwrap();
-        (best_id, proj)
+    pub fn project_local_point(
+        &self,
+        point: Vector,
+        solid: bool,
+    ) -> Option<(u32, PointProjection)> {
+        let (best_id, (_, proj)) = self.0.bvh().find_best(
+            Real::MAX,
+            |node: &BvhNode, _best_so_far| node.aabb().distance_to_local_point(point, true),
+            |primitive, _best_so_far| {
+                let proj = self.0.map_typed_part_at(primitive, |pose, shape, _| {
+                    if let Some(pose) = pose {
+                        shape.project_point(pose, point, solid)
+                    } else {
+                        shape.project_local_point(point, solid)
+                    }
+                })?;
+                let dist = (proj.point - point).length();
+                Some((dist, proj))
+            },
+        )?;
+        Some((best_id, proj))
     }
 
     /// Project a point on this composite shape.
@@ -88,27 +88,23 @@ impl<S: TypedCompositeShape> CompositeShapeRef<'_, S> {
     pub fn project_local_point_and_get_feature(
         &self,
         point: Vector,
-    ) -> (u32, (PointProjection, FeatureId)) {
-        let (best_id, (_, (proj, feature_id))) = self
-            .0
-            .bvh()
-            .find_best(
-                Real::MAX,
-                |node: &BvhNode, _best_so_far| node.aabb().distance_to_local_point(point, true),
-                |primitive, _best_so_far| {
-                    let proj = self.0.map_typed_part_at(primitive, |pose, shape, _| {
-                        if let Some(pose) = pose {
-                            shape.project_point_and_get_feature(pose, point)
-                        } else {
-                            shape.project_local_point_and_get_feature(point)
-                        }
-                    })?;
-                    let cost = (proj.0.point - point).length();
-                    Some((cost, proj))
-                },
-            )
-            .unwrap();
-        (best_id, (proj, feature_id))
+    ) -> Option<(u32, (PointProjection, FeatureId))> {
+        let (best_id, (_, (proj, feature_id))) = self.0.bvh().find_best(
+            Real::MAX,
+            |node: &BvhNode, _best_so_far| node.aabb().distance_to_local_point(point, true),
+            |primitive, _best_so_far| {
+                let proj = self.0.map_typed_part_at(primitive, |pose, shape, _| {
+                    if let Some(pose) = pose {
+                        shape.project_point_and_get_feature(pose, point)
+                    } else {
+                        shape.project_local_point_and_get_feature(point)
+                    }
+                })?;
+                let cost = (proj.0.point - point).length();
+                Some((cost, proj))
+            },
+        )?;
+        Some((best_id, (proj, feature_id)))
     }
 
     // TODO: implement distance_to_point too?
@@ -136,13 +132,17 @@ impl<S: TypedCompositeShape> CompositeShapeRef<'_, S> {
 impl PointQuery for Polyline {
     #[inline]
     fn project_local_point(&self, point: Vector, solid: bool) -> PointProjection {
-        CompositeShapeRef(self).project_local_point(point, solid).1
+        CompositeShapeRef(self)
+            .project_local_point(point, solid)
+            .unwrap_or_else(|| unreachable!())
+            .1
     }
 
     #[inline]
     fn project_local_point_and_get_feature(&self, point: Vector) -> (PointProjection, FeatureId) {
-        let (seg_id, (proj, feature)) =
-            CompositeShapeRef(self).project_local_point_and_get_feature(point);
+        let (seg_id, (proj, feature)) = CompositeShapeRef(self)
+            .project_local_point_and_get_feature(point)
+            .unwrap_or_else(|| unreachable!());
         let polyline_feature = self.segment_feature_to_polyline_feature(seg_id, feature);
         (proj, polyline_feature)
     }
@@ -160,7 +160,10 @@ impl PointQuery for Polyline {
 impl PointQuery for TriMesh {
     #[inline]
     fn project_local_point(&self, point: Vector, solid: bool) -> PointProjection {
-        CompositeShapeRef(self).project_local_point(point, solid).1
+        CompositeShapeRef(self)
+            .project_local_point(point, solid)
+            .unwrap_or_else(|| unreachable!())
+            .1
     }
 
     #[inline]
@@ -174,7 +177,9 @@ impl PointQuery for TriMesh {
         }
 
         let solid = cfg!(feature = "dim2");
-        let (tri_id, proj) = CompositeShapeRef(self).project_local_point(point, solid);
+        let (tri_id, proj) = CompositeShapeRef(self)
+            .project_local_point(point, solid)
+            .unwrap_or_else(|| unreachable!());
         (proj, FeatureId::Face(tri_id))
     }
 
@@ -211,7 +216,10 @@ impl PointQuery for TriMesh {
 impl PointQuery for Compound {
     #[inline]
     fn project_local_point(&self, point: Vector, solid: bool) -> PointProjection {
-        CompositeShapeRef(self).project_local_point(point, solid).1
+        CompositeShapeRef(self)
+            .project_local_point(point, solid)
+            .unwrap_or_else(|| unreachable!())
+            .1
     }
 
     #[inline]
@@ -219,6 +227,7 @@ impl PointQuery for Compound {
         (
             CompositeShapeRef(self)
                 .project_local_point_and_get_feature(point)
+                .unwrap_or_else(|| unreachable!())
                 .1
                  .0,
             FeatureId::Unknown,

--- a/src/query/point/point_query.rs
+++ b/src/query/point/point_query.rs
@@ -58,17 +58,17 @@ use crate::shape::FeatureId;
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
 pub struct PointProjection {
-    /// Whether the query point was inside the shape.
-    ///
-    /// - `true`: Vector is in the interior (for solid shapes)
-    /// - `false`: Vector is outside the shape
-    pub is_inside: bool,
-
     /// The closest point on the shape's surface to the query point.
     ///
     /// If `is_inside = true`, this is the nearest point on the boundary.
     /// If `is_inside = false`, this is the nearest surface point.
     pub point: Vector,
+
+    /// Whether the query point was inside the shape.
+    ///
+    /// - `true`: Vector is in the interior (for solid shapes)
+    /// - `false`: Vector is outside the shape
+    pub is_inside: bool,
 }
 
 impl PointProjection {

--- a/src/query/point/point_segment.rs
+++ b/src/query/point/point_segment.rs
@@ -1,6 +1,7 @@
 use crate::math::Vector;
 use crate::query::{PointProjection, PointQuery, PointQueryWithLocation};
 use crate::shape::{FeatureId, Segment, SegmentPointLocation};
+use crate::utils::relative_eq_vector;
 
 impl PointQuery for Segment {
     #[inline]
@@ -75,7 +76,7 @@ impl PointQueryWithLocation for Segment {
         }
 
         // TODO: is this acceptable?
-        let inside = relative_eq!(proj, pt);
+        let inside = relative_eq_vector(proj, pt);
 
         (PointProjection::new(inside, proj), location)
     }

--- a/src/query/point/point_triangle.rs
+++ b/src/query/point/point_triangle.rs
@@ -1,6 +1,7 @@
 use crate::math::{Real, Vector, DIM};
 use crate::query::{PointProjection, PointQuery, PointQueryWithLocation};
 use crate::shape::{FeatureId, Triangle, TrianglePointLocation};
+use crate::utils::relative_eq_vector;
 
 #[inline]
 fn compute_result(pt: Vector, proj: Vector) -> PointProjection {
@@ -13,7 +14,8 @@ fn compute_result(pt: Vector, proj: Vector) -> PointProjection {
     {
         // TODO: is this acceptable to assume the point is inside of the
         // triangle if it is close enough?
-        PointProjection::new(relative_eq!(proj, pt), proj)
+        let inside = relative_eq_vector(proj, pt);
+        PointProjection::new(inside, proj)
     }
 }
 

--- a/src/query/point/point_triangle.rs
+++ b/src/query/point/point_triangle.rs
@@ -1,6 +1,7 @@
 use crate::math::{Real, Vector, DIM};
 use crate::query::{PointProjection, PointQuery, PointQueryWithLocation};
 use crate::shape::{FeatureId, Triangle, TrianglePointLocation};
+#[cfg(feature = "dim3")]
 use crate::utils::relative_eq_vector;
 
 #[inline]

--- a/src/query/ray/ray_aabb.rs
+++ b/src/query/ray/ray_aabb.rs
@@ -1,7 +1,7 @@
 use core::mem;
 
 use crate::bounding_volume::Aabb;
-use crate::math::{Real, Vector, DIM};
+use crate::math::{Real, Vector, VectorExt, DIM};
 use crate::query::{Ray, RayCast, RayIntersection};
 use crate::shape::FeatureId;
 use num::Zero;
@@ -12,14 +12,17 @@ impl RayCast for Aabb {
         let mut tmax: Real = max_time_of_impact;
 
         for i in 0usize..DIM {
-            if ray.dir[i].is_zero() {
-                if ray.origin[i] < self.mins[i] || ray.origin[i] > self.maxs[i] {
+            if ray.dir.vget(i).is_zero() {
+                if ray.origin.vget(i) < self.mins.vget(i) || ray.origin.vget(i) > self.maxs.vget(i)
+                {
                     return None;
                 }
             } else {
-                let denom = 1.0 / ray.dir[i];
-                let mut inter_with_near_halfspace = (self.mins[i] - ray.origin[i]) * denom;
-                let mut inter_with_far_halfspace = (self.maxs[i] - ray.origin[i]) * denom;
+                let denom = 1.0 / ray.dir.vget(i);
+                let mut inter_with_near_halfspace =
+                    (self.mins.vget(i) - ray.origin.vget(i)) * denom;
+                let mut inter_with_far_halfspace =
+                    (self.maxs.vget(i) - ray.origin.vget(i)) * denom;
 
                 if inter_with_near_halfspace > inter_with_far_halfspace {
                     mem::swap(

--- a/src/query/ray/ray_aabb.rs
+++ b/src/query/ray/ray_aabb.rs
@@ -21,8 +21,7 @@ impl RayCast for Aabb {
                 let denom = 1.0 / ray.dir.vget(i);
                 let mut inter_with_near_halfspace =
                     (self.mins.vget(i) - ray.origin.vget(i)) * denom;
-                let mut inter_with_far_halfspace =
-                    (self.maxs.vget(i) - ray.origin.vget(i)) * denom;
+                let mut inter_with_far_halfspace = (self.maxs.vget(i) - ray.origin.vget(i)) * denom;
 
                 if inter_with_near_halfspace > inter_with_far_halfspace {
                     mem::swap(

--- a/src/query/ray/ray_aabb.rs
+++ b/src/query/ray/ray_aabb.rs
@@ -57,7 +57,12 @@ impl RayCast for Aabb {
         solid: bool,
     ) -> Option<RayIntersection> {
         ray_aabb(self, ray, max_time_of_impact, solid).map(|(t, n, i)| {
-            let feature = if i < 0 {
+            // NOTE: `i` is the side of the AABB that was hit, as an integer in `[-DIM, DIM]`.
+            //       The special value `0` indicates that the ray direction is zero/NaN and its
+            //       origin lies inside the AABB; in that case there is no specific face hit.
+            let feature = if i == 0 {
+                FeatureId::Unknown
+            } else if i < 0 {
                 FeatureId::Face((-i) as u32 - 1 + 3)
             } else {
                 FeatureId::Face(i as u32 - 1)
@@ -90,4 +95,26 @@ fn ray_aabb(
             None
         }
     })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Regression test for <https://github.com/dimforge/parry/issues/383>:
+    /// casting a ray with a zero direction starting inside an AABB used to panic with
+    /// "attempt to subtract with overflow" while computing the hit feature id.
+    #[test]
+    fn cast_zero_dir_ray_from_inside_aabb_does_not_overflow() {
+        let aabb = Aabb::new(-Vector::splat(1.0), Vector::splat(1.0));
+        let ray = Ray::new(Vector::ZERO, Vector::ZERO);
+
+        // Both `solid` and non-`solid` variants must not panic.
+        let solid = aabb.cast_local_ray_and_get_normal(&ray, 100.0, true);
+        let hollow = aabb.cast_local_ray_and_get_normal(&ray, 100.0, false);
+
+        assert!(solid.is_some());
+        assert!(hollow.is_some());
+        assert_eq!(solid.unwrap().feature, FeatureId::Unknown);
+    }
 }

--- a/src/query/ray/ray_voxels.rs
+++ b/src/query/ray/ray_voxels.rs
@@ -1,4 +1,4 @@
-use crate::math::{Real, Vector};
+use crate::math::{IVectorExt, Real, Vector, VectorExt};
 use crate::partitioning::BvhNode;
 use crate::query::{Ray, RayCast, RayIntersection};
 use crate::shape::{FeatureId, Voxels, VoxelsChunkRef};
@@ -76,15 +76,15 @@ impl<'a> RayCast for VoxelsChunkRef<'a> {
              * Find the next voxel to cast the ray on.
              */
             let toi = ii.map(|i| {
-                if ray.dir[i] > 0.0 {
-                    let t = (aabb.maxs[i] - ray.origin[i]) / ray.dir[i];
+                if ray.dir.vget(i) > 0.0 {
+                    let t = (aabb.maxs.vget(i) - ray.origin.vget(i)) / ray.dir.vget(i);
                     if t < 0.0 {
                         (Real::max_value(), true)
                     } else {
                         (t, true)
                     }
-                } else if ray.dir[i] < 0.0 {
-                    let t = (aabb.mins[i] - ray.origin[i]) / ray.dir[i];
+                } else if ray.dir.vget(i) < 0.0 {
+                    let t = (aabb.mins.vget(i) - ray.origin.vget(i)) / ray.dir.vget(i);
                     if t < 0.0 {
                         (Real::max_value(), false)
                     } else {
@@ -108,14 +108,14 @@ impl<'a> RayCast for VoxelsChunkRef<'a> {
             let imin = Vector::from(toi.map(|t| t.0)).min_position();
 
             if toi[imin].1 {
-                if voxel_key[imin] < domain_maxs[imin] - 1 {
-                    voxel_key[imin] += 1;
+                if voxel_key.ivget(imin) < domain_maxs.ivget(imin) - 1 {
+                    voxel_key.ivset(imin, voxel_key.ivget(imin) + 1);
                 } else {
-                    // Leaving the shape’s bounds.
+                    // Leaving the shape's bounds.
                     break;
                 }
-            } else if voxel_key[imin] > domain_mins[imin] {
-                voxel_key[imin] -= 1;
+            } else if voxel_key.ivget(imin) > domain_mins.ivget(imin) {
+                voxel_key.ivset(imin, voxel_key.ivget(imin) - 1);
             } else {
                 // Leaving the shape’s bounds.
                 break;

--- a/src/query/sat/sat_cuboid_cuboid.rs
+++ b/src/query/sat/sat_cuboid_cuboid.rs
@@ -262,12 +262,12 @@ pub fn cuboid_cuboid_find_local_separating_normal_oneway(
 
     for i in 0..DIM {
         #[expect(clippy::unnecessary_cast)]
-        let sign = (1.0 as Real).copysign(pos12.translation[i]);
+        let sign = (1.0 as Real).copysign(pos12.translation.vget(i));
         let axis1 = Vector::ith(i, sign);
         let axis2 = pos12.rotation.inverse() * -axis1;
         let local_pt2 = cuboid2.local_support_point(axis2);
         let pt2 = pos12 * local_pt2;
-        let separation = pt2[i] * sign - cuboid1.half_extents[i];
+        let separation = pt2.vget(i) * sign - cuboid1.half_extents.vget(i);
 
         if separation > best_separation {
             best_separation = separation;

--- a/src/query/sat/sat_cuboid_cuboid.rs
+++ b/src/query/sat/sat_cuboid_cuboid.rs
@@ -1,5 +1,6 @@
 use crate::math::{Pose, Real, Vector, VectorExt, DIM};
 use crate::shape::{Cuboid, SupportMap};
+use crate::utils::WSign;
 
 /// Computes the separation distance between two cuboids along a given axis.
 ///
@@ -63,7 +64,7 @@ pub fn cuboid_cuboid_compute_separation_wrt_local_line(
     axis1: Vector,
 ) -> (Real, Vector) {
     #[expect(clippy::unnecessary_cast)]
-    let signum = (1.0 as Real).copysign(pos12.translation.dot(axis1));
+    let signum = pos12.translation.dot(axis1).copy_sign_to(1.0 as Real);
     let axis1 = axis1 * signum;
     let axis2 = pos12.rotation.inverse() * -axis1;
     let local_pt1 = cuboid1.local_support_point(axis1);
@@ -262,7 +263,7 @@ pub fn cuboid_cuboid_find_local_separating_normal_oneway(
 
     for i in 0..DIM {
         #[expect(clippy::unnecessary_cast)]
-        let sign = (1.0 as Real).copysign(pos12.translation.vget(i));
+        let sign = pos12.translation.vget(i).copy_sign_to(1.0 as Real);
         let axis1 = Vector::ith(i, sign);
         let axis2 = pos12.rotation.inverse() * -axis1;
         let local_pt2 = cuboid2.local_support_point(axis2);

--- a/src/query/sat/sat_cuboid_support_map.rs
+++ b/src/query/sat/sat_cuboid_support_map.rs
@@ -261,7 +261,7 @@ pub fn cuboid_support_map_find_local_separating_normal_oneway<S: SupportMap>(
         for sign in &[-1.0, 1.0] {
             let axis1 = Vector::ith(i, *sign);
             let pt2 = shape2.support_point_toward(pos12, -axis1);
-            let separation = pt2[i] * *sign - cube1.half_extents[i];
+            let separation = pt2.vget(i) * *sign - cube1.half_extents.vget(i);
 
             if separation > best_separation {
                 best_separation = separation;

--- a/src/query/shape_cast/shape_cast_ball_ball.rs
+++ b/src/query/shape_cast/shape_cast_ball_ball.rs
@@ -43,7 +43,7 @@ pub fn cast_shapes_ball_ball(
             witness2 = normal2 * b2.radius;
         }
 
-        if !options.stop_at_penetration && time_of_impact < 1.0e-5 && normal1.dot(vel12) >= 0.0 {
+        if !options.stop_at_penetration && time_of_impact < 1.0e-4 && normal1.dot(vel12) >= 0.0 {
             return None;
         }
 

--- a/src/query/shape_cast/shape_cast_support_map_support_map.rs
+++ b/src/query/shape_cast/shape_cast_support_map_support_map.rs
@@ -32,8 +32,13 @@ where
         if time_of_impact > options.max_time_of_impact {
             None
         } else if (options.compute_impact_geometry_on_penetration || !options.stop_at_penetration)
-            && time_of_impact < 1.0e-5
+            && time_of_impact < 1.0e-4
         {
+            // The GJK-derived normal becomes unreliable for very small TOIs — typically
+            // when the cast starts at (or very close to) the `target_distance` boundary
+            // with a direction nearly tangent to the contact. Fall back on the contact
+            // query, which gives a robust closest-point normal and lets us detect the
+            // case where the cast direction is actually moving away from the contact.
             let contact = details::contact_support_map_support_map(pos12, g1, g2, Real::MAX)?;
             let normal_vel = contact.normal1.dot(vel12);
 

--- a/src/query/shape_cast/shape_cast_voxels_shape.rs
+++ b/src/query/shape_cast/shape_cast_voxels_shape.rs
@@ -1,4 +1,4 @@
-use crate::math::{IVector, Pose, Real, Vector};
+use crate::math::{IVector, IVectorExt, Pose, Real, Vector, VectorExt};
 use crate::query::{QueryDispatcher, ShapeCastHit, ShapeCastOptions};
 use crate::shape::{Cuboid, Shape, Voxels};
 
@@ -57,15 +57,17 @@ where
         let ii = [0, 1, 2];
 
         let toi = ii.map(|i| {
-            if vel12[i] > 0.0 {
-                let t = (search_domain_aabb.maxs[i] - start_aabb2_1.maxs[i]) / vel12[i];
+            if vel12.vget(i) > 0.0 {
+                let t = (search_domain_aabb.maxs.vget(i) - start_aabb2_1.maxs.vget(i))
+                    / vel12.vget(i);
                 if t < 0.0 {
                     (Real::max_value(), true)
                 } else {
                     (t, true)
                 }
-            } else if vel12[i] < 0.0 {
-                let t = (search_domain_aabb.mins[i] - start_aabb2_1.mins[i]) / vel12[i];
+            } else if vel12.vget(i) < 0.0 {
+                let t = (search_domain_aabb.mins.vget(i) - start_aabb2_1.mins.vget(i))
+                    / vel12.vget(i);
                 if t < 0.0 {
                     (Real::max_value(), false)
                 } else {
@@ -92,33 +94,33 @@ where
         let imin = Vector::from(toi.map(|t| t.0)).min_position();
 
         if toi[imin].1 {
-            search_domain[0][imin] += 1;
-            search_domain[1][imin] += 1;
+            search_domain[0].ivset(imin, search_domain[0].ivget(imin) + 1);
+            search_domain[1].ivset(imin, search_domain[1].ivget(imin) + 1);
 
-            if search_domain[1][imin] <= domain_maxs[imin] {
+            if search_domain[1].ivget(imin) <= domain_maxs.ivget(imin) {
                 // Check the voxels on the added row.
                 let mut prev_row = search_domain[0];
-                prev_row[imin] = search_domain[1][imin] - 1;
+                prev_row.ivset(imin, search_domain[1].ivget(imin) - 1);
 
                 let range_to_check = [prev_row, search_domain[1]];
                 check_voxels_in_range(range_to_check);
-            } else if search_domain[0][imin] >= domain_maxs[imin] {
-                // Leaving the shape’s bounds.
+            } else if search_domain[0].ivget(imin) >= domain_maxs.ivget(imin) {
+                // Leaving the shape's bounds.
                 break;
             }
         } else {
-            search_domain[0][imin] -= 1;
-            search_domain[1][imin] -= 1;
+            search_domain[0].ivset(imin, search_domain[0].ivget(imin) - 1);
+            search_domain[1].ivset(imin, search_domain[1].ivget(imin) - 1);
 
-            if search_domain[0][imin] >= domain_mins[imin] {
+            if search_domain[0].ivget(imin) >= domain_mins.ivget(imin) {
                 // Check the voxels on the added row.
                 let mut next_row = search_domain[1];
-                next_row[imin] = search_domain[0][imin] + 1;
+                next_row.ivset(imin, search_domain[0].ivget(imin) + 1);
 
                 let range_to_check = [search_domain[0], next_row];
                 check_voxels_in_range(range_to_check);
-            } else if search_domain[1][imin] <= domain_mins[imin] {
-                // Leaving the shape’s bounds.
+            } else if search_domain[1].ivget(imin) <= domain_mins.ivget(imin) {
+                // Leaving the shape's bounds.
                 break;
             }
         }

--- a/src/query/shape_cast/shape_cast_voxels_shape.rs
+++ b/src/query/shape_cast/shape_cast_voxels_shape.rs
@@ -58,16 +58,16 @@ where
 
         let toi = ii.map(|i| {
             if vel12.vget(i) > 0.0 {
-                let t = (search_domain_aabb.maxs.vget(i) - start_aabb2_1.maxs.vget(i))
-                    / vel12.vget(i);
+                let t =
+                    (search_domain_aabb.maxs.vget(i) - start_aabb2_1.maxs.vget(i)) / vel12.vget(i);
                 if t < 0.0 {
                     (Real::max_value(), true)
                 } else {
                     (t, true)
                 }
             } else if vel12.vget(i) < 0.0 {
-                let t = (search_domain_aabb.mins.vget(i) - start_aabb2_1.mins.vget(i))
-                    / vel12.vget(i);
+                let t =
+                    (search_domain_aabb.mins.vget(i) - start_aabb2_1.mins.vget(i)) / vel12.vget(i);
                 if t < 0.0 {
                     (Real::max_value(), false)
                 } else {

--- a/src/query/split/split_aabb.rs
+++ b/src/query/split/split_aabb.rs
@@ -1,5 +1,5 @@
 use crate::bounding_volume::Aabb;
-use crate::math::Real;
+use crate::math::{Real, VectorExt};
 use crate::query::SplitResult;
 
 impl Aabb {
@@ -14,15 +14,15 @@ impl Aabb {
     /// half-space delimited by the splitting plane. The second `Aabb` returned is the piece lying on the
     /// positive half-space delimited by the splitting plane.
     pub fn canonical_split(&self, axis: usize, bias: Real, epsilon: Real) -> SplitResult<Self> {
-        if self.mins[axis] >= bias - epsilon {
+        if self.mins.vget(axis) >= bias - epsilon {
             SplitResult::Positive
-        } else if self.maxs[axis] <= bias + epsilon {
+        } else if self.maxs.vget(axis) <= bias + epsilon {
             SplitResult::Negative
         } else {
             let mut left = *self;
             let mut right = *self;
-            left.maxs[axis] = bias;
-            right.mins[axis] = bias;
+            left.maxs.vset(axis, bias);
+            right.mins.vset(axis, bias);
             SplitResult::Pair(left, right)
         }
     }

--- a/src/query/split/split_trimesh.rs
+++ b/src/query/split/split_trimesh.rs
@@ -577,6 +577,14 @@ impl TriMesh {
                 let mut next = neighbors.first(); // Arbitrary neighbor
 
                 'traversal: while let Some(current) = next {
+                    // If we reach an already-visited index, the traversal cannot make any
+                    // further progress: stop here instead of looping forever. This guards
+                    // against degenerate adjacency graphs that don't form a clean loop back
+                    // to `first`.
+                    if seen[*current] {
+                        break;
+                    }
+
                     seen[*current] = true;
                     polyline_indices.push([prev as u32, *current as u32]);
 

--- a/src/shape/cone.rs
+++ b/src/shape/cone.rs
@@ -1,8 +1,8 @@
 //! Support mapping based Cone shape.
 
 use crate::math::{Real, Vector};
-use crate::utils::WSign;
 use crate::shape::SupportMap;
+use crate::utils::WSign;
 
 #[cfg(feature = "alloc")]
 use either::Either;

--- a/src/shape/cone.rs
+++ b/src/shape/cone.rs
@@ -152,19 +152,19 @@ impl SupportMap for Cone {
     fn local_support_point(&self, dir: Vector) -> Vector {
         let mut vres = dir;
 
-        vres[1] = 0.0;
+        vres.y = 0.0;
         let (mut vres, length) = vres.normalize_and_length();
 
         if length == 0.0 {
             vres = Vector::ZERO;
-            vres[1] = self.half_height.copysign(dir[1]);
+            vres.y = self.half_height.copysign(dir.y);
         } else {
             vres *= self.radius;
-            vres[1] = -self.half_height;
+            vres.y = -self.half_height;
 
-            if dir.dot(vres) < dir[1] * self.half_height {
+            if dir.dot(vres) < dir.y * self.half_height {
                 vres = Vector::ZERO;
-                vres[1] = self.half_height
+                vres.y = self.half_height
             }
         }
 

--- a/src/shape/cone.rs
+++ b/src/shape/cone.rs
@@ -1,6 +1,7 @@
 //! Support mapping based Cone shape.
 
 use crate::math::{Real, Vector};
+use crate::utils::WSign;
 use crate::shape::SupportMap;
 
 #[cfg(feature = "alloc")]
@@ -157,7 +158,7 @@ impl SupportMap for Cone {
 
         if length == 0.0 {
             vres = Vector::ZERO;
-            vres.y = self.half_height.copysign(dir.y);
+            vres.y = dir.y.copy_sign_to(self.half_height);
         } else {
             vres *= self.radius;
             vres.y = -self.half_height;

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -188,13 +188,13 @@ impl Cuboid {
         let vertices = match i {
             0 =>
                 [
-                    Vector::new(he.x, he.y.copysign(local_dir.y)),
-                    Vector::new(-he.x, he.y.copysign(local_dir.y))
+                    Vector::new(he.x, local_dir.y.copy_sign_to(he.y)),
+                    Vector::new(-he.x, local_dir.y.copy_sign_to(he.y))
                 ],
             _ =>
                 [
-                    Vector::new(he.x.copysign(local_dir.x), he.y),
-                    Vector::new(he.x.copysign(local_dir.x), -he.y)
+                    Vector::new(local_dir.x.copy_sign_to(he.x), he.y),
+                    Vector::new(local_dir.x.copy_sign_to(he.x), -he.y)
                 ]
         };
 
@@ -256,8 +256,8 @@ impl Cuboid {
         let k = (i + 2) % 3;
         let mut a = Vector::ZERO;
         a.vset(i, he.vget(i));
-        a.vset(j, he.vget(j).copysign(local_dir.vget(j)));
-        a.vset(k, he.vget(k).copysign(local_dir.vget(k)));
+        a.vset(j, local_dir.vget(j).copy_sign_to(he.vget(j)));
+        a.vset(k, local_dir.vget(k).copy_sign_to(he.vget(k)));
 
         let mut b = a;
         b.vset(i, -he.vget(i));
@@ -274,9 +274,9 @@ impl Cuboid {
         let imax = local_dir.abs().max_position();
         #[expect(clippy::unnecessary_cast)]
         let sign = match imax {
-            0 => (1.0 as Real).copysign(local_dir.x),
-            1 => (1.0 as Real).copysign(local_dir.y),
-            2 => (1.0 as Real).copysign(local_dir.z),
+            0 => local_dir.x.copy_sign_to(1.0 as Real),
+            1 => local_dir.y.copy_sign_to(1.0 as Real),
+            2 => local_dir.z.copy_sign_to(1.0 as Real),
             _ => unreachable!(),
         };
 

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -186,16 +186,14 @@ impl Cuboid {
         let i = local_dir.abs().min_position();
 
         let vertices = match i {
-            0 =>
-                [
-                    Vector::new(he.x, local_dir.y.copy_sign_to(he.y)),
-                    Vector::new(-he.x, local_dir.y.copy_sign_to(he.y))
-                ],
-            _ =>
-                [
-                    Vector::new(local_dir.x.copy_sign_to(he.x), he.y),
-                    Vector::new(local_dir.x.copy_sign_to(he.x), -he.y)
-                ]
+            0 => [
+                Vector::new(he.x, local_dir.y.copy_sign_to(he.y)),
+                Vector::new(-he.x, local_dir.y.copy_sign_to(he.y)),
+            ],
+            _ => [
+                Vector::new(local_dir.x.copy_sign_to(he.x), he.y),
+                Vector::new(local_dir.x.copy_sign_to(he.x), -he.y),
+            ],
         };
 
         let vid1 = Self::vertex_feature_id(vertices[0]);

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "dim3")]
 use crate::math::Real;
-use crate::math::Vector;
+use crate::math::{Vector, VectorExt};
 #[cfg(feature = "dim3")]
 use crate::shape::Segment;
 use crate::shape::{FeatureId, PackedFeatureId, PolygonalFeature, SupportMap};
@@ -184,20 +184,26 @@ impl Cuboid {
     pub fn support_face(&self, local_dir: Vector) -> PolygonalFeature {
         let he = self.half_extents;
         let i = local_dir.abs().min_position();
-        let j = (i + 1) % 2;
-        let mut a = Vector::ZERO;
-        a[i] = he[i];
-        a[j] = he[j].copysign(local_dir[j]);
 
-        let mut b = a;
-        b[i] = -he[i];
+        let vertices = match i {
+            0 =>
+                [
+                    Vector::new(he.x, he.y.copysign(local_dir.y)),
+                    Vector::new(-he.x, he.y.copysign(local_dir.y))
+                ],
+            _ =>
+                [
+                    Vector::new(he.x.copysign(local_dir.x), he.y),
+                    Vector::new(he.x.copysign(local_dir.x), -he.y)
+                ]
+        };
 
-        let vid1 = Self::vertex_feature_id(a);
-        let vid2 = Self::vertex_feature_id(b);
+        let vid1 = Self::vertex_feature_id(vertices[0]);
+        let vid2 = Self::vertex_feature_id(vertices[1]);
         let fid = (vid1.max(vid2) << 2) | vid1.min(vid2) | 0b11_00_00;
 
         PolygonalFeature {
-            vertices: [a, b],
+            vertices,
             vids: PackedFeatureId::vertices([vid1, vid2]),
             fid: PackedFeatureId::face(fid),
             num_vertices: 2,
@@ -249,12 +255,12 @@ impl Cuboid {
         let j = (i + 1) % 3;
         let k = (i + 2) % 3;
         let mut a = Vector::ZERO;
-        a[i] = he[i];
-        a[j] = he[j].copysign(local_dir[j]);
-        a[k] = he[k].copysign(local_dir[k]);
+        a.vset(i, he.vget(i));
+        a.vset(j, he.vget(j).copysign(local_dir.vget(j)));
+        a.vset(k, he.vget(k).copysign(local_dir.vget(k)));
 
         let mut b = a;
-        b[i] = -he[i];
+        b.vset(i, -he.vget(i));
 
         Segment::new(a, b)
     }
@@ -267,7 +273,12 @@ impl Cuboid {
         let he = self.half_extents;
         let imax = local_dir.abs().max_position();
         #[expect(clippy::unnecessary_cast)]
-        let sign = (1.0 as Real).copysign(local_dir[imax]);
+        let sign = match imax {
+            0 => (1.0 as Real).copysign(local_dir.x),
+            1 => (1.0 as Real).copysign(local_dir.y),
+            2 => (1.0 as Real).copysign(local_dir.z),
+            _ => unreachable!(),
+        };
 
         let vertices = match imax {
             0 => [
@@ -358,9 +369,9 @@ impl Cuboid {
                 let mut dir: Vector = Vector::ZERO;
 
                 if id < 2 {
-                    dir[id as usize] = 1.0;
+                    dir.vset(id as usize, 1.0);
                 } else {
-                    dir[id as usize - 2] = -1.0;
+                    dir.vset(id as usize - 2, -1.0);
                 }
                 Some(dir)
             }
@@ -369,20 +380,20 @@ impl Cuboid {
 
                 match id {
                     0b00 => {
-                        dir[0] = 1.0;
-                        dir[1] = 1.0;
+                        dir.x = 1.0;
+                        dir.y = 1.0;
                     }
                     0b01 => {
-                        dir[1] = 1.0;
-                        dir[0] = -1.0;
+                        dir.y = 1.0;
+                        dir.x = -1.0;
                     }
                     0b11 => {
-                        dir[0] = -1.0;
-                        dir[1] = -1.0;
+                        dir.x = -1.0;
+                        dir.y = -1.0;
                     }
                     0b10 => {
-                        dir[1] = -1.0;
-                        dir[0] = 1.0;
+                        dir.y = -1.0;
+                        dir.x = 1.0;
                     }
                     _ => return None,
                 }
@@ -401,9 +412,9 @@ impl Cuboid {
                 let mut dir: Vector = Vector::ZERO;
 
                 if id < 3 {
-                    dir[id as usize] = 1.0;
+                    dir.vset(id as usize, 1.0);
                 } else {
-                    dir[id as usize - 3] = -1.0;
+                    dir.vset(id as usize - 3, -1.0);
                 }
                 Some(dir)
             }
@@ -416,15 +427,15 @@ impl Cuboid {
                 let mut dir: Vector = Vector::ZERO;
 
                 if signs & (1 << face1) != 0 {
-                    dir[face1 as usize] = -1.0
+                    dir.vset(face1 as usize, -1.0)
                 } else {
-                    dir[face1 as usize] = 1.0
+                    dir.vset(face1 as usize, 1.0)
                 }
 
                 if signs & (1 << face2) != 0 {
-                    dir[face2 as usize] = -1.0
+                    dir.vset(face2 as usize, -1.0)
                 } else {
-                    dir[face2 as usize] = 1.0;
+                    dir.vset(face2 as usize, 1.0);
                 }
 
                 Some(dir.normalize())
@@ -433,9 +444,9 @@ impl Cuboid {
                 let mut dir: Vector = Vector::ZERO;
                 for i in 0..3 {
                     if id & (1 << i) != 0 {
-                        dir[i] = -1.0;
+                        dir.vset(i, -1.0);
                     } else {
-                        dir[i] = 1.0
+                        dir.vset(i, 1.0)
                     }
                 }
 
@@ -461,11 +472,11 @@ impl ConvexPolyhedron for Cuboid {
 
         for i in 0..DIM {
             if vid & (1 << i) != 0 {
-                res[i] = -res[i]
+                res.vset(i, -res.vget(i))
             }
         }
 
-        Vector::from(res)
+        res
     }
 
     #[cfg(feature = "dim3")]
@@ -478,13 +489,13 @@ impl ConvexPolyhedron for Cuboid {
 
         for i in 0..DIM {
             if i as u32 != edge_i && (vertex_i & (1 << i) != 0) {
-                res[i] = -res[i]
+                res.vset(i, -res.vget(i))
             }
         }
 
-        let p1 = Vector::from(res);
-        res[edge_i as usize] = -res[edge_i as usize];
-        let p2 = Vector::from(res);
+        let p1 = res;
+        res.vset(edge_i as usize, -res.vget(edge_i as usize));
+        let p2 = res;
         let vid1 = FeatureId::Vertex(vertex_i & !(1 << edge_i));
         let vid2 = FeatureId::Vertex(vertex_i | (1 << edge_i));
 
@@ -511,12 +522,12 @@ impl ConvexPolyhedron for Cuboid {
             let i2 = (i1 + 1) % 2;
 
             let mut vertex = self.half_extents;
-            vertex[i1] *= sign;
-            vertex[i2] *= if i1 == 0 { -sign } else { sign };
+            vertex.vset(i1, vertex.vget(i1) * sign);
+            vertex.vset(i2, vertex.vget(i2) * if i1 == 0 { -sign } else { sign });
 
-            let p1 = Vector::from(vertex);
-            vertex[i2] = -vertex[i2];
-            let p2 = Vector::from(vertex);
+            let p1 = vertex;
+            vertex.vset(i2, -vertex.vget(i2));
+            let p2 = vertex;
 
             let mut vertex_id1 = if sign < 0.0 {
                 1 << i1
@@ -524,7 +535,7 @@ impl ConvexPolyhedron for Cuboid {
                 0
             };
             let mut vertex_id2 = vertex_id1;
-            if p1[i2] < 0.0 {
+            if p1.vget(i2) < 0.0 {
                 vertex_id1 |= 1 << i2;
             } else {
                 vertex_id2 |= 1 << i2;
@@ -534,7 +545,7 @@ impl ConvexPolyhedron for Cuboid {
             out.push(p2, FeatureId::Vertex(vertex_id2));
 
             let mut normal: Vector = Vector::ZERO;
-            normal[i1] = sign;
+            normal.vset(i1, sign);
             out.set_normal(normal);
             out.set_feature_id(FeatureId::Face(i as u32));
         }
@@ -550,7 +561,7 @@ impl ConvexPolyhedron for Cuboid {
             let mask_i2 = !(1 << edge_i2); // The masks are for ensuring each edge has a unique ID.
             let mask_i3 = !(1 << edge_i3);
             let mut vertex = self.half_extents;
-            vertex[i1] *= sign;
+            vertex.vset(i1, vertex.vget(i1) * sign);
 
             let (sbit, msbit) = if sign < 0.0 {
                 (1, 0)
@@ -558,37 +569,37 @@ impl ConvexPolyhedron for Cuboid {
                 (0, 1)
             };
             let mut vertex_id = sbit << i1;
-            out.push(Vector::from(vertex), FeatureId::Vertex(vertex_id));
+            out.push(vertex, FeatureId::Vertex(vertex_id));
             out.push_edge_feature_id(FeatureId::Edge(
                 edge_i2 as u32 | ((vertex_id & mask_i2) << 2),
             ));
 
-            vertex[i2] = -sign * self.half_extents[i2];
-            vertex[i3] = sign * self.half_extents[i3];
+            vertex.vset(i2, -sign * self.half_extents.vget(i2));
+            vertex.vset(i3, sign * self.half_extents.vget(i3));
             vertex_id |= msbit << i2 | sbit << i3;
-            out.push(Vector::from(vertex), FeatureId::Vertex(vertex_id));
+            out.push(vertex, FeatureId::Vertex(vertex_id));
             out.push_edge_feature_id(FeatureId::Edge(
                 edge_i3 as u32 | ((vertex_id & mask_i3) << 2),
             ));
 
-            vertex[i2] = -self.half_extents[i2];
-            vertex[i3] = -self.half_extents[i3];
+            vertex.vset(i2, -self.half_extents.vget(i2));
+            vertex.vset(i3, -self.half_extents.vget(i3));
             vertex_id |= 1 << i2 | 1 << i3;
-            out.push(Vector::from(vertex), FeatureId::Vertex(vertex_id));
+            out.push(vertex, FeatureId::Vertex(vertex_id));
             out.push_edge_feature_id(FeatureId::Edge(
                 edge_i2 as u32 | ((vertex_id & mask_i2) << 2),
             ));
 
-            vertex[i2] = sign * self.half_extents[i2];
-            vertex[i3] = -sign * self.half_extents[i3];
+            vertex.vset(i2, sign * self.half_extents.vget(i2));
+            vertex.vset(i3, -sign * self.half_extents.vget(i3));
             vertex_id = sbit << i1 | sbit << i2 | msbit << i3;
-            out.push(Vector::from(vertex), FeatureId::Vertex(vertex_id));
+            out.push(vertex, FeatureId::Vertex(vertex_id));
             out.push_edge_feature_id(FeatureId::Edge(
                 edge_i3 as u32 | ((vertex_id & mask_i3) << 2),
             ));
 
             let mut normal: Vector = Vector::ZERO;
-            normal[i1] = sign;
+            normal.vset(i1, sign);
             out.set_normal(normal);
 
             if sign > 0.0 {
@@ -611,7 +622,7 @@ impl ConvexPolyhedron for Cuboid {
         let local_dir = m.inverse_transform_vector(dir);
         let imax = iamax(local_dir);
 
-        if local_dir[imax] > 0.0 {
+        if local_dir.vget(imax) > 0.0 {
             self.face(FeatureId::Face(imax as u32), out);
             out.transform_by(m);
         } else {
@@ -637,8 +648,8 @@ impl ConvexPolyhedron for Cuboid {
         {
             let mut support_point_id = 0;
             for i1 in 0..2 {
-                let sign = local_dir[i1].signum();
-                if sign * local_dir[i1] >= cang {
+                let sign = local_dir.vget(i1).signum();
+                if sign * local_dir.vget(i1) >= cang {
                     if sign > 0.0 {
                         self.face(FeatureId::Face(i1 as u32), out);
                         out.transform_by(m);
@@ -651,13 +662,13 @@ impl ConvexPolyhedron for Cuboid {
                     if sign < 0.0 {
                         support_point_id |= 1 << i1;
                     }
-                    support_point[i1] *= sign;
+                    support_point.vset(i1, support_point.vget(i1) * sign);
                 }
             }
 
             // We are not on a face, return the support vertex.
             out.push(
-                m * Vector::from(support_point),
+                m * support_point,
                 FeatureId::Vertex(support_point_id),
             );
             out.set_feature_id(FeatureId::Vertex(support_point_id));
@@ -670,8 +681,8 @@ impl ConvexPolyhedron for Cuboid {
 
             // Check faces.
             for i1 in 0..3 {
-                let sign = local_dir[i1].signum();
-                if sign * local_dir[i1] >= cang {
+                let sign = local_dir.vget(i1).signum();
+                if sign * local_dir.vget(i1) >= cang {
                     if sign > 0.0 {
                         self.face(FeatureId::Face(i1 as u32), out);
                         out.transform_by(m);
@@ -682,7 +693,7 @@ impl ConvexPolyhedron for Cuboid {
                     return;
                 } else {
                     if sign < 0.0 {
-                        support_point[i1] *= sign;
+                        support_point.vset(i1, support_point.vget(i1) * sign);
                         support_point_id |= 1 << i1;
                     }
                 }
@@ -690,14 +701,14 @@ impl ConvexPolyhedron for Cuboid {
 
             // Check edges.
             for i in 0..3 {
-                let sign = local_dir[i].signum();
+                let sign = local_dir.vget(i).signum();
 
-                // sign * local_dir[i] <= cos(pi / 2 - angle)
-                if sign * local_dir[i] <= sang {
-                    support_point[i] = -self.half_extents[i];
-                    let p1 = Vector::from(support_point);
-                    support_point[i] = self.half_extents[i];
-                    let p2 = Vector::from(support_point);
+                // sign * local_dir.vget(i) <= cos(pi / 2 - angle)
+                if sign * local_dir.vget(i) <= sang {
+                    support_point.vset(i, -self.half_extents.vget(i));
+                    let p1 = support_point;
+                    support_point.vset(i, self.half_extents.vget(i));
+                    let p2 = support_point;
                     let p2_id = support_point_id & !(1 << i);
                     out.push(m * p1, FeatureId::Vertex(support_point_id | (1 << i)));
                     out.push(m * p2, FeatureId::Vertex(p2_id));
@@ -711,7 +722,7 @@ impl ConvexPolyhedron for Cuboid {
 
             // We are not on a face or edge, return the support vertex.
             out.push(
-                m * Vector::from(support_point),
+                m * support_point,
                 FeatureId::Vertex(support_point_id),
             );
             out.set_feature_id(FeatureId::Vertex(support_point_id));
@@ -726,8 +737,8 @@ impl ConvexPolyhedron for Cuboid {
         {
             let mut support_point_id = 0;
             for i1 in 0..2 {
-                let sign = local_dir[i1].signum();
-                if sign * local_dir[i1] >= cang {
+                let sign = local_dir.vget(i1).signum();
+                if sign * local_dir.vget(i1) >= cang {
                     if sign > 0.0 {
                         return FeatureId::Face(i1 as u32);
                     } else {
@@ -751,8 +762,8 @@ impl ConvexPolyhedron for Cuboid {
 
             // Check faces.
             for i1 in 0..3 {
-                let sign = local_dir[i1].signum();
-                if sign * local_dir[i1] >= cang {
+                let sign = local_dir.vget(i1).signum();
+                if sign * local_dir.vget(i1) >= cang {
                     if sign > 0.0 {
                         return FeatureId::Face(i1 as u32);
                     } else {
@@ -767,10 +778,10 @@ impl ConvexPolyhedron for Cuboid {
 
             // Check edges.
             for i in 0..3 {
-                let sign = local_dir[i].signum();
+                let sign = local_dir.vget(i).signum();
 
-                // sign * local_dir[i] <= cos(pi / 2 - angle)
-                if sign * local_dir[i] <= sang {
+                // sign * local_dir.vget(i) <= cos(pi / 2 - angle)
+                if sign * local_dir.vget(i) <= sang {
                     let mask_i = !(1 << i); // To ensure each edge has a unique id.
                     return FeatureId::Edge(i as u32 | ((support_point_id & mask_i) << 2));
                 }

--- a/src/shape/cuboid.rs
+++ b/src/shape/cuboid.rs
@@ -296,7 +296,7 @@ impl Cuboid {
             i * 2
         }
 
-        let sign_index = ((sign as i8 + 1) / 2) as usize;
+        let sign_index = ((sign as isize + 1) / 2) as usize;
         // The vertex id as numbered depending on the sign of the vertex
         // component. A + sign means the corresponding bit is 0 while a -
         // sign means the corresponding bit is 1.

--- a/src/shape/cylinder.rs
+++ b/src/shape/cylinder.rs
@@ -197,9 +197,9 @@ impl Cylinder {
 impl SupportMap for Cylinder {
     fn local_support_point(&self, dir: Vector) -> Vector {
         let mut vres = dir;
-        vres[1] = 0.0;
+        vres.y = 0.0;
         vres = vres.normalize_or_zero() * self.radius;
-        vres[1] = self.half_height.copysign(dir[1]);
+        vres.y = self.half_height.copysign(dir.y);
         vres
     }
 }

--- a/src/shape/cylinder.rs
+++ b/src/shape/cylinder.rs
@@ -2,6 +2,7 @@
 
 use crate::math::{Real, Vector};
 use crate::shape::SupportMap;
+use crate::utils::WSign;
 
 #[cfg(feature = "alloc")]
 use either::Either;
@@ -199,7 +200,7 @@ impl SupportMap for Cylinder {
         let mut vres = dir;
         vres.y = 0.0;
         vres = vres.normalize_or_zero() * self.radius;
-        vres.y = self.half_height.copysign(dir.y);
+        vres.y = dir.y.copy_sign_to(self.half_height);
         vres
     }
 }

--- a/src/shape/feature_id.rs
+++ b/src/shape/feature_id.rs
@@ -484,6 +484,7 @@ impl PackedFeatureId {
     /// # }
     /// ```
     pub fn vertex(code: u32) -> Self {
+        #[cfg(not(target_arch = "spirv"))]
         assert_eq!(code & Self::HEADER_MASK, 0);
         Self(Self::HEADER_VERTEX | code)
     }
@@ -510,6 +511,7 @@ impl PackedFeatureId {
     /// ```
     #[cfg(feature = "dim3")]
     pub fn edge(code: u32) -> Self {
+        #[cfg(not(target_arch = "spirv"))]
         assert_eq!(code & Self::HEADER_MASK, 0);
         Self(Self::HEADER_EDGE | code)
     }
@@ -533,6 +535,7 @@ impl PackedFeatureId {
     /// # }
     /// ```
     pub fn face(code: u32) -> Self {
+        #[cfg(not(target_arch = "spirv"))]
         assert_eq!(code & Self::HEADER_MASK, 0);
         Self(Self::HEADER_FACE | code)
     }

--- a/src/shape/polygonal_feature_map.rs
+++ b/src/shape/polygonal_feature_map.rs
@@ -2,6 +2,7 @@ use crate::math::Vector;
 #[cfg(feature = "dim3")]
 use crate::shape::{Cone, Cylinder, PackedFeatureId};
 use crate::shape::{Cuboid, PolygonalFeature, Segment, SupportMap, Triangle};
+use crate::utils::WSign;
 
 /// Trait implemented by convex shapes with features with polyhedral approximations.
 pub trait PolygonalFeatureMap: SupportMap {
@@ -73,7 +74,7 @@ impl PolygonalFeatureMap for Cylinder {
             out_features.vids = PackedFeatureId::vertices([1, 11, 11, 11]);
         } else {
             // We return a square approximation of the cylinder cap.
-            let y = self.half_height.copysign(dir.y);
+            let y = dir.y.copy_sign_to(self.half_height);
             out_features.vertices[0] = Vector::new(dir2.x * self.radius, y, dir2.y * self.radius);
             out_features.vertices[1] = Vector::new(-dir2.y * self.radius, y, dir2.x * self.radius);
             out_features.vertices[2] = Vector::new(-dir2.x * self.radius, y, -dir2.y * self.radius);

--- a/src/shape/polygonal_feature_map.rs
+++ b/src/shape/polygonal_feature_map.rs
@@ -2,6 +2,7 @@ use crate::math::Vector;
 #[cfg(feature = "dim3")]
 use crate::shape::{Cone, Cylinder, PackedFeatureId};
 use crate::shape::{Cuboid, PolygonalFeature, Segment, SupportMap, Triangle};
+#[cfg(feature = "dim3")]
 use crate::utils::WSign;
 
 /// Trait implemented by convex shapes with features with polyhedral approximations.

--- a/src/shape/segment.rs
+++ b/src/shape/segment.rs
@@ -1,6 +1,8 @@
 //! Definition of the segment shape.
 
 use crate::math::{Pose, Real, Vector};
+#[cfg(feature = "dim3")]
+use crate::math::VectorExt;
 use crate::shape::{FeatureId, SupportMap};
 use core::mem;
 
@@ -420,18 +422,18 @@ impl Segment {
                 FeatureId::Edge(_) => {
                     let imin = direction.abs().min_position();
                     let mut normal = Vector::ZERO;
-                    normal[imin] = 1.0;
-                    normal -= direction * direction[imin];
+                    normal.vset(imin, 1.0);
+                    normal -= direction * direction.vget(imin);
                     Some(normal.normalize())
                 }
                 FeatureId::Face(id) => {
                     let mut dir = Vector::ZERO;
                     if id == 0 {
-                        dir[0] = direction[1];
-                        dir[1] = -direction[0];
+                        dir.x = direction.y;
+                        dir.y = -direction.x;
                     } else {
-                        dir[0] = -direction[1];
-                        dir[1] = direction[0];
+                        dir.x = -direction.y;
+                        dir.y = direction.x;
                     }
                     Some(dir)
                 }

--- a/src/shape/segment.rs
+++ b/src/shape/segment.rs
@@ -1,8 +1,8 @@
 //! Definition of the segment shape.
 
-use crate::math::{Pose, Real, Vector};
 #[cfg(feature = "dim3")]
 use crate::math::VectorExt;
+use crate::math::{Pose, Real, Vector};
 use crate::shape::{FeatureId, SupportMap};
 use core::mem;
 

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -1,7 +1,3 @@
-#[cfg(feature = "alloc")]
-use alloc::{boxed::Box, vec::Vec};
-use core::fmt::Debug;
-use core::any::Any;
 use crate::bounding_volume::{Aabb, BoundingSphere, BoundingVolume};
 use crate::mass_properties::MassProperties;
 use crate::math::{Pose, Real, RealField, Vector};
@@ -16,6 +12,10 @@ use crate::shape::{
 };
 #[cfg(feature = "dim3")]
 use crate::shape::{Cone, Cylinder, RoundCone, RoundCylinder};
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, vec::Vec};
+use core::any::Any;
+use core::fmt::Debug;
 
 #[cfg(feature = "dim3")]
 #[cfg(feature = "alloc")]
@@ -23,9 +23,7 @@ use crate::shape::{ConvexPolyhedron, RoundConvexPolyhedron, Voxels};
 
 #[cfg(feature = "dim2")]
 #[cfg(feature = "alloc")]
-use {
-    crate::shape::{ConvexPolygon, RoundConvexPolygon, Voxels},
-};
+use crate::shape::{ConvexPolygon, RoundConvexPolygon, Voxels};
 use num::Zero;
 use num_derive::FromPrimitive;
 

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -334,7 +334,7 @@ impl DeserializableTypedShape {
 }
 
 /// Trait implemented by shapes usable by Rapier.
-pub trait Shape: RayCast + PointQuery + Any {
+pub trait Shape: RayCast + PointQuery + Any + Send + Sync {
     /// Computes the [`Aabb`] of this shape.
     fn compute_local_aabb(&self) -> Aabb;
     /// Computes the bounding-sphere of this shape.

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "alloc")]
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt::Debug;
-
+use core::any::Any;
 use crate::bounding_volume::{Aabb, BoundingSphere, BoundingVolume};
 use crate::mass_properties::MassProperties;
 use crate::math::{Pose, Real, RealField, Vector};
@@ -23,8 +23,9 @@ use crate::shape::{ConvexPolyhedron, RoundConvexPolyhedron, Voxels};
 
 #[cfg(feature = "dim2")]
 #[cfg(feature = "alloc")]
-use crate::shape::{ConvexPolygon, RoundConvexPolygon, Voxels};
-use downcast_rs::{impl_downcast, DowncastSync};
+use {
+    crate::shape::{ConvexPolygon, RoundConvexPolygon, Voxels},
+};
 use num::Zero;
 use num_derive::FromPrimitive;
 
@@ -333,7 +334,7 @@ impl DeserializableTypedShape {
 }
 
 /// Trait implemented by shapes usable by Rapier.
-pub trait Shape: RayCast + PointQuery + DowncastSync {
+pub trait Shape: RayCast + PointQuery + Any {
     /// Computes the [`Aabb`] of this shape.
     fn compute_local_aabb(&self) -> Aabb;
     /// Computes the bounding-sphere of this shape.
@@ -432,237 +433,235 @@ pub trait Shape: RayCast + PointQuery + DowncastSync {
     }
 }
 
-impl_downcast!(sync Shape);
-
 impl dyn Shape {
     /// Converts this abstract shape to the given shape, if it is one.
     pub fn as_shape<T: Shape>(&self) -> Option<&T> {
-        self.downcast_ref()
+        (self as &dyn Any).downcast_ref()
     }
     /// Converts this abstract shape to the given mutable shape, if it is one.
     pub fn as_shape_mut<T: Shape>(&mut self) -> Option<&mut T> {
-        self.downcast_mut()
+        (self as &mut dyn Any).downcast_mut()
     }
 
     /// Converts this abstract shape to a ball, if it is one.
     pub fn as_ball(&self) -> Option<&Ball> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable ball, if it is one.
     pub fn as_ball_mut(&mut self) -> Option<&mut Ball> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a cuboid, if it is one.
     pub fn as_cuboid(&self) -> Option<&Cuboid> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable cuboid, if it is one.
     pub fn as_cuboid_mut(&mut self) -> Option<&mut Cuboid> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a halfspace, if it is one.
     pub fn as_halfspace(&self) -> Option<&HalfSpace> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a halfspace, if it is one.
     pub fn as_halfspace_mut(&mut self) -> Option<&mut HalfSpace> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a segment, if it is one.
     pub fn as_segment(&self) -> Option<&Segment> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable segment, if it is one.
     pub fn as_segment_mut(&mut self) -> Option<&mut Segment> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a capsule, if it is one.
     pub fn as_capsule(&self) -> Option<&Capsule> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable capsule, if it is one.
     pub fn as_capsule_mut(&mut self) -> Option<&mut Capsule> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a triangle, if it is one.
     pub fn as_triangle(&self) -> Option<&Triangle> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable triangle, if it is one.
     pub fn as_triangle_mut(&mut self) -> Option<&mut Triangle> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to voxels, if it is one.
     #[cfg(feature = "alloc")]
     pub fn as_voxels(&self) -> Option<&Voxels> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to mutable voxels, if it is one.
     #[cfg(feature = "alloc")]
     pub fn as_voxels_mut(&mut self) -> Option<&mut Voxels> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a compound shape, if it is one.
     #[cfg(feature = "alloc")]
     pub fn as_compound(&self) -> Option<&Compound> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable compound shape, if it is one.
     #[cfg(feature = "alloc")]
     pub fn as_compound_mut(&mut self) -> Option<&mut Compound> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a triangle mesh, if it is one.
     #[cfg(feature = "alloc")]
     pub fn as_trimesh(&self) -> Option<&TriMesh> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable triangle mesh, if it is one.
     #[cfg(feature = "alloc")]
     pub fn as_trimesh_mut(&mut self) -> Option<&mut TriMesh> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a polyline, if it is one.
     #[cfg(feature = "alloc")]
     pub fn as_polyline(&self) -> Option<&Polyline> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable polyline, if it is one.
     #[cfg(feature = "alloc")]
     pub fn as_polyline_mut(&mut self) -> Option<&mut Polyline> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a heightfield, if it is one.
     #[cfg(feature = "alloc")]
     pub fn as_heightfield(&self) -> Option<&HeightField> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable heightfield, if it is one.
     #[cfg(feature = "alloc")]
     pub fn as_heightfield_mut(&mut self) -> Option<&mut HeightField> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a round cuboid, if it is one.
     pub fn as_round_cuboid(&self) -> Option<&RoundCuboid> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable round cuboid, if it is one.
     pub fn as_round_cuboid_mut(&mut self) -> Option<&mut RoundCuboid> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a round triangle, if it is one.
     pub fn as_round_triangle(&self) -> Option<&RoundTriangle> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a round triangle, if it is one.
     pub fn as_round_triangle_mut(&mut self) -> Option<&mut RoundTriangle> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a convex polygon, if it is one.
     #[cfg(feature = "dim2")]
     #[cfg(feature = "alloc")]
     pub fn as_convex_polygon(&self) -> Option<&ConvexPolygon> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable convex polygon, if it is one.
     #[cfg(feature = "dim2")]
     #[cfg(feature = "alloc")]
     pub fn as_convex_polygon_mut(&mut self) -> Option<&mut ConvexPolygon> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a round convex polygon, if it is one.
     #[cfg(feature = "dim2")]
     #[cfg(feature = "alloc")]
     pub fn as_round_convex_polygon(&self) -> Option<&RoundConvexPolygon> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable round convex polygon, if it is one.
     #[cfg(feature = "dim2")]
     #[cfg(feature = "alloc")]
     pub fn as_round_convex_polygon_mut(&mut self) -> Option<&mut RoundConvexPolygon> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     #[cfg(feature = "dim3")]
     #[cfg(feature = "alloc")]
     pub fn as_convex_polyhedron(&self) -> Option<&ConvexPolyhedron> {
-        self.downcast_ref()
+        self.as_shape()
     }
     #[cfg(feature = "dim3")]
     #[cfg(feature = "alloc")]
     pub fn as_convex_polyhedron_mut(&mut self) -> Option<&mut ConvexPolyhedron> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a cylinder, if it is one.
     #[cfg(feature = "dim3")]
     pub fn as_cylinder(&self) -> Option<&Cylinder> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable cylinder, if it is one.
     #[cfg(feature = "dim3")]
     pub fn as_cylinder_mut(&mut self) -> Option<&mut Cylinder> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a cone, if it is one.
     #[cfg(feature = "dim3")]
     pub fn as_cone(&self) -> Option<&Cone> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable cone, if it is one.
     #[cfg(feature = "dim3")]
     pub fn as_cone_mut(&mut self) -> Option<&mut Cone> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a round cylinder, if it is one.
     #[cfg(feature = "dim3")]
     pub fn as_round_cylinder(&self) -> Option<&RoundCylinder> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable round cylinder, if it is one.
     #[cfg(feature = "dim3")]
     pub fn as_round_cylinder_mut(&mut self) -> Option<&mut RoundCylinder> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a round cone, if it is one.
     #[cfg(feature = "dim3")]
     pub fn as_round_cone(&self) -> Option<&RoundCone> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable round cone, if it is one.
     #[cfg(feature = "dim3")]
     pub fn as_round_cone_mut(&mut self) -> Option<&mut RoundCone> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 
     /// Converts this abstract shape to a round convex polyhedron, if it is one.
     #[cfg(feature = "dim3")]
     #[cfg(feature = "alloc")]
     pub fn as_round_convex_polyhedron(&self) -> Option<&RoundConvexPolyhedron> {
-        self.downcast_ref()
+        self.as_shape()
     }
     /// Converts this abstract shape to a mutable round convex polyhedron, if it is one.
     #[cfg(feature = "dim3")]
     #[cfg(feature = "alloc")]
     pub fn as_round_convex_polyhedron_mut(&mut self) -> Option<&mut RoundConvexPolyhedron> {
-        self.downcast_mut()
+        self.as_shape_mut()
     }
 }
 

--- a/src/shape/tetrahedron.rs
+++ b/src/shape/tetrahedron.rs
@@ -1,6 +1,6 @@
 //! Definition of the tetrahedron shape.
 
-use crate::math::{MatExt, Matrix, Real, Vector};
+use crate::math::{Matrix, Real, Vector};
 use crate::shape::{Segment, Triangle};
 use crate::utils;
 use core::mem;

--- a/src/shape/voxels/voxels_chunk.rs
+++ b/src/shape/voxels/voxels_chunk.rs
@@ -242,10 +242,10 @@ impl<'a> VoxelsChunkRef<'a> {
         let mins = mins.max(chunk_mins);
         let maxs = maxs.min(chunk_maxs);
 
-        (mins[0]..maxs[0]).flat_map(move |ix| {
-            (mins[1]..maxs[1]).flat_map(move |iy| {
-                let id_in_chunk = (ix - chunk_mins[0]) as usize
-                    + (iy - chunk_mins[1]) as usize * VoxelsChunk::VOXELS_PER_CHUNK_DIM;
+        (mins.x..maxs.x).flat_map(move |ix| {
+            (mins.y..maxs.y).flat_map(move |iy| {
+                let id_in_chunk = (ix - chunk_mins.x) as usize
+                    + (iy - chunk_mins.y) as usize * VoxelsChunk::VOXELS_PER_CHUNK_DIM;
                 let state = self.states[id_in_chunk];
 
                 if state.is_empty() {
@@ -282,12 +282,12 @@ impl<'a> VoxelsChunkRef<'a> {
         let mins = mins.max(chunk_mins);
         let maxs = maxs.min(chunk_maxs);
 
-        (mins[0]..maxs[0]).flat_map(move |ix| {
-            (mins[1]..maxs[1]).flat_map(move |iy| {
-                (mins[2]..maxs[2]).filter_map(move |iz| {
-                    let id_in_chunk = (ix - chunk_mins[0]) as usize
-                        + (iy - chunk_mins[1]) as usize * VoxelsChunk::VOXELS_PER_CHUNK_DIM
-                        + (iz - chunk_mins[2]) as usize
+        (mins.x..maxs.x).flat_map(move |ix| {
+            (mins.y..maxs.y).flat_map(move |iy| {
+                (mins.z..maxs.z).filter_map(move |iz| {
+                    let id_in_chunk = (ix - chunk_mins.x) as usize
+                        + (iy - chunk_mins.y) as usize * VoxelsChunk::VOXELS_PER_CHUNK_DIM
+                        + (iz - chunk_mins.z) as usize
                             * VoxelsChunk::VOXELS_PER_CHUNK_DIM
                             * VoxelsChunk::VOXELS_PER_CHUNK_DIM;
                     let state = self.states[id_in_chunk];

--- a/src/shape/voxels/voxels_edition.rs
+++ b/src/shape/voxels/voxels_edition.rs
@@ -1,5 +1,5 @@
 use crate::bounding_volume::Aabb;
-use crate::math::{IVector, Vector, DIM};
+use crate::math::{IVector, IVectorExt, Vector, DIM};
 use crate::shape::voxels::voxels_chunk::{VoxelsChunk, VoxelsChunkHeader};
 use crate::shape::{VoxelState, Voxels};
 use crate::utils::hashmap::Entry;
@@ -310,7 +310,7 @@ impl Voxels {
 
 fn grid_aabb_contains_point(mins: &IVector, maxs: &IVector, point: &IVector) -> bool {
     for i in 0..DIM {
-        if point[i] < mins[i] || point[i] > maxs[i] {
+        if point.ivget(i) < mins.ivget(i) || point.ivget(i) > maxs.ivget(i) {
             return false;
         }
     }

--- a/src/shape/voxels/voxels_neighborhood.rs
+++ b/src/shape/voxels/voxels_neighborhood.rs
@@ -1,5 +1,5 @@
 use super::VoxelsChunk;
-use crate::math::{ivect_to_vect, IVector, DIM};
+use crate::math::{ivect_to_vect, IVector, IVectorExt, DIM};
 use crate::shape::{VoxelState, Voxels};
 
 impl Voxels {
@@ -18,8 +18,8 @@ impl Voxels {
         for k in 0..DIM {
             let mut left = key;
             let mut right = key;
-            left[k] -= 1;
-            right[k] += 1;
+            left.ivset(k, left.ivget(k) - 1);
+            right.ivset(k, right.ivget(k) + 1);
 
             // TODO PERF: all the calls to `linear_index` result in a hashmap lookup each time.
             //            We should instead be smarter and detect if left/right are in the same chunk
@@ -83,8 +83,8 @@ impl Voxels {
 
         for k in 0..DIM {
             let (mut prev, mut next) = (key, key);
-            prev[k] -= 1;
-            next[k] += 1;
+            prev.ivset(k, prev.ivget(k) - 1);
+            next.ivset(k, next.ivget(k) + 1);
 
             if let Some(next_id) = self.linear_index(next) {
                 if !self.chunks[next_id.chunk_id].states[next_id.id_in_chunk].is_empty() {

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -531,7 +531,7 @@ fn insert_into_set(position: Vector3, point_set: &mut RTree<TreeVector>, epsilon
         id: point_count,
     };
 
-    match point_set.nearest_neighbor(&point_to_insert) {
+    match point_set.nearest_neighbor(point_to_insert) {
         Some(tree_point) => {
             if (tree_point.point - position).length_squared() <= epsilon {
                 tree_point.id

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -461,7 +461,11 @@ fn triangulate_constraints_and_merge_duplicates(
             utils::sanitize_spade_point(point_proj)
         })
         .collect();
-    let cdt_triangulation = ConstrainedDelaunayTriangulation::bulk_load_cdt(planar_points, edges)?;
+    // NOTE: use the fallible `try_bulk_load_cdt` instead of `bulk_load_cdt`: the latter panics
+    //       when constraint edges overlap, which can legitimately happen for degenerate inputs
+    //       (e.g. co-planar triangles). Overlapping constraints are simply skipped.
+    let cdt_triangulation =
+        ConstrainedDelaunayTriangulation::try_bulk_load_cdt(planar_points, edges, |_conflict| {})?;
     debug_assert!(cdt_triangulation.vertices().len() == points.len());
 
     let points = points.into_iter().map(|p| Vector3::from(p.point)).collect();

--- a/src/transformation/mesh_intersection/mesh_intersection.rs
+++ b/src/transformation/mesh_intersection/mesh_intersection.rs
@@ -276,7 +276,7 @@ pub fn intersect_meshes_with_tolerances(
 
     // 7: Sort the output points by insertion order.
     let mut vertices: Vec<_> = point_set.iter().copied().collect();
-    vertices.sort_by(|a, b| a.id.cmp(&b.id));
+    vertices.sort_by_key(|a| a.id);
     let vertices: Vec<_> = vertices.iter().map(|p| Vector3::from(p.point)).collect();
 
     if !topology_indices.is_empty() {
@@ -442,7 +442,7 @@ fn triangulate_constraints_and_merge_duplicates(
     }
 
     let mut points: Vec<_> = point_set.iter().cloned().collect();
-    points.sort_by(|a, b| a.id.cmp(&b.id));
+    points.sort_by_key(|a| a.id);
 
     let tri_points = tri.vertices();
     let best_source = tri.angle_closest_to_90();
@@ -532,16 +532,10 @@ fn insert_into_set(position: Vector3, point_set: &mut RTree<TreeVector>, epsilon
     };
 
     match point_set.nearest_neighbor(point_to_insert) {
-        Some(tree_point) => {
-            if (tree_point.point - position).length_squared() <= epsilon {
-                tree_point.id
-            } else {
-                point_set.insert(point_to_insert);
-                debug_assert!(point_set.size() == point_count + 1);
-                point_count
-            }
+        Some(tree_point) if (tree_point.point - position).length_squared() <= epsilon => {
+            tree_point.id
         }
-        None => {
+        _ => {
             point_set.insert(point_to_insert);
             debug_assert!(point_set.size() == point_count + 1);
             point_count

--- a/src/transformation/utils.rs
+++ b/src/transformation/utils.rs
@@ -379,8 +379,8 @@ pub fn push_xy_arc(radius: Real, nsubdiv: u32, dtheta: Real, out: &mut Vec<Vecto
     for _ in 0..nsubdiv {
         let mut pt_coords = Vector::ZERO;
 
-        pt_coords[0] = <Real as ComplexField>::cos(curr_theta) * radius;
-        pt_coords[1] = <Real as ComplexField>::sin(curr_theta) * radius;
+        pt_coords.x = <Real as ComplexField>::cos(curr_theta) * radius;
+        pt_coords.y = <Real as ComplexField>::sin(curr_theta) * radius;
         out.push(pt_coords);
 
         curr_theta += dtheta;

--- a/src/transformation/voxelization/voxel_set.rs
+++ b/src/transformation/voxelization/voxel_set.rs
@@ -1124,7 +1124,7 @@ fn convex_hull(vertices: &[Vector]) -> Vec<Vector> {
 #[cfg(feature = "dim3")]
 fn convex_hull(vertices: &[Vector]) -> (Vec<Vector>, Vec<[u32; DIM]>) {
     if vertices.len() > 2 {
-        crate::transformation::convex_hull(vertices)
+        crate::transformation::try_convex_hull(vertices).unwrap_or_default()
     } else {
         (Vec::new(), Vec::new())
     }

--- a/src/utils/ccw_face_normal.rs
+++ b/src/utils/ccw_face_normal.rs
@@ -7,7 +7,7 @@ use crate::math::Vector;
 #[cfg(feature = "dim2")]
 pub fn ccw_face_normal(pts: [Vector; 2]) -> Option<Vector> {
     let ab = pts[1] - pts[0];
-    let res = Vector::new(ab[1], -ab[0]);
+    let res = Vector::new(ab.y, -ab.x);
 
     res.try_normalize()
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -31,6 +31,7 @@ pub use self::hashable_partial_eq::HashablePartialEq;
 #[cfg(feature = "alloc")]
 pub use self::interval::{find_root_intervals, find_root_intervals_to, Interval, IntervalFunction};
 pub use self::obb::obb;
+pub use self::relative_eq::relative_eq_vector;
 pub use self::segments_intersection::{segments_intersection2d, SegmentsIntersection};
 #[cfg(feature = "dim3")]
 pub use self::sort::sort2;
@@ -39,7 +40,6 @@ pub use self::sorted_pair::SortedPair;
 #[cfg(all(feature = "dim3", feature = "spade"))]
 pub(crate) use self::spade::sanitize_spade_point;
 pub(crate) use self::wops::{WBasis, WCross, WSign};
-pub use self::relative_eq::relative_eq_vector;
 
 #[cfg(feature = "simd-is-enabled")]
 #[allow(unused_imports)]
@@ -85,6 +85,6 @@ mod wops;
 
 mod eigen2;
 mod eigen3;
+mod relative_eq;
 #[cfg(feature = "alloc")]
 mod vec_map;
-mod relative_eq;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,6 +12,7 @@ pub use self::eigen2::SymmetricEigen2;
 pub use self::eigen3::SymmetricEigen3;
 pub(crate) use self::inv::inv;
 pub use self::isometry_ops::{PoseOps, PoseOpt};
+#[cfg(feature = "alloc")]
 pub use self::median::median;
 pub use self::point_cloud_support_point::{
     point_cloud_support_point, point_cloud_support_point_id,
@@ -38,6 +39,7 @@ pub use self::sorted_pair::SortedPair;
 #[cfg(all(feature = "dim3", feature = "spade"))]
 pub(crate) use self::spade::sanitize_spade_point;
 pub(crate) use self::wops::{WBasis, WCross, WSign};
+pub use self::relative_eq::relative_eq_vector;
 
 #[cfg(feature = "simd-is-enabled")]
 #[allow(unused_imports)]
@@ -65,6 +67,7 @@ pub mod hashset;
 mod interval;
 mod inv;
 mod isometry_ops;
+#[cfg(feature = "alloc")]
 mod median;
 pub mod morton;
 mod obb;
@@ -84,3 +87,4 @@ mod eigen2;
 mod eigen3;
 #[cfg(feature = "alloc")]
 mod vec_map;
+mod relative_eq;

--- a/src/utils/morton.rs
+++ b/src/utils/morton.rs
@@ -30,16 +30,16 @@ fn morton_encode_u64(x: u32, y: u32, z: u32) -> u64 {
 #[inline]
 /// Encode a 3D position into a u64 morton value.
 /// Input should be 0.0..=1.0
+#[cfg_attr(feature = "f64", expect(clippy::unnecessary_cast))]
 pub fn morton_encode_u64_unorm(p: Vector) -> u64 {
+    let scale = (1u64 << 21) as f64;
+    let x = (p.x as f64 * scale) as u32;
+    let y = (p.y as f64 * scale) as u32;
     #[cfg(feature = "dim2")]
-    #[cfg_attr(feature = "f64", expect(clippy::unnecessary_cast))]
-    let p = glamx::DVec2::new(p.x as f64, p.y as f64) * (1 << 21) as f64;
+    return morton_encode_u64(x, y, 0);
     #[cfg(feature = "dim3")]
-    #[cfg_attr(feature = "f64", expect(clippy::unnecessary_cast))]
-    let p = glamx::DVec3::new(p.x as f64, p.y as f64, p.z as f64) * (1 << 21) as f64;
-
-    #[cfg(feature = "dim2")]
-    return morton_encode_u64(p.x as u32, p.y as u32, 0);
-    #[cfg(feature = "dim3")]
-    return morton_encode_u64(p.x as u32, p.y as u32, p.z as u32);
+    {
+        let z = (p.z as f64 * scale) as u32;
+        morton_encode_u64(x, y, z)
+    }
 }

--- a/src/utils/obb.rs
+++ b/src/utils/obb.rs
@@ -1,4 +1,4 @@
-use crate::math::{MatExt, Pose, Real, Rotation, Vector, DIM};
+use crate::math::{MatExt, Pose, Real, Rotation, Vector, VectorExt, DIM};
 use crate::shape::Cuboid;
 
 /// Computes an oriented bounding box for the given set of points.
@@ -19,8 +19,8 @@ pub fn obb(pts: &[Vector]) -> (Pose, Cuboid) {
     for pt in pts {
         for i in 0..DIM {
             let dot = eigv.col(i).dot(*pt);
-            mins[i] = mins[i].min(dot);
-            maxs[i] = maxs[i].max(dot);
+            mins.vset(i, mins.vget(i).min(dot));
+            maxs.vset(i, maxs.vget(i).max(dot));
         }
     }
 

--- a/src/utils/relative_eq.rs
+++ b/src/utils/relative_eq.rs
@@ -1,0 +1,16 @@
+//! This module only exists for working around the fact that glam
+//! doesn’t allow its `approx` feature to be enabled when targeting spirv.
+
+use crate::math::Vector;
+use approx::relative_eq;
+
+#[inline]
+pub fn relative_eq_vector(a: Vector, b: Vector) -> bool {
+    #[cfg(feature = "dim2")]
+    return relative_eq!(a.x, b.x) &&
+        relative_eq!(a.y, b.y);
+    #[cfg(feature = "dim3")]
+    return relative_eq!(a.x, b.x) &&
+        relative_eq!(a.y, b.y) &&
+        relative_eq!(a.z, b.z);
+}

--- a/src/utils/relative_eq.rs
+++ b/src/utils/relative_eq.rs
@@ -8,10 +8,7 @@ use approx::relative_eq;
 #[inline]
 pub fn relative_eq_vector(a: Vector, b: Vector) -> bool {
     #[cfg(feature = "dim2")]
-    return relative_eq!(a.x, b.x) &&
-        relative_eq!(a.y, b.y);
+    return relative_eq!(a.x, b.x) && relative_eq!(a.y, b.y);
     #[cfg(feature = "dim3")]
-    return relative_eq!(a.x, b.x) &&
-        relative_eq!(a.y, b.y) &&
-        relative_eq!(a.z, b.z);
+    return relative_eq!(a.x, b.x) && relative_eq!(a.y, b.y) && relative_eq!(a.z, b.z);
 }

--- a/src/utils/relative_eq.rs
+++ b/src/utils/relative_eq.rs
@@ -4,6 +4,7 @@
 use crate::math::Vector;
 use approx::relative_eq;
 
+/// Checks approximate equality between two vectors, component-wise.
 #[inline]
 pub fn relative_eq_vector(a: Vector, b: Vector) -> bool {
     #[cfg(feature = "dim2")]

--- a/src/utils/wops.rs
+++ b/src/utils/wops.rs
@@ -28,10 +28,20 @@ pub trait WSign<Rhs>: Sized {
 }
 
 impl WSign<Real> for Real {
+    #[inline]
     fn copy_sign_to(self, to: Self) -> Self {
-        let minus_zero: Real = -0.0;
-        let signbit = minus_zero.to_bits();
-        Real::from_bits((signbit & self.to_bits()) | ((!signbit) & to.to_bits()))
+        #[cfg(not(target_arch = "nvptx64"))]
+        return to.copysign(self);
+        #[cfg(target_arch = "nvptx64")]
+        {
+            // TODO: this is a manual implementation of copysign.
+            //       Apparently, the cuda_std copysign doesn’t compile with
+            //       rust-cuda.
+            // return cuda_std::float::GpuFloat::copysign(to, self);
+            let minus_zero: Real = -0.0;
+            let signbit = minus_zero.to_bits();
+            Real::from_bits((signbit & self.to_bits()) | ((!signbit) & to.to_bits()))
+        }
     }
 }
 


### PR DESCRIPTION
### Breaking changes

- `CompositeShapeRef::project_local_point` and `project_local_point_and_get_feature` now return
  `Option<...>` instead of unwrapping internally, and take an additional `max_dist` parameter that
  bounds the search distance.

### Modified

- Bump `glamx` to 0.3 (built on `glam` 0.33), `simba` to 0.10, `rstar` to 0.13, `hashbrown` to 0.17,
  `rand` to 0.10, and `kiss3d` (visual examples) to 0.42.
- Many shape, AABB, and voxel internals were reworked to avoid bracket-indexing of `glam` vectors,
  which is not supported on SPIR-V targets. A new `VectorExt::vget`/`vset` API and a `for_each_dim!`
  macro are now used in place of `v[i]`. `parry3d`'s `alloc` feature also now gates `smallvec`,
  `downcast-rs`, `rstar`, and `glamx/approx`, so the no-alloc build can target SPIR-V.

### Fixed
- Fix multiple EPA failures on large coordinate magnitudes by scaling the face-rejection tolerance
  relative to the simplex vertex magnitudes ([#415](https://github.com/dimforge/parry/issues/415)).
- Fix CCD edge cases (in both ball-vs-ball and support-map-vs-support-map casts) where casts
  starting at (or very close to) the contact boundary with a near-tangent direction would return
  an unreliable normal. The fallback now uses the contact query to recover a robust closest-point
  normal, and the small-TOI threshold was relaxed from `1e-5` to `1e-4`.
- Fix `Aabb::cast_local_ray_and_get_normal` panicking with a subtraction overflow when casting a
  zero-direction ray starting inside the AABB ([#383](https://github.com/dimforge/parry/issues/383)).
- Fix infinite loop in `TriMesh::intersection_with_local_plane` on degenerate adjacency graphs
  that don't loop cleanly back to the starting index
  ([#398](https://github.com/dimforge/parry/issues/398)).
- Fix panic in `mesh_intersection` when constraint edges overlap (e.g. for co-planar triangles).
  Overlapping constraints are now skipped instead of crashing the CDT
  ([#389](https://github.com/dimforge/parry/issues/389)).
- Fix panic in 3D voxelization's internal convex-hull step by falling back to `try_convex_hull`
  and returning an empty hull on failure ([#347](https://github.com/dimforge/parry/issues/347)).
- Fix `WSign::copy_sign_to` on non-CUDA targets by using the native `copysign` (the bit-twiddling
  workaround is now scoped to `nvptx64`, where `cuda_std`'s `copysign` does not compile).

fix #415
fix #383
fix #398
fix #389 
fix #347
