### PR TITLE
enhanced-determinism feature does not guarantee cross-platform determinism for 3D (missing glamx/scalar-math)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Fixed
+- Fix `enhanced-determinism` not producing cross-platform deterministic results for parry3d/parry3d-f64.
+  The feature now enables `glamx/scalar-math` to disable architecture-specific SIMD (NEON on arm64,
+  SSE2 on x86_64) which caused floating-point non-associativity in Vec3/Vec4/Quat dot products.
+
 ## 0.28.0
 
 ### Breaking changes

--- a/crates/parry3d-f64/Cargo.toml
+++ b/crates/parry3d-f64/Cargo.toml
@@ -44,7 +44,7 @@ rkyv = ["dep:rkyv", "glamx/rkyv"]
 bytemuck-serialize = ["bytemuck", "glamx/bytemuck"]
 simd-stable = ["simba/wide", "simd-is-enabled"]
 simd-nightly = ["simba/portable_simd", "simd-is-enabled"]
-enhanced-determinism = ["simba/libm_force", "indexmap", "glamx/libm"]
+enhanced-determinism = ["simba/libm_force", "indexmap", "glamx/libm", "glamx/scalar-math"]
 parallel = ["rayon"]
 # Adds `TriMesh:to_obj_file` function.
 wavefront = ["obj"]

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -45,7 +45,7 @@ bytemuck-serialize = ["bytemuck", "glamx/bytemuck"]
 
 simd-stable = ["simba/wide", "simd-is-enabled"]
 simd-nightly = ["simba/portable_simd", "simd-is-enabled"]
-enhanced-determinism = ["simba/libm_force", "indexmap", "glamx/libm"]
+enhanced-determinism = ["simba/libm_force", "indexmap", "glamx/libm", "glamx/scalar-math"]
 parallel = ["rayon"]
 # Adds `TriMesh:to_obj_file` function.
 wavefront = ["obj"]


### PR DESCRIPTION
The enhanced-determinism feature in parry3d enables glamx/libm to ensure transcendental functions (sin, cos, sqrt, etc.) produce identical results across platforms. However, it does not enable glamx/scalar-math, which means glam still uses architecture-specific SIMD backends for basic vector and quaternion operations.

This causes cross-platform divergence in 3D computations between arm64 and x86_64 due to floating-point non-associativity in the dot product implementation:

arm64 (NEON): Vec4::dot uses vmulq_f32 + vaddvq_f32 — sums all 4 products in one reduction
x86_64 (SSE2): Vec4::dot uses _mm_mul_ps + pairwise _mm_add_ps via shuffles
Since (a+b)+(c+d) ≠ ((a+b)+c)+d at the floating-point ULP level, any operation involving Vec3/Vec4/Quat normalization or dot products produces slightly different results on arm64 vs x86_64. This affects all parry3d consumers relying on enhanced-determinism for cross-platform reproducibility.

The 2D case (parry2d) is unaffected because Vec2 in glam always uses scalar code — there are no SIMD optimizations for 2-component vectors.