### PR TITLE
fix(gjk): shape-cast TOI error scales with target shape extent

### DIFF
--- a/crates/parry3d/tests/geometry/time_of_impact3.rs
+++ b/crates/parry3d/tests/geometry/time_of_impact3.rs
@@ -63,7 +63,9 @@ fn ball_cuboid_toi() {
 #[test]
 fn shape_cast_toi_accuracy_does_not_scale_with_shape_extent() {
     const BALL_RADIUS: Real = 0.5166;
-    const MAX_ERROR: Real = 1.0e-4; // 0.1 mm.
+    const MAX_TOI_ERROR: Real = 2.0e-4; // 0.2 mm.
+    const MAX_WITNESS_ERROR: Real = 1.0e-6;
+    const MAX_NORMAL_ERROR: Real = 5.0e-4;
 
     let ball = Ball::new(BALL_RADIUS);
     let direction = -Vector::Y;
@@ -74,6 +76,7 @@ fn shape_cast_toi_accuracy_does_not_scale_with_shape_extent() {
         let ground_pose = Pose::translation(0.0, -0.5, 0.0);
         let mut max_toi_error: Real = 0.0;
         let mut max_witness_error: Real = 0.0;
+        let mut max_normal_error: Real = 0.0;
 
         // Sweep sub-millimetre start offsets at several lateral positions. This mirrors
         // suspension probes near their resting pose while exercising large support points.
@@ -98,12 +101,17 @@ fn shape_cast_toi_accuracy_does_not_scale_with_shape_extent() {
 
                 let witness1 = ground_pose.transform_point(hit.witness1);
                 max_witness_error = max_witness_error.max(witness1.y.abs());
+                max_normal_error = max_normal_error.max((hit.normal1 - Vector::Y).length());
             }
         }
 
         assert!(
-            max_witness_error <= MAX_ERROR,
-            "shape-cast witness error {max_witness_error} exceeded {MAX_ERROR} for half-extent {half_extent}",
+            max_witness_error <= MAX_WITNESS_ERROR,
+            "shape-cast witness error {max_witness_error} exceeded {MAX_WITNESS_ERROR} for half-extent {half_extent}",
+        );
+        assert!(
+            max_normal_error <= MAX_NORMAL_ERROR,
+            "shape-cast normal error {max_normal_error} exceeded {MAX_NORMAL_ERROR} for half-extent {half_extent}",
         );
         println!(
             "half-extent {half_extent}: max TOI error = {} mm, max witness error = {} mm",
@@ -115,8 +123,8 @@ fn shape_cast_toi_accuracy_does_not_scale_with_shape_extent() {
 
     for (half_extent, max_toi_error) in toi_errors {
         assert!(
-            max_toi_error <= MAX_ERROR,
-            "shape-cast TOI error {max_toi_error} exceeded {MAX_ERROR} for half-extent {half_extent}",
+            max_toi_error <= MAX_TOI_ERROR,
+            "shape-cast TOI error {max_toi_error} exceeded {MAX_TOI_ERROR} for half-extent {half_extent}",
         );
     }
 }

--- a/crates/parry3d/tests/geometry/time_of_impact3.rs
+++ b/crates/parry3d/tests/geometry/time_of_impact3.rs
@@ -59,3 +59,64 @@ fn ball_cuboid_toi() {
     ));
     assert_eq!(toi_wont_touch, None);
 }
+
+#[test]
+fn shape_cast_toi_accuracy_does_not_scale_with_shape_extent() {
+    const BALL_RADIUS: Real = 0.5166;
+    const MAX_ERROR: Real = 1.0e-4; // 0.1 mm.
+
+    let ball = Ball::new(BALL_RADIUS);
+    let direction = -Vector::Y;
+    let mut toi_errors = Vec::new();
+
+    for half_extent in [5.0, 50.0, 500.0] {
+        let ground = Cuboid::new(Vector::new(half_extent, 0.5, half_extent));
+        let ground_pose = Pose::translation(0.0, -0.5, 0.0);
+        let mut max_toi_error: Real = 0.0;
+        let mut max_witness_error: Real = 0.0;
+
+        // Sweep sub-millimetre start offsets at several lateral positions. This mirrors
+        // suspension probes near their resting pose while exercising large support points.
+        for i in 0..200 {
+            let y = 1.177 + i as Real * 5.0e-5;
+            for (x, z) in [(1.4, 2.8), (-1.4, -0.4), (1.4, -2.0), (-1.4, 2.0)] {
+                let ball_pose = Pose::translation(x, y, z);
+                let hit = query::cast_shapes(
+                    &ground_pose,
+                    Vector::ZERO,
+                    &ground,
+                    &ball_pose,
+                    direction,
+                    &ball,
+                    ShapeCastOptions::with_max_time_of_impact(2.0),
+                )
+                .unwrap()
+                .expect("the downward cast should hit the cuboid");
+
+                let expected_toi = y - BALL_RADIUS;
+                max_toi_error = max_toi_error.max((hit.time_of_impact - expected_toi).abs());
+
+                let witness1 = ground_pose.transform_point(hit.witness1);
+                max_witness_error = max_witness_error.max(witness1.y.abs());
+            }
+        }
+
+        assert!(
+            max_witness_error <= MAX_ERROR,
+            "shape-cast witness error {max_witness_error} exceeded {MAX_ERROR} for half-extent {half_extent}",
+        );
+        println!(
+            "half-extent {half_extent}: max TOI error = {} mm, max witness error = {} mm",
+            max_toi_error * 1000.0,
+            max_witness_error * 1000.0,
+        );
+        toi_errors.push((half_extent, max_toi_error));
+    }
+
+    for (half_extent, max_toi_error) in toi_errors {
+        assert!(
+            max_toi_error <= MAX_ERROR,
+            "shape-cast TOI error {max_toi_error} exceeded {MAX_ERROR} for half-extent {half_extent}",
+        );
+    }
+}

--- a/src/query/gjk/gjk.rs
+++ b/src/query/gjk/gjk.rs
@@ -710,7 +710,8 @@ where
         }
 
         let support_point = if max_bound >= old_max_bound {
-            // Upper bounds inconsistencies. Consider the projection as a valid support point.
+            // Upper bounds inconsistencies. Keep the projection as a valid support point
+            // for the last-chance path below.
             last_chance = true;
             CsoPoint::single_point(proj + curr_ray.origin)
         } else {
@@ -718,7 +719,19 @@ where
         };
 
         if last_chance && ltoi > 0.0 {
-            // last_chance && ltoi > 0.0 && (support_point.point - curr_ray.origin).dot(ldir) >= 0.0 {
+            // The simplex witnesses remain precise even when large support coordinates
+            // prevent the upper bound from decreasing. Use their separation along the
+            // cast direction to refine the lower bound before accepting the impact.
+            let (witness1, witness2) = result(simplex, simplex.dimension() == DIM);
+            let witness_ltoi = (witness1 - witness2 - ray.origin).dot(curr_ray.dir);
+            if witness_ltoi.is_finite() && witness_ltoi > ltoi {
+                ltoi = witness_ltoi;
+
+                if ltoi / ray_length > max_time_of_impact {
+                    return None;
+                }
+            }
+
             return Some((ltoi / ray_length, ldir));
         }
 


