### PR TITLE
Pass the best-so-far distance to project_point's primitive_check

### DIFF
--- a/src/partitioning/bvh/bvh_queries.rs
+++ b/src/partitioning/bvh/bvh_queries.rs
@@ -219,8 +219,8 @@ impl Bvh {
         self.find_best(
             max_distance,
             |node: &BvhNode, _| node.aabb().distance_to_local_point(point, true),
-            |primitive, _| {
-                let proj = primitive_check(primitive, max_distance)?;
+            |primitive, best_so_far| {
+                let proj = primitive_check(primitive, best_so_far)?;
                 Some((proj.point.distance(point), proj))
             },
         )
@@ -243,8 +243,8 @@ impl Bvh {
         self.find_best(
             max_distance,
             |node: &BvhNode, _| node.aabb().distance_to_local_point(point, true),
-            |primitive, _| {
-                let proj = primitive_check(primitive, max_distance)?;
+            |primitive, best_so_far| {
+                let proj = primitive_check(primitive, best_so_far)?;
                 Some((proj.0.point.distance(point), proj))
             },
         )


### PR DESCRIPTION
`Bvh::project_point` and `project_point_and_get_feature` document the `Real` argument of `primitive_check` as the distance to the closest point found so far, but both pass the original `max_distance`. This disables leaf-level pruning for any callback that follows the documentation.

The best-so-far value from `find_best` is now passed through. `cast_ray` in the same module already does this. Conforming callbacks return the same winner; callbacks that prune against the argument prune earlier. Current in-tree callers ignore the argument, so there is no behavior change inside parry.
