### PR TITLE
Fix velocity calculation in shape casting

### DIFF
--- a/src/query/shape_cast/shape_cast.rs
+++ b/src/query/shape_cast/shape_cast.rs
@@ -279,6 +279,6 @@ pub fn cast_shapes(
     options: ShapeCastOptions,
 ) -> Result<Option<ShapeCastHit>, Unsupported> {
     let pos12 = pos1.inv_mul(pos2);
-    let vel12 = pos1.rotation.inverse() * vel2 - vel1;
+    let vel12 = pos1.rotation.inverse() * (vel2 - vel1);
     DefaultQueryDispatcher.cast_shapes(&pos12, vel12, g1, g2, options)
 }


### PR DESCRIPTION
Fixes #423

This pull request makes a correction to the calculation of relative velocity in the `cast_shapes` function. The change ensures that the velocity difference is computed before applying the rotation, which results in correct relative velocity handling during shape casting.