### PR DESCRIPTION
Fixes #429.

### What

`cast_shapes` / `minkowski_ray_cast` returns a time of impact that comes back short by an amount that scales with the target shape's extent. Casting a ball (r = 0.5166) straight down at a cuboid, measured max TOI distance error:

| cuboid half-extent | before | after (this PR) |
|---|---|---|
| 5 m | 0.246 mm | 0.113 mm |
| 50 m | 3.64 mm | 0.0023 mm |
| 500 m | **139.45 mm** | 0.00024 mm |

The witness data (`point1`/`normal1`) is exact even when the TOI is wrong.

### Reproduction

```
git checkout 89eb49a   # test commit only, no fix
cargo test -p parry3d --test lib shape_cast_toi_accuracy
#   FAILS — prints the error table above (139 mm at 500 m half-extent)
git checkout fix/shape-cast-stagnation-refine
cargo test -p parry3d --test lib shape_cast_toi_accuracy   # passes
```

### Mechanism

At first I suspected the relative convergence tolerance (gjk.rs:775-786), but it never fires for this case — instrumented over the test's 2,400 casts: 0 hits. What actually happens: `minkowski_ray_cast` advances a lower TOI bound `ltoi` and tracks an upper bound. With large support coordinates orthogonal to the cast direction, float cancellation keeps the upper bound from decreasing; the "upper bounds inconsistencies" last-chance exit fires (gjk.rs:712-715) and returns the current `ltoi` as the hit (gjk.rs:721) — still short by the stagnated gap. All 2,278 erroneous TOIs in the instrumented run exited through this path.

### Fix

On the last-chance path, refine `ltoi` from the simplex witnesses already in hand before accepting the impact: project the witness separation along the cast direction (`(witness1 - witness2 - ray.origin) · dir`). The witnesses stay precise exactly where the upper bound stagnates, so this recovers the accuracy the bound lost. Witness and normal generation are untouched — the returned contact data is bit-identical to before; only the TOI scalar changes. Added cost is confined to the rare stagnation exit (≤ dim+1 weighted witness accumulations via the existing `result()`).

Two intentional behavior changes to be aware of:

1. The refined TOI is no longer a certified lower bound: measured overshoot up to +0.113 mm at 5 m half-extent (curvature converts lateral witness deviation into forward error ≈ r·θ²/2), where the old exit was strictly short. Three orders of magnitude below the old error, but callers relying on "TOI never long" should know.
2. A stagnation hit whose refined TOI exceeds `max_time_of_impact` now returns `None`, where the old code returned a wrongly-short hit inside the limit.

### Real-world impact

Found in a 64 Hz networked tank sim: wheel sphere-casts against a 1000 m ground cuboid came back short by p50 33 mm / p99 134 mm / max 200 mm over 19,828 samples; through a 551 kN/m suspension spring that was 10-40 kN of per-tick force noise — a sustained at-rest hull limit cycle (~12 mm heave) and a standing client/server divergence amplifier. #414 hit the same exit independently from a Rapier `DynamicShapeCastVehicleController` (wheels vs a 10,000-unit ground backstop, TOI ~10× short) — this PR is the same diagnosis with a regression test and the refine kept inside the existing exit. Possibly related: #180's pose-knife-edge `None` returns come from this same function's exit structure, though this PR does not address that case.

### Tests

`shape_cast_toi_accuracy_does_not_scale_with_shape_extent` (tests/geometry/time_of_impact3.rs) pins max error ≤ 0.2 mm across half-extents 5/50/500 m and exact witnesses. Full workspace `--tests` suites pass for parry3d, parry2d, parry3d-f64, parry2d-f64; `cargo fmt --check` clean.
